### PR TITLE
chore: restore the test suite to green and back into the gate (#425, #426)

### DIFF
--- a/.claude/commands/check.md
+++ b/.claude/commands/check.md
@@ -1,5 +1,5 @@
 ---
-description: Run the full pre-commit gate (conventions, fmt, clippy) - the same thing CI runs
+description: Run the full pre-commit gate (conventions, fmt, clippy, tests) - the same thing CI runs
 model: haiku
 ---
 
@@ -10,14 +10,18 @@ rather than continuing past it:
 .claude/hooks/check-conventions.sh
 cargo fmt --all -- --check
 cargo clippy --workspace --all-targets -- -D warnings
+cargo nextest run --workspace
 ```
 
 If a step fails, show the actual failing output (not a summary) and stop — don't run later steps
 against code that hasn't passed the earlier ones. If everything passes, say so in one line; this
 command doesn't need a report beyond pass/fail plus whatever failed.
 
-**`cargo test --workspace` is deliberately not part of this gate right now** — see
-[GitHub issue #348](https://github.com/ColinEspinas/jerry/issues/348), which tracks getting the
-suite back into CI and this gate once resolved. If your change needs test coverage verified, run
-the relevant scoped tests yourself (e.g. `cargo test -p wt-core`, or `cargo test -p app --lib
-<module>::`) — don't treat a clean `/check` as proof the full suite passes.
+The test step covers the `unit` and `ui` tiers, which is what CI's `Linux (test)` job runs. The
+`external` tier is `#[ignore]`d and skipped — it needs real language servers and runs only in the
+nightly `External` job (see [`docs/testing.md`](../../docs/testing.md)). If you changed something
+that tier covers, run it yourself with `cargo nextest run --workspace --profile external
+--run-ignored all` and the servers installed.
+
+If `cargo nextest` isn't installed, run `/setup` — don't fall back to `cargo test`, which has no
+per-test timeout and will simply hang on a blocked test instead of naming it.

--- a/.claude/commands/setup.md
+++ b/.claude/commands/setup.md
@@ -15,6 +15,14 @@ rustc --version   # should report 1.95.0, matching rust-toolchain.toml
 If it doesn't match, `rustup` picks up `rust-toolchain.toml` automatically on the next `cargo`
 invocation in this directory — nothing to install by hand unless `rustup` itself is missing.
 
+Tests run under `cargo-nextest`, which this repo configures in `.config/nextest.toml` (per-test
+process isolation and a two-minute per-test timeout). Unlike rtk below, it is not optional — check
+for it and install it if absent:
+
+```sh
+cargo nextest --version || cargo install cargo-nextest --locked
+```
+
 ## 2. System dependencies
 
 Detect the platform and check accordingly; don't run installer commands for a platform other than

--- a/.claude/conventions-baseline.json
+++ b/.claude/conventions-baseline.json
@@ -1,5 +1,5 @@
 {
   "_comment": "Ratchet baseline for .claude/hooks/check-conventions.sh - these numbers may only go down, never up. Recount with the exact commands in that script's comments after fixing a batch of violations, and lower the number in the same commit.",
-  "glob_imports_app_src": 304,
-  "render_adapter_calls": 222
+  "glob_imports_app_src": 300,
+  "render_adapter_calls": 170
 }

--- a/.claude/hooks/pre-commit-check.sh
+++ b/.claude/hooks/pre-commit-check.sh
@@ -1,14 +1,17 @@
 #!/usr/bin/env bash
 # PreToolUse:Bash hook. Runs CLAUDE.md's pre-commit gate - the structural ratchet
-# (check-conventions.sh), fmt --check, and clippy -D warnings - before a `git commit` command
-# executes, so a lint-failing or convention-regressing change never lands in history.
-# `cargo test --workspace` is intentionally not part of this gate (or `/check`'s) right now -
-# GitHub issue #348 tracks why and getting it back. Run tests relevant to your change manually.
+# (check-conventions.sh), fmt --check, clippy -D warnings, and the `unit`/`ui` test tiers - before
+# a `git commit` command executes, so a lint-failing, convention-regressing or test-breaking
+# change never lands in history.
+#
+# Tests run through `cargo nextest`, not `cargo test`: per-test processes plus
+# `.config/nextest.toml`'s `slow-timeout` mean one hung test is a named failure rather than a hook
+# that never returns. The `external` tier is `#[ignore]`d and skipped by default (docs/testing.md).
 #
 # Exit code contract, matching Claude Code's PreToolUse protocol: this hook must NEVER hard-fail
 # in a way that blocks work for a reason unrelated to the gate itself. Missing `jq`, missing
-# `cargo`, or a command that isn't a git commit all exit 0 (allow, unmodified) rather than error.
-# Only a genuine fmt/clippy failure produces a deny decision.
+# `cargo`, missing `cargo-nextest`, or a command that isn't a git commit all exit 0 (allow,
+# unmodified) rather than error. Only a genuine fmt/clippy/test failure produces a deny decision.
 
 set -u
 
@@ -36,10 +39,24 @@ fi
 if [ -z "$FAIL" ] && command -v cargo &>/dev/null; then
   cargo clippy --workspace --all-targets -- -D warnings >/tmp/jerry-precommit-clippy.log 2>&1 || FAIL="clippy"
 fi
+# `cargo-nextest` is a separate binary, not part of a rustup toolchain: a contributor who hasn't
+# run `/setup` yet skips this step rather than being blocked by it, per this file's exit contract.
+# The skip is announced, not silent - a gate that quietly drops its only behavioural check reads as
+# a passing gate.
+if [ -z "$FAIL" ] && command -v cargo &>/dev/null; then
+  if command -v cargo-nextest &>/dev/null; then
+    cargo nextest run --workspace >/tmp/jerry-precommit-nextest.log 2>&1 || FAIL="nextest"
+  else
+    echo "pre-commit-check: cargo-nextest missing - tests NOT run for this commit." >&2
+    echo "  cargo install cargo-nextest --locked   (or run /setup)" >&2
+  fi
+fi
 
 if [ -n "$FAIL" ]; then
   if [ "$FAIL" = "conventions" ]; then
     REASON="the convention ratchet failed - see /tmp/jerry-precommit-conventions.log."
+  elif [ "$FAIL" = "nextest" ]; then
+    REASON="cargo nextest run --workspace failed - see /tmp/jerry-precommit-nextest.log. Run /check before committing."
   else
     REASON="cargo $FAIL failed - see /tmp/jerry-precommit-$FAIL.log. Run /check before committing."
   fi

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -10,12 +10,12 @@ changed and why from the diff alone.
 
 ## Steps
 
-1. **Run the gate.** `/check` (conventions + fmt + clippy `-D warnings`). Don't proceed past a
-   failure — a PR opened against a red gate just moves the failure to someone else's screen.
-   `cargo test --workspace` isn't part of this gate right now
-   ([issue #348](https://github.com/ColinEspinas/jerry/issues/348)) — run whatever tests are
-   relevant to the change manually (e.g. `cargo test -p wt-core`, or a scoped `cargo test -p app
-   --lib <module>::`) and note the result in the PR's Testing section instead of leaving it blank.
+1. **Run the gate.** `/check` (conventions + fmt + clippy `-D warnings` + `cargo nextest run
+   --workspace`). Don't proceed past a failure — a PR opened against a red gate just moves the
+   failure to someone else's screen. That covers the `unit` and `ui` tiers; if the change touches
+   the `external` tier (real language servers, `docs/testing.md`), run that yourself with
+   `cargo nextest run --workspace --profile external --run-ignored all` and note the result in the
+   PR's Testing section instead of leaving it blank.
 
 2. **Decide if this is UI-visible.** `git diff --name-only` against the target branch — did it
    touch a `render.rs`, `theme.rs`, or anything else that changes what the app looks like? If so,

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,39 @@
+# Test-runner policy for `cargo nextest run`. Each test gets its own process, so a hung or
+# resource-leaking test can be killed on its own instead of squatting a shared runner thread.
+
+[profile.default]
+# One broken module must not hide the state of the rest of the suite.
+fail-fast = false
+
+# Reported slow at 30s, killed after 4 periods (2 minutes). `cargo test` has no equivalent, which
+# is why a single blocking test can currently keep a run alive indefinitely.
+slow-timeout = { period = "30s", terminate-after = 4 }
+
+# Flakes get fixed, not retried into a green run.
+retries = 0
+
+[profile.ci]
+# Failures are repeated at the end of the log, where the Actions summary is readable.
+failure-output = "immediate-final"
+
+[profile.ci.junit]
+path = "junit.xml"
+
+# The `external` tier (docs/testing.md): real `rust-analyzer` / `typescript-language-server` /
+# `vue-language-server` / `pyright-langserver` processes. A real handshake plus a first index pass
+# legitimately takes seconds, so 30s/2min is too tight to distinguish "slow server" from "hung
+# test" here.
+#
+# This is a profile rather than the `[[profile.default.overrides]]` with a filterset that this
+# file's own TODO(#424) asked for, because that filterset cannot be written:
+# nextest's filterset language has no ignore-status predicate (verified against cargo-nextest
+# 0.9.143 - `ignored()` is a parse error, and `default()` refers to the profile's `default-filter`,
+# not to `#[ignore]`). The alternative, enumerating the tier's test names in a `test(/.../)`
+# filterset, would rot silently the moment a tier member is added or renamed. Selecting the tier by
+# the profile the tier's own CI job runs under is the version of this that cannot drift.
+#
+# Inherits `ci`, so the nightly external job gets the same immediate-final output and JUnit report
+# as the PR gate.
+[profile.external]
+inherits = "ci"
+slow-timeout = { period = "120s", terminate-after = 3 }

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,10 +14,12 @@
 
 ## Testing
 
-- [ ] `/check` (conventions + fmt + clippy `-D warnings`) passes locally
+- [ ] `/check` (conventions + fmt + clippy `-D warnings` + `cargo nextest run --workspace`) passes
+      locally
 - [ ] `verify` capture attached below, if this touches `render.rs`/`theme.rs`/layout
-- [ ] New/changed behavior has a real test, run manually and confirmed passing (`cargo test
-      --workspace` isn't part of the gate right now - issue #348)
+- [ ] New/changed behavior has a real test, in the right tier (docs/testing.md)
+- [ ] If this touches the `external` tier, it was run with the servers installed:
+      `cargo nextest run --workspace --profile external --run-ignored all`
 
 <!-- Note anything that couldn't be run and why ("not run: needs a live rust-analyzer") rather
      than silently leaving a box unchecked. -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,36 @@
 name: CI
 
 on:
+  # Scoped to the default branch on purpose. An unscoped `push:` alongside `pull_request:` fires
+  # two complete, identical runs of this workflow for every push to a PR branch - verified on
+  # GitHub issue #426's own branch, where runs 31974623400 (push) and 31974624833 (pull_request)
+  # are the same commit. PR branches are covered by `pull_request` alone.
+  #
+  # This is not about money: the repository is public, so GitHub-hosted standard runners are free
+  # and the usual Linux/Windows/macOS billing multipliers do not apply to it at all. It is about
+  # the two things that are genuinely scarce here - concurrent runner slots, where the macOS
+  # allowance is much smaller than the overall one, and the 10 GB per-repository Actions cache the
+  # duplicate run was evicting entries from.
   push:
+    branches: [master]
   pull_request:
+  # The `external` job below is gated to these two events specifically, and never runs on `push`
+  # or `pull_request`. Everything else in this workflow runs on them too, which is deliberate: a
+  # nightly rebuild is the cheapest signal there is that a toolchain or transitive-dependency
+  # update broke the build without anyone pushing.
+  workflow_dispatch:
+  schedule:
+    # 04:00 UTC - outside working hours in every timezone this project is worked in, so a nightly
+    # run never competes with a PR for runner capacity.
+    - cron: "0 4 * * *"
+
+# A new push supersedes the run still in flight for the same branch or PR instead of racing it to
+# completion and holding runner slots nothing is waiting on. `github.event_name` is part of the key
+# as well as the ref, so that a push to the default branch cannot cancel a `schedule` run that
+# shares that ref - the nightly is the only execution the `external` tier ever gets.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   CARGO_TERM_COLOR: always
@@ -17,17 +45,65 @@ env:
   JERRY_DISABLE_PROVIDER_POLL: "1"
 
 jobs:
-  # Build + the workspace's own [workspace.lints]-backed clippy check + fmt on Linux.
-  # Deliberately NOT running `cargo test --workspace` here: a real run (PR #347) showed most
-  # of the GPUI-window-touching suite failing/timing out in a non-interactive environment -
-  # far broader than the one confirmed-flaky test (#320) or the missing-language-server gap
-  # (#348). Restoring the test step needs that investigated first, not a blind re-enable -
-  # see #348, which now tracks both. The `git config --global` step below stays: it's the
-  # real fix for a `wt-core` test's own submodule-commit failure ("Author identity unknown"
-  # on a fresh runner with no global git identity), independent of whether tests run in CI.
-  linux:
-    name: Linux (build, clippy, fmt)
+  # The platform-independent half of the gate, and the only job that is not tied to an OS.
+  # `cargo fmt`, the convention ratchet and the version check all read source text: their answer
+  # cannot differ between Linux, macOS and Windows, so running them three times would burn three
+  # runners to produce the same result. They run once, here, on the cheapest one.
+  #
+  # Deliberately compile-free - no system packages, no cargo cache, no `cargo build`. None of these
+  # three steps needs a compiled workspace, which is what makes this the fast "you got something
+  # obviously wrong" signal that lands in about a minute while the platform jobs are still linking.
+  #
+  # clippy is NOT here, and that is the one real asymmetry in this file: it is a *compiled* lint, so
+  # it only ever sees the `#[cfg(target_os = ...)]` code of the platform it runs on. Running it once
+  # on Linux would leave `status_bar::process_stats::{macos,windows}` - 14 `unsafe` FFI sites, the
+  # code this project's own standards are strictest about - linted by nobody. So each platform job
+  # below runs clippy over its own target instead.
+  lint:
+    name: Lint (fmt, conventions)
     runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
+      - name: Install Rust 1.95.0
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.95.0"
+          components: rustfmt
+
+      # Deterministic ratchet, not a cargo lint: fails if the count of `use super::*` globs or
+      # of adapter calls in render.rs files rose vs .claude/conventions-baseline.json. See that
+      # script's own comments and docs/architecture/decisions.md (§3).
+      - name: Convention ratchet
+        run: .claude/hooks/check-conventions.sh
+
+      # Catches a crate manifest that regresses to a hardcoded version (issue #317).
+      - name: Crate version inheritance
+        run: .claude/hooks/check-release-version.sh
+
+      - name: cargo fmt --all -- --check
+        run: cargo fmt --all -- --check
+
+  # The three platform jobs below are deliberately the same shape: build, clippy, test. Whatever
+  # differs between them is a property of the platform, never of this file's own taste - the only
+  # intentional difference is Windows' test scope, which has its own comment.
+  #
+  # The test step is the `unit` and `ui` tiers of docs/testing.md, which is exactly what
+  # `cargo nextest run` executes by default - the `external` tier is `#[ignore]`d, and nextest skips
+  # ignored tests unless asked for them (`--run-ignored`, which only the `external` job passes).
+  #
+  # `nextest`, not `cargo test`: each test runs in its own process under `.config/nextest.toml`'s
+  # `slow-timeout`, so a test that blocks forever is a named, killed failure rather than a run that
+  # never ends.
+  linux:
+    name: Linux (build, clippy, test)
+    runs-on: ubuntu-latest
+    # A hard ceiling well above the ~10-minute target in issue #426, so a pathological hang still
+    # surfaces as a failed job rather than burning the six-hour default.
+    timeout-minutes: 45
     # System libraries GPUI's Linux backend (both the `wayland` and `x11`
     # gpui_platform features are compiled in, Revision R12 - see that file's own
     # Cargo.toml comment, and `crate::gpui_linux`'s real `guess_compositor()`-based
@@ -82,35 +158,60 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: "1.95.0"
-          components: rustfmt, clippy
+          components: clippy
 
+      # Pinned to the version this change was actually written and validated against, per this
+      # project's "same version we verified against, not latest" convention (see
+      # `crates/app/Cargo.toml`'s `tree-sitter`/`alacritty_terminal` comments).
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest@0.9.143
+
+      # `save-if` keeps the restore on every run but writes the cache only from the default branch.
+      # A repository gets 10 GB of Actions cache in total and GitHub evicts the least recently used
+      # entry once that fills; four jobs each saving a multi-gigabyte Rust target dir on every PR
+      # push churns that budget hard enough to evict the very entries the next run wants. Writing
+      # from master alone keeps one warm, stable entry per job instead.
       - name: Cache cargo/target
         uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/master' }}
+
+      # A fresh runner has no global git identity, unlike every developer machine. `wt-core`'s
+      # `discard_worktree_refuses_when_stash_push_captures_nothing_and_an_unrelated_stash_already_exists`
+      # runs `git commit` inside a real submodule checkout, and `git submodule update --init`
+      # creates an independent git directory that does not inherit the parent fixture's *local*
+      # identity - so that commit fails with a real "Author identity unknown" (observed, not
+      # hypothetical: commit ac8e6cd). This is the fix.
+      - name: Configure git identity
+        run: |
+          git config --global user.email "ci@example.invalid"
+          git config --global user.name "CI"
 
       - name: cargo build --workspace
         run: cargo build --workspace
 
-      # Deterministic ratchet, not a cargo lint: fails if the count of `use super::*` globs or
-      # of adapter calls in render.rs files rose vs .claude/conventions-baseline.json. See that
-      # script's own comments and docs/architecture/decisions.md (§3).
-      - name: Convention ratchet
-        run: .claude/hooks/check-conventions.sh
-
-      # Catches a crate manifest that regresses to a hardcoded version (issue #317).
-      - name: Crate version inheritance
-        run: .claude/hooks/check-release-version.sh
-
-      - name: cargo fmt --all -- --check
-        run: cargo fmt --all -- --check
-
       - name: cargo clippy --workspace --all-targets -- -D warnings
         run: cargo clippy --workspace --all-targets -- -D warnings
 
-  # Build-only signal on macOS and Windows, as two separate jobs (not a matrix) so all
-  # three platforms read as peers in the Actions UI, rather than Linux standing alone
-  # against one oddly-combined "the other two" job. Not every contributor can build and
-  # run the full test suite on both of these platforms locally, so these two jobs are the
-  # real verification that the workspace compiles there at all.
+      - name: cargo nextest run --workspace --profile ci
+        run: cargo nextest run --workspace --profile ci
+
+  # macOS and Windows are separate jobs rather than a matrix so all three platforms read as
+  # peers in the Actions UI. Not every contributor can build and run the suite on either of
+  # these platforms locally, so these two jobs are the only verification that the workspace
+  # works there at all.
+  #
+  # Same shape as the Linux job above - build, clippy, test - with one deliberate difference:
+  # Windows runs the narrow `status_bar::process_stats` filter it ran before issue #426 rather
+  # than the full suite. See the Windows job's own comment; that asymmetry is a recorded
+  # decision, not an oversight.
+  #
+  # macOS earned the full suite immediately: the bug that dominated this epic was a
+  # macOS-specific path canonicalization difference (`/var` is a symlink to `/private/var`,
+  # so a `PathBuf` comparison that holds on Linux does not hold there), and it went unseen
+  # precisely because no macOS runner ever executed the tests that would have caught it.
   #
   # `crates/app/Cargo.toml` has real per-target `[target.'cfg(target_os =
   # "...")'.dependencies]` sections for `gpui_platform` (Revision R11, extended in R12):
@@ -123,8 +224,9 @@ jobs:
   # needs no `--features` flag on either platform: per-target dependency/feature
   # selection is Cargo's job, resolved automatically from the actual build target.
   macos:
-    name: macOS (build + sampling tests)
+    name: macOS (build, clippy, test)
     runs-on: macos-latest
+    timeout-minutes: 45
     # A real, platform-specific build-script requirement found by reading
     # `vendor/zed/crates/gpui_macos/build.rs` directly (not assumed): it unconditionally
     # shells out to `xcrun -sdk macosx metal` to compile real Metal shaders - this needs
@@ -141,36 +243,65 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: "1.95.0"
+          components: clippy
 
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest@0.9.143
+
+      # Same `save-if` reasoning as the Linux job - see that job's own comment on the 10 GB
+      # per-repository Actions cache budget.
       - name: Cache cargo/target
         uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/master' }}
+
+      # Same reason as the Linux job's identical step: `wt-core`'s submodule-commit test
+      # needs a global git identity a fresh runner does not have.
+      - name: Configure git identity
+        run: |
+          git config --global user.email "ci@example.invalid"
+          git config --global user.name "CI"
 
       - name: cargo build --workspace
         run: cargo build --workspace
 
-      # GitHub issue #283: the macOS per-process CPU/memory sampling backend
-      # (`crate::status_bar::process_stats::macos`) is real `proc_pid_rusage` FFI that nobody
-      # working on this repo can run locally - this project's dev environment is Linux/WSL2-only
-      # (see this file's own comments above). `cargo build` above does not help: it does not
-      # compile `#[cfg(test)]` modules at all, so without this step not one line of that
-      # backend's tests would ever execute on any macOS machine.
-      #
-      # This is deliberately a *narrow* filter, not the fuller `cargo test` this job's own
-      # comments explain is out of scope: `status_bar::process_stats` needs no language servers,
-      # no git fixtures and no filesystem watchers, so it is free of every environment gap that
-      # keeps the rest of the suite off these runners.
-      #
-      # It earns its keep concretely. `ri_user_time`/`ri_system_time` are mach *timebase* units,
-      # not nanoseconds, and reading them as nanoseconds under-reports CPU by ~41.7x on Apple
-      # Silicon while being exactly right on Intel - a defect this backend genuinely shipped with
-      # for one commit. `macos-latest` is Apple Silicon, and that backend's busy-child test
-      # asserts a real lower bound against wall-clock time, so this step is what would catch it.
-      - name: cargo test (per-process sampling backend)
-        run: cargo test -p app --lib status_bar::process_stats
+      # clippy runs per platform, not once on Linux, because it only ever lints the
+      # `#[cfg(target_os = ...)]` code of the target it runs against. This step is the only thing
+      # that lints `crate::status_bar::process_stats::macos` at all - 7 `unsafe` `proc_pid_rusage`
+      # FFI sites that a Linux-only clippy pass cannot even parse into its analysis.
+      - name: cargo clippy --workspace --all-targets -- -D warnings
+        run: cargo clippy --workspace --all-targets -- -D warnings
 
+      # This job is what makes GitHub issue #283's macOS per-process CPU/memory sampling backend
+      # (`crate::status_bar::process_stats::macos`, real `proc_pid_rusage` FFI) actually get
+      # executed: `cargo build` above does not compile `#[cfg(test)]` modules at all, so without a
+      # test step not one line of that backend's tests would ever run on any macOS machine. It
+      # earns its keep concretely - `ri_user_time`/`ri_system_time` are mach *timebase* units, not
+      # nanoseconds, and reading them as nanoseconds under-reports CPU by ~41.7x on Apple Silicon
+      # while being exactly right on Intel, a defect this backend genuinely shipped with for one
+      # commit. `macos-latest` is Apple Silicon, and that backend's busy-child test asserts a real
+      # lower bound against wall-clock time.
+      - name: cargo nextest run --workspace --profile ci
+        run: cargo nextest run --workspace --profile ci
+
+  # DELIBERATELY NARROW - do not widen this to `--workspace` without reading issue #440 first.
+  #
+  # Issue #426 widened this job to the full suite for exactly one run, and that run is the whole
+  # argument: 3073 tests, 134 failed and 26 timed out, in 1407 seconds. Those failures are real
+  # and they are a large investigation of their own - paths formatted into strings, forward
+  # slashes baked into expected values, and 26 timeouts whose mechanism nobody has diagnosed yet.
+  # Issue #440 tracks that work. It was split out of epic #427 rather than done here because
+  # chasing it would hold a finished epic behind an unbounded piece of work.
+  #
+  # So Windows test coverage is deferred, not forgotten, and this job is back to the
+  # `status_bar::process_stats` filter it ran before #426. The full suite does not pass on
+  # Windows yet; re-widening it before #440 is done just turns this check permanently red.
   windows:
-    name: Windows (build + sampling tests)
+    name: Windows (build, clippy, sampling tests)
     runs-on: windows-latest
+    timeout-minutes: 45
     # A real, platform-specific build-script quirk found by reading
     # `vendor/zed/crates/gpui_windows/build.rs` directly (not assumed): its
     # `fxc.exe`-based HLSL shader compilation is gated behind
@@ -189,12 +320,26 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: "1.95.0"
+          components: clippy
 
+      # Same `save-if` reasoning as the Linux job - see that job's own comment on the 10 GB
+      # per-repository Actions cache budget.
       - name: Cache cargo/target
         uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/master' }}
 
       - name: cargo build --workspace
         run: cargo build --workspace
+
+      # The Windows twin of the macOS job's clippy step, and the only thing that lints
+      # `crate::status_bar::process_stats::windows` - 7 `unsafe` `GetProcessTimes`/PSAPI FFI sites
+      # written on a Linux machine and, until this step, never seen by clippy on any target where
+      # they actually compile. Note this lints the whole workspace for the Windows target even
+      # though the test step below is narrow: linting is cheap and has none of the 3073-test
+      # problems issue #440 tracks.
+      - name: cargo clippy --workspace --all-targets -- -D warnings
+        run: cargo clippy --workspace --all-targets -- -D warnings
 
       # GitHub issue #283, the Windows twin of the macOS job's step above - same reasoning,
       # same narrow filter. `crate::status_bar::process_stats::windows` is real `GetProcessTimes`
@@ -204,3 +349,101 @@ jobs:
       # claim would be empty.
       - name: cargo test (per-process sampling backend)
         run: cargo test -p app --lib status_bar::process_stats
+
+  # The `external` tier (docs/testing.md): tests that spawn a real language server. Never on a PR,
+  # by the `if` below - these need binaries the repo does not vendor and a live npm registry, so
+  # they are slow, network-dependent and outside anything a contributor's PR controls. Nightly and
+  # on demand only.
+  #
+  # `--run-ignored all` runs the whole suite *including* the ignored tier, rather than
+  # `ignored-only`: an `external` test that passes while its `unit`/`ui` neighbours have regressed
+  # is not a useful signal, and the extra cost is one already-cached build away.
+  external:
+    name: External (real language servers)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
+      # Same list, same reasons, as the `linux` job above.
+      - name: Install Linux system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential \
+            clang \
+            cmake \
+            pkg-config \
+            libfontconfig-dev \
+            libvulkan1 \
+            mesa-vulkan-drivers \
+            libwayland-dev \
+            libxkbcommon-dev \
+            libxkbcommon-x11-dev \
+            libx11-xcb-dev \
+            libasound2-dev
+
+      # `rust-analyzer` is a real rustup component, not a separate download, so requesting it here
+      # pins it to the same 1.95.0 toolchain the rest of the workflow uses - the strongest pin
+      # available for it, and free. Verified: `rustup component list` reports
+      # `rust-analyzer-<host>` and installing it puts a `rust-analyzer` proxy on PATH.
+      - name: Install Rust 1.95.0
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.95.0"
+          components: rust-analyzer
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest@0.9.143
+
+      # Pinned to the version verified against, not latest, per `crates/app/Cargo.toml`'s
+      # `tree-sitter`/`alacritty_terminal` convention. `@vue/language-server@3.3.8` is the version
+      # `crate::language`'s module docs were written against.
+      #
+      # `typescript-language-server` and `pyright` are deliberately unpinned: no version is
+      # recorded anywhere in the repo for the tests that use them, and a guessed pin looks
+      # authoritative while hiding drift. TODO(#426): the "Resolved server versions" step prints
+      # what npm resolved on each nightly run - bisect from a passing run, then pin.
+      #
+      # `gopls` is absent because no test spawns it: `crate::language` gives Go `lsp: None`, and
+      # the Settings page only detects it on PATH.
+      - name: Install language servers
+        run: |
+          npm install -g \
+            "@vue/language-server@3.3.8" \
+            typescript-language-server \
+            pyright
+
+      # The evidence-gathering half of the unpinned-version TODO above: every nightly run records
+      # exactly which versions it tested against, so pinning later is a lookup, not a re-guess.
+      # `|| true` because this step exists to record information, not to gate: `npm ls` exits
+      # non-zero on any pre-existing peer-dependency complaint in the runner image's own global
+      # tree, which has nothing to do with whether the servers installed.
+      - name: Resolved server versions
+        run: |
+          npm ls -g --depth=0 || true
+          rust-analyzer --version
+
+      # No `save-if` here, unlike the three platform jobs: this job only ever runs from
+      # `workflow_dispatch` or the nightly `schedule`, never on a PR, so it is not a source of
+      # cache churn and its own entry is worth keeping warm between nightlies.
+      - name: Cache cargo/target
+        uses: Swatinem/rust-cache@v2
+
+      # Same reason as the Linux job's identical step: `wt-core`'s submodule-commit test
+      # needs a global git identity a fresh runner does not have.
+      - name: Configure git identity
+        run: |
+          git config --global user.email "ci@example.invalid"
+          git config --global user.name "CI"
+
+      # `--profile external` inherits `ci` and raises `slow-timeout` - see `.config/nextest.toml`
+      # for why the tier gets its own profile rather than a filterset override.
+      - name: cargo nextest run --workspace --profile external --run-ignored all
+        run: cargo nextest run --workspace --profile external --run-ignored all

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,19 +16,18 @@ the product description; this file only covers how to build it.
 cargo build --workspace
 cargo clippy --workspace --all-targets -- -D warnings
 cargo fmt --all -- --check
+cargo nextest run --workspace
 ```
 
-All three together are the pre-commit gate — run them as `/check` before considering anything
-done. `.claude/hooks/pre-commit-check.sh` runs the same three automatically before any
+All four together are the pre-commit gate — run them as `/check` before considering anything
+done. `.claude/hooks/pre-commit-check.sh` runs the same four automatically before any
 `git commit`, as a safety net. None are optional; a PR that needs `#[allow(...)]` to silence a
 lint either fixes the underlying issue or justifies the allow with a one-line comment.
 
-**`cargo test --workspace` is deliberately not part of this gate right now.** A real run
-surfaced most of the GPUI-window-touching suite failing/timing out outside an interactive
-session — investigated in [GitHub issue #348](https://github.com/ColinEspinas/jerry/issues/348),
-which also tracks getting it back into CI and this gate once resolved. Run tests relevant to what
-you're touching manually in the meantime (e.g. `cargo test -p wt-core`, or a scoped
-`cargo test -p app --lib <module>::`), and don't treat a clean `/check` as proof the suite passes.
+The test step covers the `unit` and `ui` tiers; the `external` tier is `#[ignore]`d and runs only
+in CI's nightly job (see "Testing" below). `cargo nextest`, not `cargo test`: `.config/nextest.toml`
+gives each test its own process and a real timeout, so a hung test fails that test instead of
+sitting on the whole run forever.
 
 Run the app with `cargo run --release -p app [repo-path]`. Use `--release` unless you're actively
 recompiling every few seconds: a debug-profile GPUI build is commonly 5–20× slower for the per-frame
@@ -125,10 +124,13 @@ what this rule would have flagged.
 
 ## Testing
 
-`#[gpui::test]` + `TestAppContext`/`VisualTestContext` for anything touching a `Render`/`Entity` —
-not a snapshot of stdout, which doesn't cover a retained-mode GPU UI. Name test modules by concern
-(`mod change_row_selection_tests`, not `mod tests`) — the existing 175-name convention is good,
-keep it. Fixtures live under a sibling `testdata/` directory, not inlined as string literals.
+Every test is one of three tiers: `unit` (plain `#[test]`, pure logic or a tempdir, < 10 ms), `ui`
+(`#[gpui::test]` + `TestAppContext`/`VisualTestContext` for anything touching a `Render`/`Entity`,
+< 2 s), or `external` (`#[ignore = "external: <binary>; …"]`, a real language server or agent
+process, its own CI job and never the PR gate). Shared fixtures — argv-only `git`, seeded
+repositories, `wait_until`, `ChildGuard` — come from `crates/test-support`, which stays `gpui`-free;
+GPUI ones from `crates/app/src/test_support.rs`. What deserves a test, what gets deleted and why,
+and the no-`thread::sleep` rule: [`docs/testing.md`](docs/testing.md).
 
 ## Workflow
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,12 @@ it that way as more people touch it.
 — the revision lives in the root [`Cargo.toml`](Cargo.toml), which is its only home; don't restate
 it elsewhere. Cargo fetches them automatically; no manual checkout is needed.
 
+Tests run under [`cargo-nextest`](https://nexte.st), not `cargo test` — install it once:
+
+```sh
+cargo install cargo-nextest --locked
+```
+
 Coding standards (what "no fake functionality" means, the exact hard rules on `unwrap`/`unsafe`/
 paths/git argv, comment style, GPUI patterns) live in [`CLAUDE.md`](CLAUDE.md) — read that, not this
 file, for how the code itself should look. This file covers the human contribution process around
@@ -22,12 +28,24 @@ Every change must pass, locally, before you open a PR — the same checks CI run
 cargo build --workspace
 cargo clippy --workspace --all-targets -- -D warnings
 cargo fmt --all -- --check
+cargo nextest run --workspace
 ```
 
 Run them together as `/check` if you're working through Claude Code. None are optional or "mostly
-passing." `cargo test --workspace` is intentionally not part of this list right now — see
-[issue #348](https://github.com/ColinEspinas/jerry/issues/348); run tests relevant to what you're
-touching manually instead.
+passing."
+
+`.config/nextest.toml` gives every test its own process and kills one that is still running after
+two minutes, so a hung test fails that test instead of the whole run. `cargo test` has no
+equivalent and will sit there indefinitely — prefer `cargo nextest run`. While iterating, scope it
+to what you're touching:
+
+```sh
+cargo nextest run -p wt-core
+```
+
+That covers the `unit` and `ui` tiers. The `external` tier — tests that spawn a real language
+server — is `#[ignore]`d, never part of the PR gate, and runs in its own nightly CI job. See
+[`docs/testing.md`](docs/testing.md).
 
 See [`docs/development-workflow.md`](docs/development-workflow.md) for how a change actually moves
 from a GitHub issue to a merged PR in this repo, including which Claude Code skill covers which

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,6 +312,7 @@ dependencies = [
  "sha2",
  "streaming-iterator",
  "tempfile",
+ "test-support",
  "toml 0.8.23",
  "tree-sitter",
  "tree-sitter-c",
@@ -4776,6 +4777,7 @@ name = "lsp-core"
 version = "0.1.1"
 dependencies = [
  "dunce",
+ "libc",
  "log",
  "lsp-types",
  "nix",
@@ -4783,6 +4785,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "test-support",
  "thiserror 1.0.69",
  "url",
 ]
@@ -6148,9 +6151,11 @@ version = "0.1.1"
 dependencies = [
  "anyhow",
  "filedescriptor",
+ "libc",
  "nix",
  "portable-pty",
  "tempfile",
+ "test-support",
  "thiserror 1.0.69",
 ]
 
@@ -7926,6 +7931,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "test-support"
+version = "0.1.1"
+dependencies = [
+ "tempfile",
 ]
 
 [[package]]
@@ -9890,6 +9902,7 @@ dependencies = [
  "gix",
  "sha2",
  "tempfile",
+ "test-support",
  "thiserror 1.0.69",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,9 @@ members = [
     "crates/pty-core",
     "crates/lsp-core",
     "crates/app",
+    # Dev-dependency only, and deliberately gpui-free so the core crates can use it too
+    # (docs/architecture/decisions.md §1, docs/testing.md).
+    "crates/test-support",
 ]
 
 [workspace.package]

--- a/README.md
+++ b/README.md
@@ -274,6 +274,11 @@ split, and the reasoning for each, are in [`docs/architecture/`](docs/architectu
 a change moves from issue to merged PR is in
 [`docs/development-workflow.md`](docs/development-workflow.md).
 
+Tests run under [`cargo-nextest`](https://nexte.st) rather than `cargo test`, for the per-test
+process isolation and timeout configured in `.config/nextest.toml`. CI runs the full suite on Linux
+and macOS; Windows builds and runs only its platform-specific sampling tests, because the rest does
+not pass there yet ([issue #440](https://github.com/ColinEspinas/jerry/issues/440)).
+
 ## License
 
 [MIT](LICENSE-MIT) or [Apache-2.0](LICENSE-APACHE).

--- a/assets/themes/ember.toml
+++ b/assets/themes/ember.toml
@@ -81,7 +81,7 @@ diagnostic_card_footer = "#251d22"  # The Diagnostic popover's own footer band's
 # The Files tree's own structural marks (GitHub issue #18 §3).
 [tree]
 indent_guide        = "#1c2124"
-indent_guide_active = "#224959"  # The guide for a level in the selected file's ancestor chain
+indent_guide_active = "#224959"
 
 # The overlay scrollbar (GitHub issue #30).
 [scrollbar]

--- a/assets/themes/jerry-dim.toml
+++ b/assets/themes/jerry-dim.toml
@@ -81,7 +81,7 @@ diagnostic_card_footer = "#312829"  # The Diagnostic popover's own footer band's
 # The Files tree's own structural marks (GitHub issue #18 §3).
 [tree]
 indent_guide        = "#292c30"
-indent_guide_active = "#435971"  # The guide for a level in the selected file's ancestor chain
+indent_guide_active = "#435971"
 
 # The overlay scrollbar (GitHub issue #30).
 [scrollbar]

--- a/assets/themes/moss.toml
+++ b/assets/themes/moss.toml
@@ -81,7 +81,7 @@ diagnostic_card_footer = "#292224"  # The Diagnostic popover's own footer band's
 # The Files tree's own structural marks (GitHub issue #18 §3).
 [tree]
 indent_guide        = "#232528"
-indent_guide_active = "#3f5264"  # The guide for a level in the selected file's ancestor chain
+indent_guide_active = "#3f5264"
 
 # The overlay scrollbar (GitHub issue #30).
 [scrollbar]

--- a/assets/themes/paper.toml
+++ b/assets/themes/paper.toml
@@ -81,7 +81,7 @@ diagnostic_card_footer = "#dfd5d7"  # The Diagnostic popover's own footer band's
 # The Files tree's own structural marks (GitHub issue #18 §3).
 [tree]
 indent_guide        = "#d3d8dc"
-indent_guide_active = "#90a9bf"  # The guide for a level in the selected file's ancestor chain
+indent_guide_active = "#90a9bf"
 
 # The overlay scrollbar (GitHub issue #30).
 [scrollbar]

--- a/assets/themes/slate.toml
+++ b/assets/themes/slate.toml
@@ -81,7 +81,7 @@ diagnostic_card_footer = "#251d1e"  # The Diagnostic popover's own footer band's
 # The Files tree's own structural marks (GitHub issue #18 §3).
 [tree]
 indent_guide        = "#1d2024"
-indent_guide_active = "#2d435b"  # The guide for a level in the selected file's ancestor chain
+indent_guide_active = "#2d435b"
 
 # The overlay scrollbar (GitHub issue #30).
 [scrollbar]

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -379,6 +379,9 @@ windows-sys = { version = "0.61.2", features = [
 
 [dev-dependencies]
 tempfile = "3"
+# Shared, gpui-free fixtures (real seeded repositories, argv-only `git`, bounded waits,
+# `ChildGuard`) - see `docs/testing.md`.
+test-support = { path = "../test-support" }
 # `test-support` unlocks GPUI's real interactive test harness (`#[gpui::test]`,
 # `TestAppContext`/`VisualTestContext` - a real window, real focus tracking, real action
 # dispatch/keystroke simulation, not a mock). Kept as a permanent dependency, not a temporary

--- a/crates/app/src/code_surface/code_view.rs
+++ b/crates/app/src/code_surface/code_view.rs
@@ -2031,21 +2031,21 @@ mod tests {
     }
 
     #[test]
-    fn detects_lf_from_real_bytes() {
-        assert_eq!(detect_line_ending(b"fn main() {\n}\n"), LineEnding::Lf);
-    }
-
-    #[test]
-    fn detects_crlf_from_real_bytes() {
-        assert_eq!(
-            detect_line_ending(b"fn main() {\r\n}\r\n"),
-            LineEnding::Crlf
-        );
-    }
-
-    #[test]
-    fn a_file_with_no_newline_at_all_defaults_to_lf() {
-        assert_eq!(detect_line_ending(b"no newline here"), LineEnding::Lf);
+    fn detect_line_ending_reads_the_real_bytes_and_defaults_to_lf() {
+        let cases: &[(&[u8], LineEnding)] = &[
+            (b"fn main() {\n}\n", LineEnding::Lf),
+            (b"fn main() {\r\n}\r\n", LineEnding::Crlf),
+            // Nothing to read: a file with no newline at all is LF, not "unknown".
+            (b"no newline here", LineEnding::Lf),
+        ];
+        for (bytes, expected) in cases {
+            assert_eq!(
+                detect_line_ending(bytes),
+                *expected,
+                "{:?}",
+                String::from_utf8_lossy(bytes)
+            );
+        }
     }
 
     fn plain_line(text: &str) -> RenderedLine {
@@ -2055,111 +2055,69 @@ mod tests {
         }
     }
 
+    /// Every shape `detect_indent_width` has to get right, in one table. The two "one-off" rows
+    /// are the audit's own reproductions: a C-style block-comment header's single leading space
+    /// and a hanging-indent continuation line must each lose to the file's real, repeated indent
+    /// unit rather than being picked just for appearing first.
     #[test]
-    fn detect_indent_width_finds_the_first_real_space_indented_line() {
-        let lines: Vec<RenderedLine> = ["fn main() {", "    let x = 1;", "}"]
-            .iter()
-            .map(|text| plain_line(text))
-            .collect();
-        assert_eq!(detect_indent_width(&lines), Some(4));
-    }
-
-    #[test]
-    fn detect_indent_width_skips_tab_indented_lines() {
-        let lines: Vec<RenderedLine> = ["fn main() {", "\tlet x = 1;", "  let y = 2;"]
-            .iter()
-            .map(|text| plain_line(text))
-            .collect();
-        assert_eq!(
-            detect_indent_width(&lines),
-            Some(2),
-            "a tab-indented line has no single \"N spaces\" answer - keep scanning for a real \
-             space-indented one"
-        );
-    }
-
-    #[test]
-    fn detect_indent_width_skips_whitespace_only_lines() {
-        let lines: Vec<RenderedLine> = ["fn main() {", "    ", "      let x = 1;"]
-            .iter()
-            .map(|text| plain_line(text))
-            .collect();
-        assert_eq!(
-            detect_indent_width(&lines),
-            Some(6),
-            "a blank/whitespace-only line says nothing about the real indent unit"
-        );
-    }
-
-    #[test]
-    fn detect_indent_width_with_no_indentation_anywhere_is_none() {
-        let lines: Vec<RenderedLine> = ["fn main() {", "}"]
-            .iter()
-            .map(|text| plain_line(text))
-            .collect();
-        assert_eq!(detect_indent_width(&lines), None);
-    }
-
-    #[test]
-    fn detect_indent_width_on_an_empty_file_is_none() {
-        assert_eq!(detect_indent_width(&[]), None);
-    }
-
-    #[test]
-    fn detect_indent_width_is_not_fooled_by_a_single_block_comment_header_line() {
-        let lines: Vec<RenderedLine> = [
-            "/**",
-            " * Copyright 2024 Example Corp.",
-            " */",
-            "fn main() {",
-            "    let x = 1;",
-            "    let y = 2;",
-            "    let z = 3;",
-            "}",
-        ]
-        .iter()
-        .map(|text| plain_line(text))
-        .collect();
-        assert_eq!(
-            detect_indent_width(&lines),
-            Some(4),
-            "the real, repeated 4-space body indent should win over a one-off single leading \
-             space from a C-style block comment header"
-        );
-    }
-
-    #[test]
-    fn detect_indent_width_is_not_fooled_by_a_single_hanging_indent_continuation_line() {
-        let lines: Vec<RenderedLine> = [
-            "let long_name =",
-            "  some_call(a, b);",
-            "fn main() {",
-            "    let x = 1;",
-            "    let y = 2;",
-            "}",
-        ]
-        .iter()
-        .map(|text| plain_line(text))
-        .collect();
-        assert_eq!(
-            detect_indent_width(&lines),
-            Some(4),
-            "a one-off 2-space hanging-indent continuation line must not out-vote the file's \
-             real, repeated 4-space indent"
-        );
-    }
-
-    #[test]
-    fn detect_indent_width_breaks_a_tie_toward_the_smaller_width() {
-        let lines: Vec<RenderedLine> = ["  two spaces", "    four spaces"]
-            .iter()
-            .map(|text| plain_line(text))
-            .collect();
-        assert_eq!(
-            detect_indent_width(&lines),
-            Some(2),
-            "an exact tie in occurrence count should prefer the smaller, more conventional width"
-        );
+    fn detect_indent_width_picks_the_files_real_repeated_indent_unit() {
+        let cases: &[(&str, &[&str], Option<usize>)] = &[
+            (
+                "plain space indent",
+                &["fn main() {", "    let x = 1;", "}"],
+                Some(4),
+            ),
+            // A tab-indented line has no single "N spaces" answer - keep scanning.
+            (
+                "tab lines skipped",
+                &["fn main() {", "\tlet x = 1;", "  let y = 2;"],
+                Some(2),
+            ),
+            // A blank/whitespace-only line says nothing about the real indent unit.
+            (
+                "blank lines skipped",
+                &["fn main() {", "    ", "      let x = 1;"],
+                Some(6),
+            ),
+            ("no indentation at all", &["fn main() {", "}"], None),
+            ("empty file", &[], None),
+            (
+                "block comment header",
+                &[
+                    "/**",
+                    " * Copyright 2024 Example Corp.",
+                    " */",
+                    "fn main() {",
+                    "    let x = 1;",
+                    "    let y = 2;",
+                    "    let z = 3;",
+                    "}",
+                ],
+                Some(4),
+            ),
+            (
+                "hanging indent continuation",
+                &[
+                    "let long_name =",
+                    "  some_call(a, b);",
+                    "fn main() {",
+                    "    let x = 1;",
+                    "    let y = 2;",
+                    "}",
+                ],
+                Some(4),
+            ),
+            // An exact tie in occurrence count prefers the smaller, more conventional width.
+            (
+                "tie breaks smaller",
+                &["  two spaces", "    four spaces"],
+                Some(2),
+            ),
+        ];
+        for (label, texts, expected) in cases {
+            let lines: Vec<RenderedLine> = texts.iter().map(|text| plain_line(text)).collect();
+            assert_eq!(detect_indent_width(&lines), *expected, "{label}");
+        }
     }
 
     #[test]
@@ -2201,176 +2159,423 @@ mod tests {
     const SAMPLE_RUST: &str =
         "/// Adds one.\nfn add(left: i32) -> i32 {\n    let name = \"x\";\n    left + 1\n}\n";
 
-    #[test]
-    fn fn_keyword_is_classified_as_keyword() {
-        let spans = highlight_rust(SAMPLE_RUST);
-        let span = find_span(&spans, SAMPLE_RUST, "fn").expect("fn span");
-        assert_eq!(span.kind, HighlightKind::Keyword);
-    }
-
-    #[test]
-    fn a_string_literal_is_classified_as_string() {
-        let spans = highlight_rust(SAMPLE_RUST);
-        let span = find_span(&spans, SAMPLE_RUST, "\"x\"").expect("string literal span");
-        assert_eq!(span.kind, HighlightKind::String);
-    }
-
-    #[test]
-    fn a_function_name_is_classified_as_function() {
-        let spans = highlight_rust(SAMPLE_RUST);
-        let span = find_span(&spans, SAMPLE_RUST, "add").expect("function name span");
-        assert_eq!(span.kind, HighlightKind::FunctionDefinition);
-    }
-
-    #[test]
-    fn a_primitive_type_identifier_is_classified_as_type_builtin() {
-        let spans = highlight_rust(SAMPLE_RUST);
-        // "i32" appears twice (parameter type, return type); just confirm at least one
-        // occurrence was classified as TypeBuiltin - `i32` is a real `(primitive_type)` node in
-        // `tree-sitter-rust`'s own grammar, captured `@type.builtin`, not the plain `@type` a
-        // user-defined type name would get.
-        let type_spans: Vec<_> = spans
-            .iter()
-            .filter(|span| SAMPLE_RUST[span.start..span.end] == *"i32")
-            .collect();
-        assert!(!type_spans.is_empty());
-        assert!(type_spans
-            .iter()
-            .all(|span| span.kind == HighlightKind::TypeBuiltin));
-    }
-
-    #[test]
-    fn a_doc_comment_is_classified_as_comment_doc() {
-        let spans = highlight_rust(SAMPLE_RUST);
-        // The `line_comment` node's byte range includes its trailing newline; it's treated as
-        // one span rather than recursed into, since its children are just lexical pieces, not
-        // separately-colourable syntax. `///` is a real `(doc_comment)` child node, captured
-        // `@comment.documentation` - its own dedicated bucket since GitHub issue #31, not the
-        // plain `Comment` an ordinary `//` line gets.
-        let span = find_span(&spans, SAMPLE_RUST, "/// Adds one.\n").expect("doc comment span");
-        assert_eq!(span.kind, HighlightKind::CommentDoc);
-    }
-
-    #[test]
-    fn self_is_classified_as_variable_builtin_not_keyword() {
-        let source = "impl Foo {\n    fn bar(&self) -> i32 {\n        self.value\n    }\n}\n";
-        let spans = highlight_rust(source);
-        let span = find_span(&spans, source, "self").expect("self span");
-        assert_eq!(span.kind, HighlightKind::VariableBuiltin);
-    }
-
-    #[test]
-    fn highlighting_invalid_rust_still_returns_a_real_non_empty_span_list() {
-        // Tree-sitter produces a best-effort tree for malformed input rather than failing
-        // outright - confirm this doesn't panic and still classifies the keyword token present.
-        let spans = highlight_rust("fn (((( broken");
-        assert!(spans.iter().any(|span| span.kind == HighlightKind::Keyword));
-    }
-
     // Real TypeScript highlighting coverage - mirrors `highlight_rust`'s own test shape above.
     // Before this fix, none of `highlight_typescript`'s real, common-case behavior had any test
     // coverage at all.
 
     const SAMPLE_TYPESCRIPT: &str = "/** Adds one. */\nfunction add(left: number): number {\n    const name = \"x\";\n    return left + 1;\n}\n";
 
+    /// One row per real token this module's docs claim a bucket for, across every grammar - the
+    /// table form of what used to be one `#[test]` per row.
+    ///
+    /// Each row asks exactly what the renderer asks: which [`HighlightKind`] covers this token's
+    /// first byte ([`kind_at`]). Behaviour that is *not* a single token -> single bucket lookup
+    /// (definition vs. call site, casing sweeps, injected fences, bracket rings) keeps its own
+    /// test below; this table is only for the flat ones.
     #[test]
-    fn typescript_function_keyword_is_classified_as_keyword() {
-        let spans = highlight_typescript(SAMPLE_TYPESCRIPT, false);
-        let span = find_span(&spans, SAMPLE_TYPESCRIPT, "function").expect("function span");
-        assert_eq!(span.kind, HighlightKind::Keyword);
+    fn every_documented_token_lands_in_its_documented_bucket() {
+        let cases: &[(
+            &str,
+            crate::language::HighlighterFn,
+            &str,
+            &str,
+            HighlightKind,
+        )] = &[
+            (
+                "rust",
+                highlight_rust,
+                SAMPLE_RUST,
+                "fn",
+                HighlightKind::Keyword,
+            ),
+            (
+                "rust",
+                highlight_rust,
+                SAMPLE_RUST,
+                "add",
+                HighlightKind::FunctionDefinition,
+            ),
+            (
+                "rust",
+                highlight_rust,
+                SAMPLE_RUST,
+                "\"x\"",
+                HighlightKind::String,
+            ),
+            (
+                "rust",
+                highlight_rust,
+                SAMPLE_RUST,
+                "i32",
+                HighlightKind::TypeBuiltin,
+            ),
+            (
+                "rust",
+                highlight_rust,
+                SAMPLE_RUST,
+                "/// Adds one.",
+                HighlightKind::CommentDoc,
+            ),
+            (
+                "ts",
+                highlight_ts,
+                SAMPLE_TYPESCRIPT,
+                "function",
+                HighlightKind::Keyword,
+            ),
+            (
+                "ts",
+                highlight_ts,
+                SAMPLE_TYPESCRIPT,
+                "add",
+                HighlightKind::FunctionDefinition,
+            ),
+            (
+                "ts",
+                highlight_ts,
+                SAMPLE_TYPESCRIPT,
+                "\"x\"",
+                HighlightKind::String,
+            ),
+            (
+                "ts",
+                highlight_ts,
+                SAMPLE_TYPESCRIPT,
+                "number",
+                HighlightKind::TypeBuiltin,
+            ),
+            (
+                "ts",
+                highlight_ts,
+                SAMPLE_TYPESCRIPT,
+                "/** Adds one. */",
+                HighlightKind::Comment,
+            ),
+            // `(regex) @string.special`, its own bucket since GitHub issue #183 - it used to
+            // fall through to the plain `"string"` entry and read as an ordinary string.
+            (
+                "ts",
+                highlight_ts,
+                "const pattern = /^[a-z]+$/;\n",
+                "^[a-z]+$",
+                HighlightKind::StringSpecial,
+            ),
+            // The three `name`-field collisions that all used to come out `Function`: a
+            // `const` binding, an `interface` member, and a class method (which really is one).
+            (
+                "ts",
+                highlight_ts,
+                "const s: string = \"hi\";\n",
+                "s: string",
+                HighlightKind::Variable,
+            ),
+            (
+                "ts",
+                highlight_ts,
+                "interface Point { x: number }\n",
+                "x: number",
+                HighlightKind::Property,
+            ),
+            (
+                "ts",
+                highlight_ts,
+                "class Point {\n    length() {\n        return 0;\n    }\n}\n",
+                "length",
+                HighlightKind::FunctionDefinition,
+            ),
+            // A TSX tag name is the same collision once more, and gets its own `Tag` bucket.
+            (
+                "tsx",
+                highlight_tsx,
+                "const el = <div />;\n",
+                "div",
+                HighlightKind::Tag,
+            ),
+            (
+                "python",
+                highlight_python,
+                SAMPLE_PYTHON,
+                "def",
+                HighlightKind::Keyword,
+            ),
+            (
+                "python",
+                highlight_python,
+                SAMPLE_PYTHON,
+                "add",
+                HighlightKind::FunctionDefinition,
+            ),
+            (
+                "python",
+                highlight_python,
+                SAMPLE_PYTHON,
+                "\"x\"",
+                HighlightKind::String,
+            ),
+            (
+                "python",
+                highlight_python,
+                SAMPLE_PYTHON,
+                "int",
+                HighlightKind::Type,
+            ),
+            (
+                "python",
+                highlight_python,
+                "# a real comment\nx = 1\n",
+                "# a real comment",
+                HighlightKind::Comment,
+            ),
+            // A method name and a class name are two different `name` fields of two different
+            // node kinds, told apart inside one real parse.
+            (
+                "python",
+                highlight_python,
+                "class Foo:\n    def bar(self):\n        pass\n",
+                "bar",
+                HighlightKind::FunctionDefinition,
+            ),
+            (
+                "toml",
+                highlight_toml,
+                SAMPLE_TOML,
+                "name",
+                HighlightKind::Property,
+            ),
+            (
+                "toml",
+                highlight_toml,
+                SAMPLE_TOML,
+                "\"jerry\"",
+                HighlightKind::String,
+            ),
+            (
+                "toml",
+                highlight_toml,
+                SAMPLE_TOML,
+                "true",
+                HighlightKind::ConstantBuiltin,
+            ),
+            (
+                "toml",
+                highlight_toml,
+                SAMPLE_TOML,
+                "1979-05-27",
+                HighlightKind::StringSpecial,
+            ),
+            (
+                "go",
+                highlight_go,
+                SAMPLE_GO,
+                "func",
+                HighlightKind::Keyword,
+            ),
+            (
+                "go",
+                highlight_go,
+                SAMPLE_GO,
+                "add",
+                HighlightKind::FunctionDefinition,
+            ),
+            (
+                "go",
+                highlight_go,
+                SAMPLE_GO,
+                "len(",
+                HighlightKind::FunctionBuiltin,
+            ),
+            // A JSON key must win the more specific `string.special.key` registration over the
+            // plain `string` one; a JSON *value* must not.
+            (
+                "json",
+                highlight_json,
+                SAMPLE_JSON,
+                "\"name\"",
+                HighlightKind::Property,
+            ),
+            (
+                "json",
+                highlight_json,
+                SAMPLE_JSON,
+                "\"jerry\"",
+                HighlightKind::String,
+            ),
+            (
+                "json",
+                highlight_json,
+                SAMPLE_JSON,
+                "3",
+                HighlightKind::Number,
+            ),
+            (
+                "yaml",
+                highlight_yaml,
+                SAMPLE_YAML,
+                "count",
+                HighlightKind::Property,
+            ),
+            (
+                "yaml",
+                highlight_yaml,
+                SAMPLE_YAML,
+                "true",
+                HighlightKind::ConstantBuiltin,
+            ),
+            // `(anchor_name) @label` is the YAML half of the cross-language `"label"`
+            // registration; the C `goto` target below is its other half.
+            (
+                "yaml",
+                highlight_yaml,
+                SAMPLE_YAML,
+                "base\n",
+                HighlightKind::Label,
+            ),
+            (
+                "yaml",
+                highlight_yaml,
+                SAMPLE_YAML,
+                "&base",
+                HighlightKind::PunctuationSpecial,
+            ),
+            (
+                "yaml",
+                highlight_yaml,
+                SAMPLE_YAML,
+                "*base",
+                HighlightKind::PunctuationSpecial,
+            ),
+            ("c", highlight_c, SAMPLE_C, "return", HighlightKind::Keyword),
+            (
+                "c",
+                highlight_c,
+                SAMPLE_C,
+                "add",
+                HighlightKind::FunctionDefinition,
+            ),
+            ("c", highlight_c, SAMPLE_C, "done:", HighlightKind::Label),
+            (
+                "c",
+                highlight_c,
+                SAMPLE_C,
+                ";",
+                HighlightKind::PunctuationDelimiter,
+            ),
+            (
+                "markdown",
+                highlight_markdown,
+                SAMPLE_MARKDOWN,
+                "Title",
+                HighlightKind::Heading,
+            ),
+            (
+                "markdown",
+                highlight_markdown,
+                SAMPLE_MARKDOWN,
+                "bold",
+                HighlightKind::Strong,
+            ),
+            (
+                "markdown",
+                highlight_markdown,
+                SAMPLE_MARKDOWN,
+                "italic",
+                HighlightKind::Emphasis,
+            ),
+            (
+                "markdown",
+                highlight_markdown,
+                SAMPLE_MARKDOWN,
+                "inline code",
+                HighlightKind::String,
+            ),
+            (
+                "markdown",
+                highlight_markdown,
+                SAMPLE_MARKDOWN,
+                "https://example.com",
+                HighlightKind::Link,
+            ),
+            (
+                "markdown",
+                highlight_markdown,
+                SAMPLE_MARKDOWN,
+                "link",
+                HighlightKind::Link,
+            ),
+            // `string.special` must not match JSON's more specific `string.special.key`: the
+            // recognized-name rule needs every dot-part of the name present in the capture.
+            (
+                "css",
+                highlight_css,
+                SAMPLE_CSS,
+                "ff0000",
+                HighlightKind::StringSpecial,
+            ),
+        ];
+        for (label, highlighter, source, token, expected) in cases {
+            assert_eq!(
+                kind_at(&highlighter(source), source, token),
+                *expected,
+                "{label}: {token:?}"
+            );
+        }
     }
 
+    /// Tree-sitter produces a best-effort tree for malformed input rather than failing outright:
+    /// every grammar must still classify the keyword it *can* see, and none may panic.
     #[test]
-    fn typescript_string_literal_is_classified_as_string() {
-        let spans = highlight_typescript(SAMPLE_TYPESCRIPT, false);
-        let span = find_span(&spans, SAMPLE_TYPESCRIPT, "\"x\"").expect("string literal span");
-        assert_eq!(span.kind, HighlightKind::String);
+    fn highlighting_invalid_input_still_returns_a_real_non_empty_span_list() {
+        let cases: &[(&str, crate::language::HighlighterFn, &str)] = &[
+            ("rust", highlight_rust, "fn (((( broken"),
+            ("typescript", highlight_ts, "function (((( broken"),
+            ("python", highlight_python, "def (((( broken"),
+        ];
+        for (label, highlighter, source) in cases {
+            let spans = highlighter(source);
+            assert!(
+                spans.iter().any(|span| span.kind == HighlightKind::Keyword),
+                "{label}: malformed input must still classify its real leading keyword"
+            );
+        }
     }
 
-    #[test]
-    fn typescript_regex_literal_is_classified_as_string_special() {
-        let source = "const pattern = /^[a-z]+$/;\n";
-        let spans = highlight_typescript(source, false);
-        assert_eq!(
-            kind_at(&spans, source, "^[a-z]+$"),
-            HighlightKind::StringSpecial
-        );
-    }
+    // GitHub issue #200's own doc-tag coverage. `every_documented_token_lands_in_its_documented_
+    // bucket`'s TypeScript doc-comment row above deliberately calls `highlight_ts` directly - the
+    // raw grammar layer, bypassing `HighlightOptions::apply` entirely (same reason
+    // `colorize_bracket_pairs`'s own tests do this) - so it stays correct unchanged:
+    // `split_doc_comment_tags` only ever runs inside `apply()`, which every real, live rendering
+    // path (`load_file_with_options`, `highlight_block`) goes through but that pinned raw-grammar
+    // row doesn't.
 
     #[test]
-    fn typescript_function_declaration_name_is_classified_as_function() {
-        let spans = highlight_typescript(SAMPLE_TYPESCRIPT, false);
-        let span = find_span(&spans, SAMPLE_TYPESCRIPT, "add").expect("function name span");
-        assert_eq!(span.kind, HighlightKind::FunctionDefinition);
-    }
-
-    #[test]
-    fn typescript_predefined_type_is_classified_as_type_builtin() {
-        let spans = highlight_typescript(SAMPLE_TYPESCRIPT, false);
-        let type_spans: Vec<_> = spans
-            .iter()
-            .filter(|span| SAMPLE_TYPESCRIPT[span.start..span.end] == *"number")
-            .collect();
-        assert!(!type_spans.is_empty());
-        assert!(type_spans
-            .iter()
-            .all(|span| span.kind == HighlightKind::TypeBuiltin));
-    }
-
-    #[test]
-    fn typescript_doc_comment_is_classified_as_comment() {
-        let spans = highlight_typescript(SAMPLE_TYPESCRIPT, false);
-        let span =
-            find_span(&spans, SAMPLE_TYPESCRIPT, "/** Adds one. */").expect("doc comment span");
-        assert_eq!(span.kind, HighlightKind::Comment);
-    }
-
-    // GitHub issue #200's own doc-tag coverage. `typescript_doc_comment_is_classified_as_comment`
-    // just above deliberately calls `highlight_typescript` directly - the raw grammar layer,
-    // bypassing `HighlightOptions::apply` entirely (same reason `colorize_bracket_pairs`'s own
-    // tests do this) - so it stays correct unchanged: `split_doc_comment_tags` only ever runs
-    // inside `apply()`, which every real, live rendering path (`load_file_with_options`,
-    // `highlight_block`) goes through but this one pinned raw-grammar test doesn't.
-
-    #[test]
-    fn doc_tag_ranges_finds_a_real_block_tag_preceded_by_whitespace() {
-        let text = "Adds one.\n@param left the number to add to\n@returns the sum";
-        let ranges: Vec<&str> = doc_tag_ranges(text)
-            .into_iter()
-            .map(|range| &text[range])
-            .collect();
-        assert_eq!(ranges, vec!["@param", "@returns"]);
-    }
-
-    #[test]
-    fn doc_tag_ranges_never_matches_an_email_style_at_sign() {
-        let text = "Contact foo@example.com for details.";
-        assert!(
-            doc_tag_ranges(text).is_empty(),
-            "an `@` directly preceded by an identifier byte (the `o` in `foo`) is not a real \
-             doc tag - got: {:?}",
-            doc_tag_ranges(text)
-        );
-    }
-
-    #[test]
-    fn doc_tag_ranges_finds_a_real_inline_link_tag_brace_to_brace() {
-        let text = "See {@link Foo#bar} for more.";
-        let ranges: Vec<&str> = doc_tag_ranges(text)
-            .into_iter()
-            .map(|range| &text[range])
-            .collect();
-        assert_eq!(ranges, vec!["{@link Foo#bar}"]);
-    }
-
-    #[test]
-    fn doc_tag_ranges_falls_back_to_a_bare_block_tag_for_an_unclosed_inline_tag() {
-        let text = "See {@link Foo#bar for more.";
-        let ranges: Vec<&str> = doc_tag_ranges(text)
-            .into_iter()
-            .map(|range| &text[range])
-            .collect();
-        assert_eq!(ranges, vec!["@link"]);
+    fn doc_tag_ranges_recognizes_every_real_tag_shape_and_nothing_else() {
+        let cases: &[(&str, &str, &[&str])] = &[
+            (
+                "block tags",
+                "Adds one.\n@param left the number to add to\n@returns the sum",
+                &["@param", "@returns"],
+            ),
+            // An `@` directly preceded by an identifier byte (the `o` in `foo`) is an email
+            // address, not a tag.
+            ("email address", "Contact foo@example.com for details.", &[]),
+            (
+                "inline link tag",
+                "See {@link Foo#bar} for more.",
+                &["{@link Foo#bar}"],
+            ),
+            (
+                "unclosed inline tag",
+                "See {@link Foo#bar for more.",
+                &["@link"],
+            ),
+        ];
+        for (label, text, expected) in cases {
+            let ranges: Vec<&str> = doc_tag_ranges(text)
+                .into_iter()
+                .map(|range| &text[range])
+                .collect();
+            assert_eq!(ranges, *expected, "{label}");
+        }
     }
 
     #[test]
@@ -2427,191 +2632,12 @@ mod tests {
         );
     }
 
-    #[test]
-    fn typescript_const_variable_name_is_not_misclassified_as_a_function() {
-        // The audit's exact reproduction. `find_span`'s plain substring search would otherwise
-        // match the embedded "s" inside "const" itself, so the real declared variable's own byte
-        // offset (right after "const ") is computed explicitly instead.
-        let source = "const s: string = \"hi\";\n";
-        let variable_start = source.find("const ").expect("const") + "const ".len();
-        let spans = highlight_typescript(source, false);
-        let kind = spans
-            .iter()
-            .find(|span| span.start <= variable_start && variable_start < span.end)
-            .map_or(HighlightKind::Text, |span| span.kind);
-        assert_eq!(
-            kind,
-            HighlightKind::Variable,
-            "a const/let/var binding's own name must never be classified as a function"
-        );
-    }
-
-    #[test]
-    fn typescript_interface_member_name_is_not_misclassified_as_a_function() {
-        let source = "interface Point { x: number }\n";
-        let spans = highlight_typescript(source, false);
-        assert_eq!(
-            kind_at(&spans, source, "x: number"),
-            HighlightKind::Property
-        );
-    }
-
-    #[test]
-    fn typescript_class_method_name_is_classified_as_a_function_method() {
-        let source = "class Point {\n    length() {\n        return 0;\n    }\n}\n";
-        let spans = highlight_typescript(source, false);
-        let span = find_span(&spans, source, "length").expect("method name span");
-        // `(method_definition name: (property_identifier) @function.method)` - its own
-        // dedicated bucket since GitHub issue #31 (previously folded into plain `Function`).
-        assert_eq!(span.kind, HighlightKind::FunctionDefinition);
-    }
-
-    #[test]
-    fn typescript_call_expression_callee_is_classified_as_a_function() {
-        let source = "function top() {}\ntop();\n";
-        let spans = highlight_typescript(source, false);
-        let function_spans: Vec<_> = spans
-            .iter()
-            .filter(|span| source[span.start..span.end] == *"top")
-            .collect();
-        assert_eq!(function_spans.len(), 2, "the declaration and the call site");
-        assert_eq!(
-            function_spans[0].kind,
-            HighlightKind::FunctionDefinition,
-            "the `function top()` declaration is a real definition site"
-        );
-        assert_eq!(
-            function_spans[1].kind,
-            HighlightKind::Function,
-            "the `top()` call site stays a plain function - this split is the whole point of \
-             JAVASCRIPT_DEFINITION_SUPPLEMENT"
-        );
-    }
-
-    #[test]
-    fn tsx_tag_name_is_not_misclassified_as_a_function() {
-        let source = "const el = <div />;\n";
-        let spans = highlight_typescript(source, true);
-        let span = find_span(&spans, source, "div").expect("tag name span");
-        assert_ne!(span.kind, HighlightKind::Function);
-        assert_eq!(span.kind, HighlightKind::Tag);
-    }
-
-    #[test]
-    fn highlighting_invalid_typescript_still_returns_a_real_non_empty_span_list() {
-        let spans = highlight_typescript("function (((( broken", false);
-        assert!(spans.iter().any(|span| span.kind == HighlightKind::Keyword));
-    }
-
     // Real Python highlighting coverage - mirrors `highlight_rust`'s own test shape above.
     // Before this fix, none of `highlight_python`'s real, common-case behavior had any test
     // coverage at all.
 
     const SAMPLE_PYTHON: &str =
         "def add(left: int) -> int:\n    name = \"x\"\n    return left + 1\n";
-
-    #[test]
-    fn python_def_keyword_is_classified_as_keyword() {
-        let spans = highlight_python(SAMPLE_PYTHON);
-        let span = find_span(&spans, SAMPLE_PYTHON, "def").expect("def span");
-        assert_eq!(span.kind, HighlightKind::Keyword);
-    }
-
-    #[test]
-    fn python_string_literal_is_classified_as_string() {
-        let spans = highlight_python(SAMPLE_PYTHON);
-        let span = find_span(&spans, SAMPLE_PYTHON, "\"x\"").expect("string literal span");
-        assert_eq!(span.kind, HighlightKind::String);
-    }
-
-    #[test]
-    fn python_function_definition_name_is_classified_as_function() {
-        let spans = highlight_python(SAMPLE_PYTHON);
-        let span = find_span(&spans, SAMPLE_PYTHON, "add").expect("function name span");
-        assert_eq!(span.kind, HighlightKind::FunctionDefinition);
-    }
-
-    #[test]
-    fn python_type_annotation_is_classified_as_type() {
-        let spans = highlight_python(SAMPLE_PYTHON);
-        let type_spans: Vec<_> = spans
-            .iter()
-            .filter(|span| SAMPLE_PYTHON[span.start..span.end] == *"int")
-            .collect();
-        assert!(!type_spans.is_empty());
-        assert!(type_spans
-            .iter()
-            .all(|span| span.kind == HighlightKind::Type));
-    }
-
-    #[test]
-    fn python_comment_is_classified_as_comment() {
-        let source = "# a real comment\nx = 1\n";
-        let spans = highlight_python(source);
-        let span = find_span(&spans, source, "# a real comment").expect("comment span");
-        assert_eq!(span.kind, HighlightKind::Comment);
-    }
-
-    #[test]
-    fn python_self_is_classified_as_variable_builtin_not_a_plain_identifier() {
-        let source = "class Foo:\n    def bar(self):\n        return self.value\n";
-        let spans = highlight_python(source);
-        let self_spans: Vec<_> = spans
-            .iter()
-            .filter(|span| source[span.start..span.end] == *"self")
-            .collect();
-        assert!(!self_spans.is_empty());
-        assert!(self_spans
-            .iter()
-            .all(|span| span.kind == HighlightKind::VariableBuiltin));
-    }
-
-    #[test]
-    fn python_class_name_is_classified_as_type_not_function() {
-        let source = "class Foo:\n    pass\n";
-        let spans = highlight_python(source);
-        let span = find_span(&spans, source, "Foo").expect("class name span");
-        assert_eq!(
-            span.kind,
-            HighlightKind::Type,
-            "a class's own declared name should be a Type, not a Function"
-        );
-    }
-
-    #[test]
-    fn python_method_name_inside_a_class_is_still_classified_as_function() {
-        let source = "class Foo:\n    def bar(self):\n        pass\n";
-        let spans = highlight_python(source);
-        let span = find_span(&spans, source, "bar").expect("method name span");
-        assert_eq!(span.kind, HighlightKind::FunctionDefinition);
-    }
-
-    #[test]
-    fn python_call_callee_is_classified_as_a_function() {
-        let source = "def top():\n    pass\n\ntop()\n";
-        let spans = highlight_python(source);
-        let function_spans: Vec<_> = spans
-            .iter()
-            .filter(|span| source[span.start..span.end] == *"top")
-            .collect();
-        assert_eq!(function_spans.len(), 2, "the definition and the call site");
-        assert_eq!(
-            function_spans[0].kind,
-            HighlightKind::FunctionDefinition,
-            "the `def top()` name is a real definition site"
-        );
-        assert_eq!(
-            function_spans[1].kind,
-            HighlightKind::Function,
-            "the `top()` call site stays a plain function"
-        );
-    }
-
-    #[test]
-    fn highlighting_invalid_python_still_returns_a_real_non_empty_span_list() {
-        let spans = highlight_python("def (((( broken");
-        assert!(spans.iter().any(|span| span.kind == HighlightKind::Keyword));
-    }
 
     // ---------------------------------------------------------------------------------------
     // `tree-sitter-highlight` migration coverage.
@@ -3078,168 +3104,15 @@ mod tests {
 
     const SAMPLE_TOML: &str = "name = \"jerry\"\ncount = 3\nenabled = true\nbuilt = 1979-05-27\n";
 
-    #[test]
-    fn toml_key_is_classified_as_property() {
-        let spans = highlight_toml(SAMPLE_TOML);
-        assert_eq!(
-            kind_at(&spans, SAMPLE_TOML, "name"),
-            HighlightKind::Property
-        );
-    }
-
-    #[test]
-    fn toml_string_value_is_classified_as_string() {
-        let spans = highlight_toml(SAMPLE_TOML);
-        assert_eq!(
-            kind_at(&spans, SAMPLE_TOML, "\"jerry\""),
-            HighlightKind::String
-        );
-    }
-
-    #[test]
-    fn toml_boolean_is_classified_as_constant_builtin() {
-        let spans = highlight_toml(SAMPLE_TOML);
-        assert_eq!(
-            kind_at(&spans, SAMPLE_TOML, "true"),
-            HighlightKind::ConstantBuiltin
-        );
-    }
-
-    #[test]
-    fn toml_date_literal_is_classified_as_string_special() {
-        let spans = highlight_toml(SAMPLE_TOML);
-        assert_eq!(
-            kind_at(&spans, SAMPLE_TOML, "1979-05-27"),
-            HighlightKind::StringSpecial
-        );
-    }
-
     const SAMPLE_GO: &str =
         "package main\n\nfunc add(x int) int {\n\treturn len(fmt.Sprint(x))\n}\n";
 
-    #[test]
-    fn go_func_keyword_is_classified_as_keyword() {
-        let spans = highlight_go(SAMPLE_GO);
-        assert_eq!(kind_at(&spans, SAMPLE_GO, "func"), HighlightKind::Keyword);
-    }
-
-    #[test]
-    fn go_function_definition_name_is_classified_as_function() {
-        let spans = highlight_go(SAMPLE_GO);
-        assert_eq!(
-            kind_at(&spans, SAMPLE_GO, "add"),
-            HighlightKind::FunctionDefinition
-        );
-    }
-
-    #[test]
-    fn go_builtin_function_call_is_classified_as_function_builtin() {
-        let spans = highlight_go(SAMPLE_GO);
-        assert_eq!(
-            kind_at(&spans, SAMPLE_GO, "len("),
-            HighlightKind::FunctionBuiltin
-        );
-    }
-
     const SAMPLE_JSON: &str = "{\n  \"name\": \"jerry\",\n  \"count\": 3\n}\n";
-
-    #[test]
-    fn json_object_key_is_classified_as_property_not_string() {
-        let spans = highlight_json(SAMPLE_JSON);
-        assert_eq!(
-            kind_at(&spans, SAMPLE_JSON, "\"name\""),
-            HighlightKind::Property,
-            "a real JSON key must win the more-specific string.special.key registration over \
-             the plain string entry"
-        );
-    }
-
-    #[test]
-    fn json_string_value_is_classified_as_string_not_property() {
-        let spans = highlight_json(SAMPLE_JSON);
-        assert_eq!(
-            kind_at(&spans, SAMPLE_JSON, "\"jerry\""),
-            HighlightKind::String
-        );
-    }
-
-    #[test]
-    fn json_number_value_is_classified_as_number() {
-        let spans = highlight_json(SAMPLE_JSON);
-        assert_eq!(kind_at(&spans, SAMPLE_JSON, "3"), HighlightKind::Number);
-    }
 
     const SAMPLE_YAML: &str = "anchor: &base\n  enabled: true\nalias: *base\ncount: 3\n";
 
-    #[test]
-    fn yaml_key_is_classified_as_property() {
-        let spans = highlight_yaml(SAMPLE_YAML);
-        assert_eq!(
-            kind_at(&spans, SAMPLE_YAML, "count"),
-            HighlightKind::Property
-        );
-    }
-
-    #[test]
-    fn yaml_boolean_is_classified_as_constant_builtin() {
-        let spans = highlight_yaml(SAMPLE_YAML);
-        assert_eq!(
-            kind_at(&spans, SAMPLE_YAML, "true"),
-            HighlightKind::ConstantBuiltin
-        );
-    }
-
-    #[test]
-    fn yaml_anchor_name_is_classified_as_label() {
-        let spans = highlight_yaml(SAMPLE_YAML);
-        assert_eq!(kind_at(&spans, SAMPLE_YAML, "base\n"), HighlightKind::Label);
-    }
-
-    #[test]
-    fn yaml_anchor_and_alias_sigils_are_classified_as_punctuation_special() {
-        let spans = highlight_yaml(SAMPLE_YAML);
-        assert_eq!(
-            kind_at(&spans, SAMPLE_YAML, "&base"),
-            HighlightKind::PunctuationSpecial
-        );
-        assert_eq!(
-            kind_at(&spans, SAMPLE_YAML, "*base"),
-            HighlightKind::PunctuationSpecial
-        );
-    }
-
     const SAMPLE_C: &str =
         "int add(int x) {\n  int total = 0;\n  goto done;\n done:\n  return total;\n}\n";
-
-    #[test]
-    fn c_keyword_is_classified_as_keyword() {
-        let spans = highlight_c(SAMPLE_C);
-        assert_eq!(kind_at(&spans, SAMPLE_C, "return"), HighlightKind::Keyword);
-    }
-
-    #[test]
-    fn c_function_definition_name_is_classified_as_function() {
-        let spans = highlight_c(SAMPLE_C);
-        assert_eq!(
-            kind_at(&spans, SAMPLE_C, "add"),
-            HighlightKind::FunctionDefinition
-        );
-    }
-
-    #[test]
-    fn c_goto_label_is_classified_as_label() {
-        let spans = highlight_c(SAMPLE_C);
-        assert_eq!(kind_at(&spans, SAMPLE_C, "done:"), HighlightKind::Label);
-    }
-
-    #[test]
-    fn c_semicolon_is_classified_as_punctuation_delimiter() {
-        let spans = highlight_c(SAMPLE_C);
-        assert_eq!(
-            kind_at(&spans, SAMPLE_C, ";"),
-            HighlightKind::PunctuationDelimiter
-        );
-    }
 
     const SAMPLE_MARKDOWN: &str = "# Title\n\nSome **bold** and *italic* text with `inline code` and a [link](https://example.com).\n\n```rust\nfn main() {}\n```\n";
 
@@ -3253,57 +3126,12 @@ mod tests {
         );
     }
 
-    #[test]
-    fn markdown_heading_text_is_classified_as_heading() {
-        let spans = highlight_markdown(SAMPLE_MARKDOWN);
-        assert_eq!(
-            kind_at(&spans, SAMPLE_MARKDOWN, "Title"),
-            HighlightKind::Heading
-        );
-    }
-
-    #[test]
-    fn markdown_bold_text_is_classified_as_strong() {
-        let spans = highlight_markdown(SAMPLE_MARKDOWN);
-        assert_eq!(
-            kind_at(&spans, SAMPLE_MARKDOWN, "bold"),
-            HighlightKind::Strong
-        );
-    }
-
-    #[test]
-    fn markdown_italic_text_is_classified_as_emphasis() {
-        let spans = highlight_markdown(SAMPLE_MARKDOWN);
-        assert_eq!(
-            kind_at(&spans, SAMPLE_MARKDOWN, "italic"),
-            HighlightKind::Emphasis
-        );
-    }
-
-    #[test]
-    fn markdown_inline_code_is_classified_as_literal_string() {
-        let spans = highlight_markdown(SAMPLE_MARKDOWN);
-        assert_eq!(
-            kind_at(&spans, SAMPLE_MARKDOWN, "inline code"),
-            HighlightKind::String
-        );
-    }
-
-    #[test]
-    fn markdown_link_destination_and_label_are_classified_as_link() {
-        let spans = highlight_markdown(SAMPLE_MARKDOWN);
-        assert_eq!(
-            kind_at(&spans, SAMPLE_MARKDOWN, "https://example.com"),
-            HighlightKind::Link,
-            "the link destination"
-        );
-        assert_eq!(
-            kind_at(&spans, SAMPLE_MARKDOWN, "link"),
-            HighlightKind::Link,
-            "the link's own visible label text"
-        );
-    }
-
+    /// Fenced code content must never inherit the enclosing fence's own `@text.literal` `String`
+    /// colour. GitHub issue #104 achieved that by registering `"none"`; GitHub issue #154 achieves
+    /// it by cancelling `@text.literal` at source instead - see
+    /// [`MARKDOWN_BLOCK_HIGHLIGHTS_SUPPLEMENT`] for why the second way is the only one compatible
+    /// with a real injected layer. Either way this assertion is the same one, and it is the guard
+    /// that the swap did not quietly lose it.
     #[test]
     fn markdown_fenced_code_block_content_is_not_colored_like_a_string() {
         let spans = highlight_markdown(SAMPLE_MARKDOWN);
@@ -3423,61 +3251,36 @@ mod tests {
         );
     }
 
-    #[test]
-    fn css_color_literal_is_a_string_special_not_a_json_style_key() {
-        let spans = highlight_css(SAMPLE_CSS);
-        assert_eq!(
-            kind_at(&spans, SAMPLE_CSS, "ff0000"),
-            HighlightKind::StringSpecial
-        );
-    }
-
     const SAMPLE_MARKDOWN_FENCES: &str = "# Fences\n\n```html\n<div class=\"card\">hi</div>\n```\n\n```css\n.card { color: red; }\n```\n\n```rust\nfn main() {}\n```\n\n```zig\nconst x = 1;\n```\n\n```\nplain fence\n```\n";
 
+    /// GitHub issue #154's own headline ask - "including in the markdown files". A tagged
+    /// fence's *content* really is reparsed by that tag's own grammar, and each of these buckets
+    /// is one no markdown query has any rule capable of producing.
+    ///
+    /// Three languages in one table because that is the point: the same injection query resolves
+    /// all of them, with no per-language code anywhere in [`MARKDOWN_INJECTION_QUERY`] or
+    /// [`Grammar::for_injection_name`]. The ` ```rust ` rows also cover the fence's very first
+    /// token, which is exactly the one a parent highlight left open over the injected range
+    /// would silently steal.
     #[test]
-    fn a_markdown_html_fence_really_highlights_its_content_as_html() {
+    fn a_tagged_markdown_fence_really_highlights_its_content_with_that_languages_grammar() {
         let spans = highlight_markdown(SAMPLE_MARKDOWN_FENCES);
-        assert_eq!(
-            kind_at(&spans, SAMPLE_MARKDOWN_FENCES, "div class"),
-            HighlightKind::Tag
-        );
-        assert_eq!(
-            kind_at(&spans, SAMPLE_MARKDOWN_FENCES, "class="),
-            HighlightKind::Attribute
-        );
-        assert_eq!(
-            kind_at(&spans, SAMPLE_MARKDOWN_FENCES, "card\">"),
-            HighlightKind::String
-        );
-    }
-
-    #[test]
-    fn a_markdown_css_fence_really_highlights_its_content_as_css() {
-        let spans = highlight_markdown(SAMPLE_MARKDOWN_FENCES);
-        assert_eq!(
-            kind_at(&spans, SAMPLE_MARKDOWN_FENCES, "card { "),
-            HighlightKind::Property,
-            "the class selector inside the ```css fence"
-        );
-        assert_eq!(
-            kind_at(&spans, SAMPLE_MARKDOWN_FENCES, "color: red"),
-            HighlightKind::Property
-        );
-    }
-
-    #[test]
-    fn a_markdown_rust_fence_really_highlights_its_content_as_rust() {
-        let spans = highlight_markdown(SAMPLE_MARKDOWN_FENCES);
-        assert_eq!(
-            kind_at(&spans, SAMPLE_MARKDOWN_FENCES, "fn main"),
-            HighlightKind::Keyword,
-            "the `fn` keyword - the first token of the fence's content, which is exactly the one \
-             a parent highlight left open over the injected range would silently steal"
-        );
-        assert_eq!(
-            kind_at(&spans, SAMPLE_MARKDOWN_FENCES, "main()"),
-            HighlightKind::FunctionDefinition
-        );
+        let cases: &[(&str, &str, HighlightKind)] = &[
+            ("html tag name", "div class", HighlightKind::Tag),
+            ("html attribute", "class=", HighlightKind::Attribute),
+            ("html attribute value", "card\">", HighlightKind::String),
+            ("css class selector", "card { ", HighlightKind::Property),
+            ("css declaration", "color: red", HighlightKind::Property),
+            ("rust keyword", "fn main", HighlightKind::Keyword),
+            ("rust fn name", "main()", HighlightKind::FunctionDefinition),
+        ];
+        for (label, token, expected) in cases {
+            assert_eq!(
+                kind_at(&spans, SAMPLE_MARKDOWN_FENCES, token),
+                *expected,
+                "{label}"
+            );
+        }
     }
 
     #[test]

--- a/crates/app/src/code_surface/diff_view.rs
+++ b/crates/app/src/code_surface/diff_view.rs
@@ -3,12 +3,14 @@
 
 use super::zoom::zoom_scoped;
 use super::*;
-use crate::review_notes::{NoteAnchor, NoteMark};
 #[cfg(test)]
-use crate::root::focus::palette_focus_tests;
+use crate::code_surface::fixtures::temp_repo;
+use crate::review_notes::{NoteAnchor, NoteMark};
 use crate::root::plural;
 use crate::root::scrollbar;
 use crate::root::widgets::render_sidebar_message;
+#[cfg(test)]
+use crate::test_support::open_test_app;
 use std::rc::Rc;
 
 /// Every row of the Diff view's virtualized list, in the flat order it scrolls in - built once
@@ -901,29 +903,12 @@ pub(in crate::code_surface) struct DiffLineChrome<'a> {
 mod diff_render_tests {
     use super::*;
     use gpui::TestAppContext;
-
-    fn git(dir: &std::path::Path, args: &[&str]) {
-        let output = std::process::Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {:?} failed in {:?}:\nstdout: {}\nstderr: {}",
-            args,
-            dir,
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
+    use test_support::git;
 
     #[gpui::test]
     fn opening_a_real_diff_renders_real_syntax_highlighted_rows(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        git(repo.path(), &["init", "-b", "main"]);
-        git(repo.path(), &["config", "user.email", "test@example.com"]);
-        git(repo.path(), &["config", "user.name", "Test User"]);
+        let repo = temp_repo();
+        test_support::seed_empty_repo_at(repo.path());
         std::fs::write(
             repo.path().join("sample.rs"),
             "fn add(x: i32) -> i32 {\n    x + 1\n}\n",
@@ -938,7 +923,7 @@ mod diff_render_tests {
         )
         .expect("rewrite sample.rs");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         app.update_in(cx, |app, window, cx| {
@@ -993,10 +978,8 @@ mod diff_render_tests {
     fn repeated_refreshes_of_the_same_open_diff_reuse_the_cached_highlighting(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        git(repo.path(), &["init", "-b", "main"]);
-        git(repo.path(), &["config", "user.email", "test@example.com"]);
-        git(repo.path(), &["config", "user.name", "Test User"]);
+        let repo = temp_repo();
+        test_support::seed_empty_repo_at(repo.path());
         std::fs::write(
             repo.path().join("sample.rs"),
             "fn add() -> i32 {\n    1\n}\n",
@@ -1011,7 +994,7 @@ mod diff_render_tests {
         )
         .expect("rewrite sample.rs");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
         app.update_in(cx, |app, window, cx| {
             app.open_change_diff(PathBuf::from("sample.rs"), window, cx);
@@ -1048,10 +1031,8 @@ mod diff_render_tests {
     fn switching_the_open_diff_to_a_different_file_recomputes_the_highlight_cache(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        git(repo.path(), &["init", "-b", "main"]);
-        git(repo.path(), &["config", "user.email", "test@example.com"]);
-        git(repo.path(), &["config", "user.name", "Test User"]);
+        let repo = temp_repo();
+        test_support::seed_empty_repo_at(repo.path());
         std::fs::write(repo.path().join("a.rs"), "fn a() -> i32 {\n    1\n}\n")
             .expect("write a.rs");
         std::fs::write(repo.path().join("b.py"), "def b():\n    return 1\n").expect("write b.py");
@@ -1062,7 +1043,7 @@ mod diff_render_tests {
             .expect("rewrite a.rs");
         std::fs::write(repo.path().join("b.py"), "def b():\n    return 2\n").expect("rewrite b.py");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
         app.update_in(cx, |app, window, cx| {
             app.open_change_diff(PathBuf::from("a.rs"), window, cx);
@@ -1112,10 +1093,8 @@ mod diff_render_tests {
     fn a_diff_past_the_rendered_line_cap_still_highlights_every_line_it_actually_renders(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        git(repo.path(), &["init", "-b", "main"]);
-        git(repo.path(), &["config", "user.email", "test@example.com"]);
-        git(repo.path(), &["config", "user.name", "Test User"]);
+        let repo = temp_repo();
+        test_support::seed_empty_repo_at(repo.path());
         std::fs::write(repo.path().join("big.rs"), "fn noop() {}\n").expect("write big.rs");
         git(repo.path(), &["add", "."]);
         git(repo.path(), &["commit", "-m", "initial"]);
@@ -1126,7 +1105,7 @@ mod diff_render_tests {
         }
         std::fs::write(repo.path().join("big.rs"), &content).expect("rewrite big.rs");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
         app.update_in(cx, |app, window, cx| {
             app.open_change_diff(PathBuf::from("big.rs"), window, cx);
@@ -1516,32 +1495,12 @@ mod diff_row_plan_tests {
 mod diff_virtualization_tests {
     use super::*;
     use gpui::{Entity, TestAppContext};
-
-    fn git(dir: &std::path::Path, args: &[&str]) {
-        let output = std::process::Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {:?} failed in {:?}: {}",
-            args,
-            dir,
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
-    fn init_repo(dir: &std::path::Path) {
-        git(dir, &["init", "-b", "main"]);
-        git(dir, &["config", "user.email", "test@example.com"]);
-        git(dir, &["config", "user.name", "Test User"]);
-    }
+    use test_support::git;
 
     /// A real repository whose working tree differs from its committed base by `added` brand-new
     /// lines in one file - a single real git hunk, `added` lines long.
     fn seed_big_diff(dir: &std::path::Path, added: usize) {
-        init_repo(dir);
+        test_support::seed_empty_repo_at(dir);
         std::fs::write(dir.join("big.rs"), "fn noop() {}\n").expect("write big.rs");
         git(dir, &["add", "."]);
         git(dir, &["commit", "-m", "initial"]);
@@ -1557,7 +1516,7 @@ mod diff_virtualization_tests {
     /// of a 60-line file - two real git hunks with a real unchanged span between them, which is
     /// what makes `changes::fold_gap_between` produce a genuine `⋯ N unchanged lines` row.
     fn seed_two_hunk_diff(dir: &std::path::Path) {
-        init_repo(dir);
+        test_support::seed_empty_repo_at(dir);
         let original: String = (1..=60).map(|n| format!("fn f{n}() {{ {n} }}\n")).collect();
         std::fs::write(dir.join("two.rs"), &original).expect("write two.rs");
         git(dir, &["add", "."]);
@@ -1580,7 +1539,7 @@ mod diff_virtualization_tests {
         repo: &std::path::Path,
         path: &str,
     ) -> (Entity<AdeApp>, &'a mut gpui::VisualTestContext) {
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.to_path_buf());
         cx.run_until_parked();
         let path = PathBuf::from(path);
         app.update_in(cx, |app, window, cx| {
@@ -1604,7 +1563,7 @@ mod diff_virtualization_tests {
 
     #[gpui::test]
     fn a_diff_line_far_below_the_viewport_is_never_painted(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         seed_big_diff(repo.path(), 350);
         let (_app, cx) = open_diff_on(cx, repo.path(), "big.rs");
 
@@ -1625,7 +1584,7 @@ mod diff_virtualization_tests {
     fn scrolling_the_virtualized_diff_materializes_a_row_that_was_not_painted(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         seed_big_diff(repo.path(), 350);
         let (_app, cx) = open_diff_on(cx, repo.path(), "big.rs");
 
@@ -1654,7 +1613,7 @@ mod diff_virtualization_tests {
 
     #[gpui::test]
     fn hunk_headers_and_fold_markers_paint_at_the_shared_row_height(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         seed_two_hunk_diff(repo.path());
         let (app, cx) = open_diff_on(cx, repo.path(), "two.rs");
 
@@ -1719,7 +1678,7 @@ mod diff_virtualization_tests {
     fn the_truncation_notice_is_the_last_item_of_the_list_at_the_shared_row_height(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         seed_big_diff(repo.path(), 350);
         let (_app, cx) = open_diff_on(cx, repo.path(), "big.rs");
 
@@ -1754,7 +1713,7 @@ mod diff_virtualization_tests {
 
     #[gpui::test]
     fn the_overlay_scrollbar_still_tracks_the_virtualized_list(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         seed_big_diff(repo.path(), 350);
         let (app, cx) = open_diff_on(cx, repo.path(), "big.rs");
         // The scrollbar is built from the geometry the *previous* frame's layout wrote onto the
@@ -1769,8 +1728,9 @@ mod diff_virtualization_tests {
              this fails the handle's geometry is no longer reaching it"
         );
 
-        let small = tempfile::tempdir().expect("tempdir");
-        init_repo(small.path());
+        // A diff that genuinely fits must still get no scrollbar at all.
+        let small = temp_repo();
+        test_support::seed_empty_repo_at(small.path());
         std::fs::write(small.path().join("small.rs"), "fn a() -> i32 {\n    1\n}\n")
             .expect("write small.rs");
         git(small.path(), &["add", "."]);
@@ -1796,7 +1756,7 @@ mod diff_virtualization_tests {
     fn every_virtualized_row_resolves_its_own_line_through_the_identity_guard(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         seed_two_hunk_diff(repo.path());
         let (app, cx) = open_diff_on(cx, repo.path(), "two.rs");
 

--- a/crates/app/src/code_surface/edit_buffer.rs
+++ b/crates/app/src/code_surface/edit_buffer.rs
@@ -2621,22 +2621,18 @@ impl QueryBuilder {
         assert_eq!(buf.content, "    a;\n    \nb;\n\n");
     }
 
+    /// The three positions worth pinning: an empty buffer's only offset, the very last byte, and
+    /// a line boundary (which resolves to the *start of the next* line, not the end of the
+    /// previous one).
     #[test]
-    fn line_col_for_offset_at_the_very_start_of_an_empty_file_is_zero_zero() {
-        let buf = buffer("");
-        assert_eq!(buf.line_col_for_offset(0), (0, 0));
-    }
+    fn line_col_for_offset_resolves_the_documented_edge_positions() {
+        assert_eq!(buffer("").line_col_for_offset(0), (0, 0));
 
-    #[test]
-    fn line_col_for_offset_at_the_very_end_of_the_file() {
         let buf = buffer("abc\ndef");
-        assert_eq!(buf.line_col_for_offset(7), (1, 3));
-    }
-
-    #[test]
-    fn line_col_for_offset_exactly_on_a_line_boundary_is_the_start_of_the_next_line() {
-        let buf = buffer("abc\ndef");
-        assert_eq!(buf.line_col_for_offset(4), (1, 0));
+        // Byte 4 is 'd', the first byte of line 1.
+        for (offset, expected) in [(4usize, (1usize, 0usize)), (7, (1, 3))] {
+            assert_eq!(buf.line_col_for_offset(offset), expected, "offset {offset}");
+        }
     }
 
     #[test]

--- a/crates/app/src/code_surface/editing.rs
+++ b/crates/app/src/code_surface/editing.rs
@@ -17,6 +17,8 @@ use crate::code_surface::blame;
 use crate::code_surface::blame_view::render_inline_blame_span;
 use crate::code_surface::code_view;
 use crate::code_surface::edit_buffer::EditBuffer;
+#[cfg(test)]
+use crate::code_surface::fixtures::temp_repo;
 use crate::code_surface::indent;
 use crate::code_surface::lsp_ui::{
     diagnostic_row_bg, diagnostic_underline_color, render_inline_diagnostic_message,
@@ -33,6 +35,8 @@ use crate::root::{
     EditorSkipOccurrence, EditorUp, EditorWordLeft, EditorWordRight, TextRedo, TextUndo,
 };
 use crate::settings::store as settings_store;
+#[cfg(test)]
+use crate::test_support::open_test_app;
 use crate::theme;
 
 /// How long after the last keystroke [`AdeApp::schedule_rehighlight`] waits before running a real
@@ -2366,7 +2370,6 @@ mod caret_paint_quad_tests {
 mod editing_tests {
     use super::*;
     use crate::code_surface::{DiffBase, DiffLoadState};
-    use crate::root::focus::palette_focus_tests;
     use gpui::TestAppContext;
 
     fn write_file(repo: &std::path::Path, name: &str, content: &str) -> PathBuf {
@@ -2405,9 +2408,9 @@ mod editing_tests {
     fn typing_changes_real_content_and_updates_syntax_highlighting_after_the_debounce(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.rs", "foo(x: i32) {}\n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         let relative = PathBuf::from("sample.rs");
 
@@ -2510,9 +2513,9 @@ mod editing_tests {
 
     #[gpui::test]
     fn arrow_keys_move_the_real_caret_and_cross_a_real_line_boundary(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.txt", "ab\ncd\n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         bind_real_keys(cx);
         let relative = PathBuf::from("sample.txt");
@@ -2551,9 +2554,9 @@ mod editing_tests {
 
     #[gpui::test]
     fn shift_arrow_extends_a_real_selection_through_the_real_key_bindings(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.txt", "hello\n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         bind_real_keys(cx);
         let relative = PathBuf::from("sample.txt");
@@ -2574,9 +2577,9 @@ mod editing_tests {
     fn ctrl_shift_arrow_extends_a_real_selection_word_wise_through_the_real_key_bindings(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.txt", "hello world\n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         bind_real_keys(cx);
         let relative = PathBuf::from("sample.txt");
@@ -2619,9 +2622,9 @@ mod editing_tests {
     fn double_click_selects_the_real_word_and_triple_click_selects_the_real_line(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.txt", "hello world\nsecond line\n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         let relative = PathBuf::from("sample.txt");
 
@@ -2671,9 +2674,9 @@ mod editing_tests {
 
     #[gpui::test]
     fn an_indented_lines_indent_guide_paints_when_the_setting_is_on(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.rs", "fn main() {\n    let x = 1;\n}\n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         assert!(
             app.read_with(cx, |app, _| app.settings.appearance.show_indent_guides),
             "sanity check: the real default is guides on"
@@ -2689,9 +2692,9 @@ mod editing_tests {
 
     #[gpui::test]
     fn no_indent_guide_paints_when_the_setting_is_off(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.rs", "fn main() {\n    let x = 1;\n}\n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update(cx, |app, _cx| {
             app.settings.appearance.show_indent_guides = false;
         });
@@ -2708,10 +2711,10 @@ mod editing_tests {
     fn selection_survives_a_row_scrolling_out_of_the_virtualized_range_and_back(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let many_lines: String = (0..500).map(|n| format!("line {n}\n")).collect();
         let file_path = write_file(repo.path(), "sample.txt", &many_lines);
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         let relative = PathBuf::from("sample.txt");
 
@@ -2780,9 +2783,9 @@ mod editing_tests {
     fn ctrl_d_through_real_key_bindings_adds_a_cursor_and_typing_fans_out_to_both(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.txt", "value + value\n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         bind_real_keys(cx);
         let relative = PathBuf::from("sample.txt");
@@ -2826,9 +2829,9 @@ mod editing_tests {
 
     #[gpui::test]
     fn ctrl_shift_l_through_real_key_bindings_selects_every_occurrence(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.txt", "value + value + value\n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         bind_real_keys(cx);
         let relative = PathBuf::from("sample.txt");
@@ -2853,9 +2856,9 @@ mod editing_tests {
     fn ctrl_k_ctrl_d_through_real_key_bindings_skips_without_adding_a_cursor(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.txt", "value + value\n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         bind_real_keys(cx);
         let relative = PathBuf::from("sample.txt");
@@ -2878,9 +2881,9 @@ mod editing_tests {
 
     #[gpui::test]
     fn escape_through_real_key_bindings_collapses_multi_cursor_state(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.txt", "value + value\n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         bind_real_keys(cx);
         let relative = PathBuf::from("sample.txt");
@@ -2915,9 +2918,9 @@ mod editing_tests {
     fn backspace_and_delete_remove_real_text_through_the_real_key_bindings(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.txt", "abc\n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         bind_real_keys(cx);
         let relative = PathBuf::from("sample.txt");
@@ -2950,9 +2953,9 @@ mod editing_tests {
 
     #[gpui::test]
     fn editor_save_writes_real_content_to_disk_and_clears_the_dirty_flag(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.txt", "hello\n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         bind_real_keys(cx);
         let relative = PathBuf::from("sample.txt");
@@ -2986,9 +2989,9 @@ mod editing_tests {
     fn external_change_while_dirty_is_detected_and_blocks_save_without_overwriting_either_version(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.txt", "original\n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         let relative = PathBuf::from("sample.txt");
 
@@ -2999,7 +3002,11 @@ mod editing_tests {
 
         std::fs::write(&file_path, "changed on disk, a completely different size\n")
             .expect("external rewrite");
-        std::thread::sleep(crate::root::FILE_FRESHNESS_CHECK_INTERVAL + Duration::from_millis(50));
+        // Force the throttled freshness check to run now, instead of waiting out its real
+        // wall-clock interval.
+        app.update(cx, |app, _| {
+            app.file_view_last_freshness_check = None;
+        });
 
         app.update(cx, |app, cx| {
             app.render_center_pane(cx);
@@ -3035,9 +3042,9 @@ mod editing_tests {
     fn a_save_with_no_external_interference_is_not_falsely_flagged_as_a_conflict(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.txt", "hello\n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         let relative = PathBuf::from("sample.txt");
 
@@ -3057,35 +3064,28 @@ mod editing_tests {
         assert_eq!(on_disk, "well hello\n");
     }
 
-    /// `.output()`, not `.status()` - see `crate::sidebar::render::virtualization_tests::git`'s
-    /// own comment for why (a 40-line "create mode 100644" dump would otherwise land in every
-    /// test run's output here too).
-    fn git(dir: &std::path::Path, args: &[&str]) {
-        let output = std::process::Command::new("git")
-            .args(args)
-            .current_dir(dir)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {args:?} failed: {}",
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
+    /// GitHub issue #89 ("Changes not showing in editor and file tree"): saving a file never
+    /// called `AdeApp::load_diff`, so `AdeApp::diff_state` - the one thing both the file tree's
+    /// "M"/"A" marks (`crate::sidebar::render::tree_change_marks`) and the Changes/diff view
+    /// are computed from - stayed on whatever it was the last time something else happened to
+    /// reload it (a worktree switch, a tree op via `crate::sidebar::tree_ops::AdeApp::
+    /// refresh_after_file_op`), never the save itself. This drives a real `git`-backed repo one
+    /// branch off `main` (so there is a real base to diff against and this hits `DiffBase::Diff`
+    /// specifically, not the `DiffBase::NoBase` uncommitted-vs-HEAD fallback a same-branch setup
+    /// would also report changes through, per `wt_core::diff::diff_against_base`'s own docs),
+    /// saves a real edit through the app, and asserts the
+    /// reloaded `diff_state` reports the file as changed without any other trigger in between.
     #[gpui::test]
     fn saving_a_file_immediately_refreshes_diff_state_for_issue_89(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        git(repo.path(), &["init", "-b", "main"]);
-        git(repo.path(), &["config", "user.email", "test@example.com"]);
-        git(repo.path(), &["config", "user.name", "Test User"]);
+        let repo = temp_repo();
+        test_support::seed_empty_repo_at(repo.path());
         let file_path = write_file(repo.path(), "sample.txt", "one\ntwo\nthree\n");
-        git(repo.path(), &["add", "."]);
-        git(repo.path(), &["commit", "-m", "initial"]);
-        git(repo.path(), &["checkout", "-b", "feature"]);
+        test_support::git(repo.path(), &["add", "."]);
+        test_support::git(repo.path(), &["commit", "-m", "initial"]);
+        test_support::git(repo.path(), &["checkout", "-b", "feature"]);
         let relative = PathBuf::from("sample.txt");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         let changed_before_edit = app.read_with(cx, |app, _| match &app.diff_state {
@@ -3134,9 +3134,9 @@ mod editing_tests {
     fn the_conflict_flag_does_not_self_clear_once_file_view_cache_catches_up_while_still_dirty(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.txt", "original\n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         let relative = PathBuf::from("sample.txt");
 
@@ -3145,7 +3145,11 @@ mod editing_tests {
         });
 
         std::fs::write(&file_path, "changed on disk\n").expect("external rewrite");
-        std::thread::sleep(crate::root::FILE_FRESHNESS_CHECK_INTERVAL + Duration::from_millis(50));
+        // Force the throttled freshness check to run now, instead of waiting out its real
+        // wall-clock interval.
+        app.update(cx, |app, _| {
+            app.file_view_last_freshness_check = None;
+        });
 
         // First real freshness check: detects the conflict, and dispatches (then resolves) a
         // real background reload that catches `file_view_cache` up to the new disk content.
@@ -3161,7 +3165,11 @@ mod editing_tests {
         // A second full throttle interval, with the buffer still dirty and disk still not
         // matching the buffer's own load-time snapshot - `file_view_cache` is now fresh (it
         // caught up above), but the real conflict has not actually been resolved.
-        std::thread::sleep(crate::root::FILE_FRESHNESS_CHECK_INTERVAL + Duration::from_millis(50));
+        // Force the throttled freshness check to run now, instead of waiting out its real
+        // wall-clock interval.
+        app.update(cx, |app, _| {
+            app.file_view_last_freshness_check = None;
+        });
         app.update(cx, |app, cx| {
             app.render_center_pane(cx);
         });
@@ -3178,9 +3186,9 @@ mod editing_tests {
     fn replace_and_mark_text_in_range_records_a_real_composition_and_unmark_clears_it(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.txt", "ab\n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         let relative = PathBuf::from("sample.txt");
 
@@ -3220,33 +3228,15 @@ mod editing_tests {
 
     #[gpui::test]
     fn editor_actions_are_a_safe_no_op_while_the_diff_view_is_active(cx: &mut TestAppContext) {
-        fn git(dir: &std::path::Path, args: &[&str]) {
-            let output = std::process::Command::new("git")
-                .current_dir(dir)
-                .args(args)
-                .output()
-                .expect("failed to spawn git");
-            assert!(
-                output.status.success(),
-                "git {:?} failed in {:?}:\nstdout: {}\nstderr: {}",
-                args,
-                dir,
-                String::from_utf8_lossy(&output.stdout),
-                String::from_utf8_lossy(&output.stderr)
-            );
-        }
-
-        let repo = tempfile::tempdir().expect("tempdir");
-        git(repo.path(), &["init", "-b", "main"]);
-        git(repo.path(), &["config", "user.email", "test@example.com"]);
-        git(repo.path(), &["config", "user.name", "Test User"]);
+        let repo = temp_repo();
+        test_support::seed_empty_repo_at(repo.path());
         write_file(repo.path(), "sample.rs", "fn add() -> i32 {\n    1\n}\n");
-        git(repo.path(), &["add", "."]);
-        git(repo.path(), &["commit", "-m", "initial"]);
-        git(repo.path(), &["checkout", "-b", "feature"]);
+        test_support::git(repo.path(), &["add", "."]);
+        test_support::git(repo.path(), &["commit", "-m", "initial"]);
+        test_support::git(repo.path(), &["checkout", "-b", "feature"]);
         write_file(repo.path(), "sample.rs", "fn add() -> i32 {\n    2\n}\n");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
         app.update_in(cx, |app, window, cx| {
             app.open_change_diff(PathBuf::from("sample.rs"), window, cx);
@@ -3282,13 +3272,13 @@ mod editing_tests {
     fn clicking_a_real_editable_row_places_the_real_cursor_without_panicking(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(
             repo.path(),
             "sample.txt",
             "a short line\nworld, a longer real line of text\n",
         );
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         let relative = PathBuf::from("sample.txt");
 
@@ -3339,13 +3329,13 @@ mod editing_tests {
     fn clicking_past_the_end_of_a_short_line_places_the_cursor_at_the_end_of_that_line(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(
             repo.path(),
             "sample.txt",
             "a short line\nworld, a longer real line of text that runs on for a while\n",
         );
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         let relative = PathBuf::from("sample.txt");
 
@@ -3384,9 +3374,9 @@ mod editing_tests {
 
     #[gpui::test]
     fn clicking_on_a_real_blank_line_places_the_cursor_there(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.txt", "first\n\nthird\n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         let relative = PathBuf::from("sample.txt");
 
@@ -3419,9 +3409,9 @@ mod editing_tests {
     fn clicking_below_the_last_line_places_the_cursor_at_the_end_of_the_buffer(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.txt", "one\ntwo\nthree");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         let relative = PathBuf::from("sample.txt");
 
@@ -3463,12 +3453,12 @@ mod editing_tests {
 
     #[gpui::test]
     fn a_file_with_invalid_utf8_bytes_does_not_get_a_real_edit_buffer(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = repo.path().join("binary.txt");
         // A lone UTF-8 continuation byte (0x80) is never valid on its own - real, genuinely
         // invalid UTF-8, not a contrived edge case.
         std::fs::write(&file_path, [b'h', b'i', 0x80, b'\n']).expect("write invalid-utf8 file");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         let relative = PathBuf::from("binary.txt");
 
@@ -3488,9 +3478,9 @@ mod editing_tests {
 
     #[gpui::test]
     fn editor_save_anyway_resolves_a_real_permanently_stuck_conflict(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.txt", "original\n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         bind_real_keys(cx);
         let relative = PathBuf::from("sample.txt");
@@ -3500,7 +3490,11 @@ mod editing_tests {
         });
 
         std::fs::write(&file_path, "changed on disk\n").expect("external rewrite");
-        std::thread::sleep(crate::root::FILE_FRESHNESS_CHECK_INTERVAL + Duration::from_millis(50));
+        // Force the throttled freshness check to run now, instead of waiting out its real
+        // wall-clock interval.
+        app.update(cx, |app, _| {
+            app.file_view_last_freshness_check = None;
+        });
         app.update(cx, |app, cx| {
             app.render_center_pane(cx);
         });
@@ -3571,9 +3565,9 @@ mod editing_tests {
 
     #[gpui::test]
     fn force_save_active_file_is_a_real_no_op_on_an_already_clean_buffer(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.txt", "hello\n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         let relative = PathBuf::from("sample.txt");
 
@@ -3605,9 +3599,9 @@ mod editing_tests {
     fn a_pending_save_whose_buffer_vanished_before_the_writer_loop_checked_it_does_not_leak_file_save_running(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.txt", "hello\n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         let relative = PathBuf::from("sample.txt");
 
@@ -3665,9 +3659,9 @@ mod editing_tests {
     fn real_cjk_ime_composition_with_a_non_default_caret_does_not_corrupt_the_selection_or_panic_on_the_next_keystroke(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.txt", "prefix ok\n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         let relative = PathBuf::from("sample.txt");
 
@@ -3720,9 +3714,9 @@ mod editing_tests {
     fn a_literal_right_bracket_keystroke_reaches_the_real_edit_buffer_while_the_file_view_is_editing(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.rs", "abc\n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         bind_real_keys(cx);
         let relative = PathBuf::from("sample.rs");
@@ -3751,9 +3745,9 @@ mod editing_tests {
     fn completions_keybindings_are_correctly_scoped_in_both_the_open_and_closed_state(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.rs", "ab\ncd\n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         bind_real_keys(cx);
         let relative = PathBuf::from("sample.rs");
@@ -3958,9 +3952,9 @@ mod editing_tests {
 
     #[gpui::test]
     fn typing_past_the_trigger_point_narrows_the_real_completions_list(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.rs", "let x = \n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         bind_real_keys(cx);
         let relative = PathBuf::from("sample.rs");
@@ -4018,9 +4012,9 @@ mod editing_tests {
 
     #[gpui::test]
     fn a_real_non_contiguous_typed_prefix_still_matches_the_right_item(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.rs", "let x = \n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         bind_real_keys(cx);
         let relative = PathBuf::from("sample.rs");
@@ -4047,9 +4041,9 @@ mod editing_tests {
     fn keyboard_selection_stays_aligned_with_the_filtered_completions_view(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.rs", "let x = \n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         bind_real_keys(cx);
         let relative = PathBuf::from("sample.rs");
@@ -4106,70 +4100,23 @@ mod editing_tests {
         );
     }
 
-    #[gpui::test]
-    fn enter_carries_the_real_leading_whitespace_of_the_previous_line_over(
-        cx: &mut TestAppContext,
-    ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let file_path = write_file(repo.path(), "sample.rs", "fn main() {\n    let x = 1;\n}\n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
-        open_file_for_editing(&app, cx, file_path.clone());
-        bind_real_keys(cx);
-        let relative = PathBuf::from("sample.rs");
-
-        app.update(cx, |app, cx| {
-            app.edit_buffer_mut(&relative)
-                .unwrap()
-                .move_to("fn main() {\n    let x = 1;".len());
-            cx.notify();
-        });
-
-        cx.simulate_keystrokes("enter");
-
-        assert_eq!(
-            app.read_with(cx, |app, _| app
-                .edit_buffer(&relative)
-                .unwrap()
-                .content
-                .clone()),
-            "fn main() {\n    let x = 1;\n    \n}\n",
-            "the new line must start with the exact same real 4-space indentation the line \
-             above it had, read from the real buffer content"
-        );
-    }
-
-    #[gpui::test]
-    fn enter_adds_no_whitespace_after_a_column_zero_line(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let file_path = write_file(repo.path(), "sample.rs", "foo();\nbar();\n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
-        open_file_for_editing(&app, cx, file_path.clone());
-        bind_real_keys(cx);
-        let relative = PathBuf::from("sample.rs");
-
-        app.update(cx, |app, cx| {
-            app.edit_buffer_mut(&relative).unwrap().move_to(6); // end of "foo();"
-            cx.notify();
-        });
-
-        cx.simulate_keystrokes("enter");
-
-        assert_eq!(
-            app.read_with(cx, |app, _| app
-                .edit_buffer(&relative)
-                .unwrap()
-                .content
-                .clone()),
-            "foo();\n\nbar();\n",
-            "a column-0 line must not gain any real indentation it never had"
-        );
-    }
-
+    /// GitHub issue #121, test (c) - stretch goal: `Enter` right after a real opening bracket
+    /// adds one more real indent unit on top of the carried-over whitespace, using the exact same
+    /// real indent-unit resolution (tabs/spaces/width) `Self::handle_editor_indent_action`'s own
+    /// `Tab` uses - proven here by checking the inserted whitespace is real 4 literal spaces (the
+    /// default `EditorSettings::tab_width`/`insert_spaces`, not a hardcoded `"    "` this test
+    /// would pass even if the production code had a different, wrong hardcoded width).
+    ///
+    /// This is the *only* `Enter` test at this layer, deliberately: the individual auto-indent
+    /// rules (carry-over, column zero, Python's `:` header) are covered directly against
+    /// `EditBuffer::insert_newline_with_auto_indent`, and what a keystroke test adds over those
+    /// is the wiring - the bound `EditorEnter` reaching the handler with the real, settings-
+    /// derived indent unit, which the `tab_width = 2` half below is what actually proves.
     #[gpui::test]
     fn enter_adds_one_extra_real_indent_level_after_an_opening_bracket(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.rs", "fn main() {\n}\n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         bind_real_keys(cx);
         let relative = PathBuf::from("sample.rs");
@@ -4213,43 +4160,24 @@ mod editing_tests {
         );
     }
 
-    #[gpui::test]
-    fn enter_adds_one_extra_real_indent_level_after_a_python_colon_header(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let file_path = write_file(repo.path(), "sample.py", "if True:\n    pass\n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
-        open_file_for_editing(&app, cx, file_path.clone());
-        bind_real_keys(cx);
-        let relative = PathBuf::from("sample.py");
-
-        app.update(cx, |app, cx| {
-            app.edit_buffer_mut(&relative)
-                .unwrap()
-                .move_to("if True:".len());
-            cx.notify();
-        });
-
-        cx.simulate_keystrokes("enter");
-
-        assert_eq!(
-            app.read_with(cx, |app, _| app
-                .edit_buffer(&relative)
-                .unwrap()
-                .content
-                .clone()),
-            "if True:\n    \n    pass\n",
-            "a Python block header ending in ':' must add one real indent unit, exactly like \
-             an opening bracket does"
-        );
-    }
-
+    /// Revision R8.5b audit finding 1's direct regression test: the sixth instance of this
+    /// project's recurring "a keystroke gets swallowed" bug class. Before this fix, `Self::
+    /// completions_open_for_active_path` returned `true` for *any* real [`CompletionsEntry`],
+    /// including a merely `Loading`/`Failed` one - which `AdeApp::prepare_lsp_sync` seeds on
+    /// *every* completion-worthy keystroke, before the real request even completes - so the real
+    /// `"completions"` key context stayed active (claiming `Enter`/`Down`) for the *entire* real
+    /// round trip a completion request takes, live-reproduced against a real rust-analyzer as:
+    /// pressing Enter while a request was merely loading inserted no newline at all, and Down did
+    /// nothing either. Verified here by simulating real keystrokes (not calling handlers
+    /// directly) against a real, seeded `Loading` entry, then a real `Failed` one - both must
+    /// fall all the way through to the plain `Editor*` behavior, exactly as if no popup existed.
     #[gpui::test]
     fn enter_and_down_are_not_swallowed_while_completions_are_merely_loading_or_failed(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.rs", "ab\ncd\n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         bind_real_keys(cx);
         let relative = PathBuf::from("sample.rs");
@@ -4370,9 +4298,9 @@ mod editing_tests {
     fn a_real_typing_burst_undoes_and_redoes_as_one_step_through_the_real_key_bindings(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.txt", "ab\ncd\n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         bind_real_keys(cx);
         let relative = PathBuf::from("sample.txt");
@@ -4415,9 +4343,9 @@ mod editing_tests {
     fn a_real_space_typed_into_the_file_view_is_text_not_the_stage_binding(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.txt", "ab\n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         bind_real_keys(cx);
         let relative = PathBuf::from("sample.txt");
@@ -4437,9 +4365,9 @@ mod editing_tests {
 
     #[gpui::test]
     fn ctrl_y_really_redoes_in_the_code_editor(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.txt", "ab\n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         bind_real_keys(cx);
         let relative = PathBuf::from("sample.txt");
@@ -4453,9 +4381,9 @@ mod editing_tests {
 
     #[gpui::test]
     fn secondary_z_in_the_code_editor_reaches_text_undo(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.txt", "ab\n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         bind_real_keys(cx);
         let relative = PathBuf::from("sample.txt");
@@ -4478,9 +4406,9 @@ mod editing_tests {
     fn secondary_z_still_reaches_text_undo_while_the_completions_popup_is_open(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.rs", "ab\n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         bind_real_keys(cx);
         let relative = PathBuf::from("sample.rs");
@@ -4521,10 +4449,10 @@ mod editing_tests {
 
     #[gpui::test]
     fn a_files_undo_history_survives_switching_to_another_tab_and_back(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let first = write_file(repo.path(), "first.txt", "one\n");
         let second = write_file(repo.path(), "second.txt", "two\n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, first.clone());
         bind_real_keys(cx);
         let first_relative = PathBuf::from("first.txt");
@@ -4561,9 +4489,9 @@ mod editing_tests {
 
     #[gpui::test]
     fn an_external_rewrite_of_a_clean_buffer_reloads_as_one_undoable_step(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.txt", "original\n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         bind_real_keys(cx);
         let relative = PathBuf::from("sample.txt");
@@ -4581,7 +4509,9 @@ mod editing_tests {
             "sanity check: the buffer must really be clean before the external rewrite"
         );
 
-        std::thread::sleep(std::time::Duration::from_millis(20));
+        // A real external writer rewrites the file. No wait for a newer mtime is needed:
+        // `code_view::cache_is_fresh` compares length as well, and this content is a different
+        // length from what the buffer was loaded with.
         std::fs::write(&file_path, "rewritten by an agent\n").expect("external rewrite");
         app.update(cx, |app, _| {
             app.file_view_last_freshness_check = None;
@@ -4619,9 +4549,9 @@ mod editing_tests {
     fn an_external_rewrite_of_a_dirty_buffer_leaves_the_buffer_and_its_history_untouched(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.txt", "original\n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         bind_real_keys(cx);
         let relative = PathBuf::from("sample.txt");
@@ -4629,7 +4559,8 @@ mod editing_tests {
         cx.simulate_input("MINE");
         assert!(app.read_with(cx, |app, _| app.edit_buffer(&relative).unwrap().is_dirty()));
 
-        std::thread::sleep(std::time::Duration::from_millis(20));
+        // A different length from the loaded content, so the freshness check below sees the
+        // rewrite without this test having to wait for a coarser mtime to tick over.
         std::fs::write(&file_path, "theirs\n").expect("external rewrite");
         app.update(cx, |app, _| {
             app.file_view_last_freshness_check = None;
@@ -4663,15 +4594,15 @@ mod editing_tests {
     fn switching_worktrees_and_back_preserves_unsaved_edits_without_cross_worktree_collision(
         cx: &mut TestAppContext,
     ) {
-        let repo_a = tempfile::tempdir().expect("tempdir a");
-        let repo_b = tempfile::tempdir().expect("tempdir b");
+        let repo_a = temp_repo();
+        let repo_b = temp_repo();
         // Deliberately the *same* relative path in both worktrees - the real collision risk this
         // test exists to rule out.
         let file_a = write_file(repo_a.path(), "sample.txt", "worktree a original\n");
         let file_b = write_file(repo_b.path(), "sample.txt", "worktree b original\n");
         let relative = PathBuf::from("sample.txt");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo_a.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo_a.path().to_path_buf());
         app.update(cx, |app, _cx| {
             app.worktrees = vec![
                 crate::rail::worktrees::WorktreeItem {
@@ -4779,13 +4710,13 @@ mod editing_tests {
     fn toggling_bracket_pair_colorization_re_highlights_an_already_open_buffer(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(
             repo.path(),
             "sample.rs",
             "fn main() { let v = vec![(1, 2)]; }\n",
         );
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
 
         let relative = PathBuf::from("sample.rs");
@@ -4867,14 +4798,14 @@ let last = 5;
     fn open_foldable_file(
         cx: &mut TestAppContext,
     ) -> (Entity<AdeApp>, &mut gpui::VisualTestContext, PathBuf) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let repo_path = repo.path().to_path_buf();
         // The tempdir must outlive the test body; every other test in this module keeps it in a
         // local, but these need the app *and* the context back, so it is leaked deliberately -
         // the process exits at the end of the test binary anyway.
         std::mem::forget(repo);
         let file_path = write_file(&repo_path, "sample.rs", FOLDABLE_SOURCE);
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo_path);
+        let (app, cx) = open_test_app(cx, repo_path);
         open_file_for_editing(&app, cx, file_path.clone());
         (app, cx, file_path)
     }
@@ -5135,10 +5066,10 @@ let last = 5;
 
     #[gpui::test]
     fn fold_state_is_per_file(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let folded_file = write_file(repo.path(), "sample.rs", FOLDABLE_SOURCE);
         let other_file = write_file(repo.path(), "other.rs", FOLDABLE_SOURCE);
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
 
         open_file_for_editing(&app, cx, folded_file.clone());
         click_fold_chevron(cx, 1);
@@ -5166,9 +5097,9 @@ let last = 5;
 
     #[gpui::test]
     fn clicking_below_a_folded_files_content_still_reveals_the_caret_row(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.rs", LAST_LINE_FOLD_SOURCE);
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
 
         click_fold_chevron(cx, 2);
@@ -5211,9 +5142,9 @@ let last = 5;
 
     #[gpui::test]
     fn a_real_external_rewrite_clears_stale_fold_state_for_that_file(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.rs", FOLDABLE_SOURCE);
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
 
         click_fold_chevron(cx, 1);
@@ -5238,9 +5169,11 @@ let last = 5;
             "fn alpha() {\n    let a = 1;\n    let b = 2;\n    let c = 3;\n}\n",
         )
         .expect("rewrite sample.rs");
-        std::thread::sleep(
-            crate::root::FILE_FRESHNESS_CHECK_INTERVAL + std::time::Duration::from_millis(50),
-        );
+        // Force the throttled freshness check to run now, instead of waiting out its real
+        // wall-clock interval.
+        app.update(cx, |app, _| {
+            app.file_view_last_freshness_check = None;
+        });
         app.update(cx, |app, cx| {
             app.render_center_pane(cx);
         });
@@ -5296,7 +5229,6 @@ let last = 5;
 #[cfg(test)]
 mod caret_alignment_tests {
     use super::*;
-    use crate::root::focus::palette_focus_tests;
     use gpui::TestAppContext;
 
     /// A deliberately dense single line: `tree-sitter` splits it into dozens of real runs
@@ -5313,12 +5245,13 @@ mod caret_alignment_tests {
         Entity<AdeApp>,
         &mut gpui::VisualTestContext,
         PathBuf,
-        tempfile::TempDir,
+        crate::code_surface::fixtures::TempRepo,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let file_path = repo.path().join("dense.rs");
+        let repo = temp_repo();
+        let root = repo.path().canonicalize().expect("canonical tempdir");
+        let file_path = root.join("dense.rs");
         std::fs::write(&file_path, format!("fn main() {{\n{DENSE_LINE}\n}}\n")).expect("write");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, root.clone());
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(file_path, window, cx);
         });
@@ -5395,13 +5328,13 @@ mod caret_alignment_tests {
     fn painted_code_text_matches_the_caret_shaping_for_real_multi_byte_text(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         // 2-byte Latin-1 accents, 3-byte CJK and a 4-byte emoji, all inside real Rust string
         // literals so `tree-sitter` still splits the line into several runs around them.
         let line = "    let s = \"café\" ; let t = \"日本語\" ; let u = \"🙂\" ;";
         let file_path = repo.path().join("unicode.rs");
         std::fs::write(&file_path, format!("fn main() {{\n{line}\n}}\n")).expect("write");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(file_path, window, cx);
         });

--- a/crates/app/src/code_surface/file_view.rs
+++ b/crates/app/src/code_surface/file_view.rs
@@ -7,12 +7,14 @@ use super::lsp_ui::{
 };
 use super::zoom::zoom_scoped;
 use super::*;
-use crate::lsp::client::{lsp_file_status, LspFileStatus};
 #[cfg(test)]
-use crate::root::focus::palette_focus_tests;
+use crate::code_surface::fixtures::temp_repo;
+use crate::lsp::client::{lsp_file_status, LspFileStatus};
 use crate::root::plural;
 use crate::root::scrollbar;
 use crate::root::widgets::render_sidebar_message;
+#[cfg(test)]
+use crate::test_support::open_test_app;
 use std::collections::HashSet;
 
 impl AdeApp {
@@ -1758,17 +1760,21 @@ mod lsp_failed_status_chip_tests {
 
     const CHIP_SELECTOR: &str = "file-view-lsp-status";
 
+    // The assertion below is that the click's own `ensure_lsp_client` reached `Spawning`/`Ready`,
+    // which only happens when a real `rust-analyzer` is on PATH; without one the restart lands
+    // straight back in `Failed` and the test fails. That is the `external` tier by definition.
+    #[ignore = "external: rust-analyzer; see docs/testing.md"]
     #[gpui::test]
     async fn clicking_the_failed_status_chip_really_restarts_the_language_servers(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let root = repo.path().to_path_buf();
         std::fs::create_dir_all(root.join("src")).expect("mkdir src");
         let main_rs = root.join("src").join("main.rs");
         std::fs::write(&main_rs, "fn main() {}\n").expect("write main.rs");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, root.clone());
+        let (app, cx) = open_test_app(cx, root.clone());
         let key = (root.clone(), "rust-analyzer");
         app.update_in(cx, |app, window, cx| {
             // A real, already-recorded failure - exactly the state `reap_dead_lsp_clients` puts a

--- a/crates/app/src/code_surface/fixtures.rs
+++ b/crates/app/src/code_surface/fixtures.rs
@@ -1,0 +1,63 @@
+//! Test-only fixtures shared by this folder's own test modules.
+//!
+//! Owns exactly one thing: handing a test a repository root the app will agree with. Anything
+//! git-, wait- or process-shaped belongs in `crates/test-support` instead, and anything that
+//! opens a window in `crate::test_support`.
+
+use gpui::VisualTestContext;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+/// A real temporary directory whose [`Self::path`] is the root to hand
+/// [`crate::test_support::open_test_app`].
+///
+/// The path is canonicalized because `AdeApp` canonicalizes the repo root it is given
+/// ([`crate::rail::repo::canonical_repo_path`]) and then keys `edit_buffers`/`open_files` by
+/// `path.strip_prefix(file_tree_root)`. On macOS `std::env::temp_dir()` is itself behind a
+/// symlink (`/var` -> `/private/var`), so a fixture that builds file paths from
+/// `tempfile::TempDir::path()` verbatim produces paths that cannot be stripped against the root
+/// the app resolved, and every worktree-relative lookup in the test then silently misses.
+pub(in crate::code_surface) struct TempRepo {
+    /// Held for its `Drop`; the directory is removed when this value is.
+    _dir: tempfile::TempDir,
+    root: PathBuf,
+}
+
+impl TempRepo {
+    pub(in crate::code_surface) fn path(&self) -> &Path {
+        &self.root
+    }
+
+    /// Writes `contents` to a `self`-relative `name`, creating parent directories, and returns
+    /// the absolute path.
+    pub(in crate::code_surface) fn write(&self, name: &str, contents: &str) -> PathBuf {
+        let path = self.root.join(name);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).expect("create parent directories");
+        }
+        std::fs::write(&path, contents).expect("write fixture file");
+        path
+    }
+}
+
+pub(in crate::code_surface) fn temp_repo() -> TempRepo {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path().canonicalize().expect("canonicalize tempdir");
+    TempRepo { _dir: dir, root }
+}
+
+/// `test_support::wait_until`'s GPUI-driven sibling, for the `external`-tier tests that poll a
+/// real language server: re-runs `attempt` until it reports `true` or `deadline` elapses, and
+/// reports which - so the caller writes its own assertion message, exactly as the shared helper
+/// does.
+///
+/// The shared helper cannot serve these callers: its condition closure takes no arguments, and
+/// the state they poll only advances after a real render plus a `run_until_parked` that has to
+/// happen *between* polls, on the `VisualTestContext` this hands back each time.
+pub(in crate::code_surface) fn wait_until_parked(
+    cx: &mut VisualTestContext,
+    deadline: Duration,
+    mut attempt: impl FnMut(&mut VisualTestContext) -> bool,
+) -> bool {
+    test_support::wait_until(deadline, || attempt(cx))
+}

--- a/crates/app/src/code_surface/lsp_ui.rs
+++ b/crates/app/src/code_surface/lsp_ui.rs
@@ -7,11 +7,13 @@ use super::*;
 // `AdeApp::lsp_connection_for_path`'s facade instead of raw client states (see
 // `crate::lsp::client::LspConnection`), so a non-test import here would be genuinely unused.
 #[cfg(test)]
-use crate::lsp::client::LspClientState;
+use crate::code_surface::fixtures::{temp_repo, wait_until_parked};
 #[cfg(test)]
-use crate::root::focus::palette_focus_tests;
+use crate::lsp::client::LspClientState;
 use crate::root::scrollbar;
 use crate::root::widgets::render_keycap;
+#[cfg(test)]
+use crate::test_support::open_test_app;
 use std::time::Duration;
 
 /// How long the pointer has to rest on one real token before a real `textDocument/hover` request
@@ -1698,15 +1700,13 @@ mod lsp_hover_wiring_tests {
     use gpui::{Entity, TestAppContext, VisualTestContext};
     use std::time::{Duration, Instant};
 
-    fn write_scratch_project(main_rs: &str) -> tempfile::TempDir {
-        let dir = tempfile::TempDir::new().expect("tempdir");
-        std::fs::write(
-            dir.path().join("Cargo.toml"),
+    fn write_scratch_project(main_rs: &str) -> crate::code_surface::fixtures::TempRepo {
+        let dir = temp_repo();
+        dir.write(
+            "Cargo.toml",
             "[package]\nname = \"app_hover_wiring_fixture\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
-        )
-        .expect("write Cargo.toml");
-        std::fs::create_dir(dir.path().join("src")).expect("mkdir src");
-        std::fs::write(dir.path().join("src").join("main.rs"), main_rs).expect("write main.rs");
+        );
+        dir.write("src/main.rs", main_rs);
         dir
     }
 
@@ -1731,24 +1731,22 @@ mod lsp_hover_wiring_tests {
                     cx,
                 );
             });
-            loop {
+            // Each attempt waits for its *own* round trip to settle before the retry below
+            // sends another one, so a slow server is waited on rather than flooded.
+            let settled = wait_until_parked(cx, ONE_REQUEST_WINDOW, |cx| {
                 cx.run_until_parked();
-                let settled = app.read_with(cx, |app, _| {
+                app.read_with(cx, |app, _| {
                     matches!(
                         app.hover.as_ref().map(|entry| &entry.status),
                         Some(HoverStatus::Ready(_)) | Some(HoverStatus::Failed(_))
                     )
-                });
-                if settled {
-                    break;
-                }
-                assert!(
-                    Instant::now() < deadline,
-                    "AdeApp::hover never left its real Loading state within the real deadline"
-                );
-                std::thread::sleep(Duration::from_millis(200));
-            }
-            let resolved = app.update(cx, |app, _| match &app.hover {
+                })
+            });
+            assert!(
+                settled || Instant::now() < deadline,
+                "AdeApp::hover never left its real Loading state within the real deadline"
+            );
+            let resolved = app.read_with(cx, |app, _| match &app.hover {
                 Some(HoverEntry {
                     status: HoverStatus::Ready(Some(model)),
                     ..
@@ -1764,9 +1762,42 @@ mod lsp_hover_wiring_tests {
                  call site within the real deadline - rust-analyzer kept answering with real \
                  \"nothing here\"/errors past its own indexing window"
             );
-            std::thread::sleep(Duration::from_millis(300));
         }
     }
+
+    /// How long one real request is given to settle before the enclosing retry loop sends
+    /// another. Its own bound, separate from the whole test's `deadline`.
+    const ONE_REQUEST_WINDOW: Duration = Duration::from_secs(5);
+
+    /// Drives real renders until `key`'s language server reports `Ready`, or the tier's real
+    /// deadline passes. Re-rendering (not just waiting) is load-bearing: `render_file_view` is
+    /// what spawns the client and, once it is Ready, what dispatches `didOpen` - and there is no
+    /// window compositor driving repaints in a headless test.
+    fn wait_for_ready_client(
+        app: &Entity<AdeApp>,
+        cx: &mut VisualTestContext,
+        root: &Path,
+        key: &str,
+    ) {
+        let ready = wait_until_parked(cx, CLIENT_HANDSHAKE_WINDOW, |cx| {
+            app.update(cx, |app, cx| {
+                app.render_center_pane(cx);
+            });
+            cx.run_until_parked();
+            app.read_with(cx, |app, _| {
+                matches!(
+                    app.lsp_clients.get(&(root.to_path_buf(), key)),
+                    Some(LspClientState::Ready(_))
+                )
+            })
+        });
+        assert!(
+            ready,
+            "the real {key} client never became Ready within {CLIENT_HANDSHAKE_WINDOW:?}"
+        );
+    }
+
+    const CLIENT_HANDSHAKE_WINDOW: Duration = Duration::from_secs(120);
 
     /// Click position for `"    let result = add_one(41);"` (line index 8, 0-based), reused from
     /// `lsp_core::client::tests::rust_analyzer_returns_a_real_hover_for_a_documented_function`'s
@@ -1786,11 +1817,12 @@ mod lsp_hover_wiring_tests {
     };
 
     #[gpui::test]
+    #[ignore = "external: rust-analyzer; see docs/testing.md"]
     fn a_real_click_resolves_to_a_real_hover_render_model(cx: &mut TestAppContext) {
         let project = write_scratch_project(FIXTURE_SOURCE);
         let main_rs = project.path().join("src").join("main.rs");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, project.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, project.path().to_path_buf());
 
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(main_rs.clone(), window, cx);
@@ -1806,28 +1838,7 @@ mod lsp_hover_wiring_tests {
         // Keeps re-rendering (the trigger for `dispatch_did_open` once the client is Ready)
         // while waiting for the handshake - a single "wait, then render once" could leave
         // `didOpen` never sent for a client that only just became Ready.
-        let client_deadline = Instant::now() + Duration::from_secs(120);
-        loop {
-            app.update(cx, |app, cx| {
-                app.render_center_pane(cx);
-            });
-            cx.run_until_parked();
-            let ready = app.read_with(cx, |app, _| {
-                matches!(
-                    app.lsp_clients
-                        .get(&(project.path().to_path_buf(), "rust-analyzer")),
-                    Some(LspClientState::Ready(_))
-                )
-            });
-            if ready {
-                break;
-            }
-            assert!(
-                Instant::now() < client_deadline,
-                "the real rust-analyzer client never became Ready within 120s"
-            );
-            std::thread::sleep(Duration::from_millis(200));
-        }
+        wait_for_ready_client(&app, cx, project.path(), "rust-analyzer");
 
         let deadline = Instant::now() + Duration::from_secs(120);
         let model = request_hover_until_resolved(&app, cx, main_rs.clone(), deadline);
@@ -1855,8 +1866,8 @@ mod lsp_hover_wiring_tests {
 
     #[gpui::test]
     fn f12_action_reaches_the_real_handler_on_a_fresh_window(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = temp_repo();
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
 
         assert_eq!(
             app.read_with(cx, |app, _| app.hover.clone()),
@@ -1873,11 +1884,12 @@ mod lsp_hover_wiring_tests {
     }
 
     #[gpui::test]
+    #[ignore = "external: rust-analyzer; see docs/testing.md"]
     fn f12_action_navigates_to_the_real_definition_line(cx: &mut TestAppContext) {
         let project = write_scratch_project(FIXTURE_SOURCE);
         let main_rs = project.path().join("src").join("main.rs");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, project.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, project.path().to_path_buf());
 
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(main_rs.clone(), window, cx);
@@ -1886,28 +1898,7 @@ mod lsp_hover_wiring_tests {
 
         // See the hover test above's identical loop for why re-rendering, not just waiting,
         // matters.
-        let client_deadline = Instant::now() + Duration::from_secs(120);
-        loop {
-            app.update(cx, |app, cx| {
-                app.render_center_pane(cx);
-            });
-            cx.run_until_parked();
-            let ready = app.read_with(cx, |app, _| {
-                matches!(
-                    app.lsp_clients
-                        .get(&(project.path().to_path_buf(), "rust-analyzer")),
-                    Some(LspClientState::Ready(_))
-                )
-            });
-            if ready {
-                break;
-            }
-            assert!(
-                Instant::now() < client_deadline,
-                "the real rust-analyzer client never became Ready within 120s"
-            );
-            std::thread::sleep(Duration::from_millis(200));
-        }
+        wait_for_ready_client(&app, cx, project.path(), "rust-analyzer");
 
         // `trigger_goto_definition` reads `hover`'s path/position regardless of whether the
         // hover content itself has resolved - a `Loading` entry already carries a valid request
@@ -1923,69 +1914,50 @@ mod lsp_hover_wiring_tests {
         });
         cx.run_until_parked();
 
-        // Retried on a timer rather than called once: a `textDocument/definition` response can
-        // honestly be empty while rust-analyzer is still mid-index, and a real user would just
-        // press F12 again.
-        let definition_deadline = Instant::now() + Duration::from_secs(120);
-        loop {
+        // Retried rather than called once: a `textDocument/definition` response can honestly be
+        // empty while rust-analyzer is still mid-index, and a real user would just press F12
+        // again. The request itself runs on a background OS thread, so each attempt polls (which
+        // re-drains the executor between tries) rather than reading once.
+        let navigated = wait_until_parked(cx, DEFINITION_WINDOW, |cx| {
             app.update(cx, |app, cx| {
                 app.trigger_goto_definition(cx);
             });
-            cx.run_until_parked();
-            // The definition request runs on a background OS thread; GPUI's deterministic test
-            // executor's `run_until_parked` only drains its own scheduled queue, which is empty
-            // again the instant that background call is dispatched, so a wall-clock sleep is
-            // needed before a second `run_until_parked` can observe the completion callback.
-            std::thread::sleep(Duration::from_millis(300));
-            cx.run_until_parked();
-            // `fn add_one` is on line 4 (1-based), different from `CALL_SITE_LINE` (9), proving
-            // this is real navigation, not a no-op that left the cursor where it was.
-            let navigated = app.read_with(cx, |app, _| app.code_cursor == Some(4));
-            if navigated {
-                break;
-            }
-            assert!(
-                Instant::now() < definition_deadline,
-                "trigger_goto_definition never navigated AdeApp::code_cursor to the real \
-                 definition line within 120s - last observed code_cursor: {:?}",
-                app.read_with(cx, |app, _| app.code_cursor)
-            );
-        }
+            wait_until_parked(cx, ONE_REQUEST_WINDOW, |cx| {
+                cx.run_until_parked();
+                // `fn add_one` is on line 4 (1-based), different from `CALL_SITE_LINE` (9),
+                // proving this is real navigation, not a no-op that left the cursor where it was.
+                app.read_with(cx, |app, _| app.code_cursor == Some(4))
+            })
+        });
+        assert!(
+            navigated,
+            "trigger_goto_definition never navigated AdeApp::code_cursor to the real definition \
+             line within {DEFINITION_WINDOW:?} - last observed code_cursor: {:?}",
+            app.read_with(cx, |app, _| app.code_cursor)
+        );
     }
 
+    /// How long the whole retry sequence for one real `textDocument/definition` answer is given.
+    const DEFINITION_WINDOW: Duration = Duration::from_secs(120);
+
+    /// Real, end-to-end coverage for the Ctrl/Cmd+click go-to-definition affordance: a real
+    /// simulated mouse click, with a real secondary modifier held, on the real painted call-site
+    /// token, against a genuinely spawned rust-analyzer - not a call straight into
+    /// `trigger_goto_definition` the way [`f12_action_navigates_to_the_real_definition_line`]
+    /// tests the mechanism itself. This is what actually proves the click *routes* there.
     #[gpui::test]
+    #[ignore = "external: rust-analyzer; see docs/testing.md"]
     fn ctrl_click_on_a_real_token_navigates_to_its_real_definition(cx: &mut TestAppContext) {
         let project = write_scratch_project(FIXTURE_SOURCE);
         let main_rs = project.path().join("src").join("main.rs");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, project.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, project.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(main_rs.clone(), window, cx);
         });
         cx.run_until_parked();
 
-        let client_deadline = Instant::now() + Duration::from_secs(120);
-        loop {
-            app.update(cx, |app, cx| {
-                app.render_center_pane(cx);
-            });
-            cx.run_until_parked();
-            let ready = app.read_with(cx, |app, _| {
-                matches!(
-                    app.lsp_clients
-                        .get(&(project.path().to_path_buf(), "rust-analyzer")),
-                    Some(LspClientState::Ready(_))
-                )
-            });
-            if ready {
-                break;
-            }
-            assert!(
-                Instant::now() < client_deadline,
-                "the real rust-analyzer client never became Ready within 120s"
-            );
-            std::thread::sleep(Duration::from_millis(200));
-        }
+        wait_for_ready_client(&app, cx, project.path(), "rust-analyzer");
 
         let (row_bounds, shaped) = app
             .read_with(cx, |app, _| {
@@ -1996,46 +1968,39 @@ mod lsp_hover_wiring_tests {
             row_bounds.left() + shaped.x_for_index(CALL_SITE_BYTE_RANGE.start + 1),
             row_bounds.center().y,
         );
-        // `Modifiers::secondary()` reads `control` on every platform this test actually runs on
-        // (non-macOS - see that method's own docs) - a real, held Ctrl, not a stand-in for it.
-        let ctrl_click = gpui::Modifiers {
-            control: true,
-            ..Default::default()
-        };
+        // The real modifier the production click handler checks for (`Modifiers::secondary()`),
+        // which is Cmd on macOS and Ctrl elsewhere - held for real, not stood in for.
+        let ctrl_click = gpui::Modifiers::secondary_key();
 
         // Retried the same real way `f12_action_navigates_to_the_real_definition_line` retries
         // its own equivalent request: a real `textDocument/definition` response can honestly come
         // back empty while rust-analyzer is still mid-index, and a real user would just click
         // again. Re-clicking (not just re-waiting) is load-bearing here - a single stale response
         // means nothing will ever change without a fresh request.
-        let definition_deadline = Instant::now() + Duration::from_secs(120);
-        loop {
+        let navigated = wait_until_parked(cx, DEFINITION_WINDOW, |cx| {
             cx.simulate_click(click_point, ctrl_click);
-            cx.run_until_parked();
-            std::thread::sleep(Duration::from_millis(300));
-            cx.run_until_parked();
-            // `fn add_one` is on line 4 (1-based), different from `CALL_SITE_LINE` (9) - real
-            // navigation, not the click's own plain caret placement being mistaken for it.
-            let navigated = app.read_with(cx, |app, _| app.code_cursor == Some(4));
-            if navigated {
-                break;
-            }
-            assert!(
-                Instant::now() < definition_deadline,
-                "a real Ctrl+click on the real call-site token never navigated \
-                 AdeApp::code_cursor to the real definition line within 120s - last observed \
-                 code_cursor: {:?}",
-                app.read_with(cx, |app, _| app.code_cursor)
-            );
-        }
+            wait_until_parked(cx, ONE_REQUEST_WINDOW, |cx| {
+                cx.run_until_parked();
+                // `fn add_one` is on line 4 (1-based), different from `CALL_SITE_LINE` (9) - real
+                // navigation, not the click's own plain caret placement being mistaken for it.
+                app.read_with(cx, |app, _| app.code_cursor == Some(4))
+            })
+        });
+        assert!(
+            navigated,
+            "a real Ctrl+click on the real call-site token never navigated AdeApp::code_cursor \
+             to the real definition line within {DEFINITION_WINDOW:?} - last observed \
+             code_cursor: {:?}",
+            app.read_with(cx, |app, _| app.code_cursor)
+        );
     }
 
     #[gpui::test]
     fn a_plain_click_with_no_modifier_does_not_trigger_navigation(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = repo.path().join("sample.rs");
         std::fs::write(&file_path, "fn one() {}\nfn two() {}\n").expect("write sample.rs");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(file_path.clone(), window, cx);
         });
@@ -2139,10 +2104,10 @@ mod hover_popover_position_tests {
 
     #[gpui::test]
     fn a_genuinely_empty_hover_result_paints_no_popup_at_all(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = repo.path().join("sample.rs");
         std::fs::write(&file_path, "fn main() {}\n").expect("write sample.rs");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(file_path.clone(), window, cx);
         });
@@ -2205,10 +2170,10 @@ mod hover_popover_position_tests {
     fn a_real_long_signature_wraps_inside_the_card_instead_of_being_clipped(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = repo.path().join("sample.rs");
         std::fs::write(&file_path, "fn main() {}\n").expect("write sample.rs");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(file_path.clone(), window, cx);
         });
@@ -2274,13 +2239,13 @@ mod hover_popover_position_tests {
     fn a_card_with_no_room_below_sits_against_its_row_not_a_card_height_above_it(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = repo.path().join("sample.txt");
         // Long enough that its later rows are genuinely near the bottom of the painted body -
         // the only way to make a card flip for real rather than by faking bounds.
         let source: String = (1..=200).map(|index| format!("line {index}\n")).collect();
         std::fs::write(&file_path, &source).expect("write sample.txt");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(file_path.clone(), window, cx);
         });
@@ -2336,10 +2301,10 @@ mod hover_popover_position_tests {
 
     #[gpui::test]
     fn the_real_painted_hover_card_moves_with_the_real_hovered_row(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = repo.path().join("sample.txt");
         std::fs::write(&file_path, "one\ntwo\nthree\nfour\nfive\n").expect("write sample.txt");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(file_path.clone(), window, cx);
         });
@@ -2403,10 +2368,10 @@ mod hover_popover_position_tests {
     fn the_real_painted_hover_card_moves_horizontally_with_the_real_hovered_column(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = repo.path().join("sample.txt");
         std::fs::write(&file_path, "aaaa bbbb cccc dddd\n").expect("write sample.txt");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(file_path.clone(), window, cx);
         });
@@ -2538,16 +2503,15 @@ mod vue_two_server_wiring_tests {
     /// `node_modules/typescript/lib/typescript.js` specifically, and refuses to spawn without it).
     /// A stubbed stand-in would be worse than useless here - the real `vue-language-server` really
     /// does load this file, and a fake one would produce a different, equally fake failure.
-    fn write_scratch_vue_project() -> tempfile::TempDir {
-        let dir = tempfile::TempDir::new().expect("tempdir");
-        std::fs::write(
-            dir.path().join("tsconfig.json"),
+    fn write_scratch_vue_project() -> crate::code_surface::fixtures::TempRepo {
+        let dir = temp_repo();
+        dir.write(
+            "tsconfig.json",
             "{\"compilerOptions\": {\"strict\": true, \"target\": \"ES2020\", \
              \"module\": \"ESNext\", \"moduleResolution\": \"Bundler\", \"jsx\": \"preserve\"}, \
              \"include\": [\"**/*.ts\", \"**/*.vue\"]}\n",
-        )
-        .expect("write tsconfig.json");
-        std::fs::write(dir.path().join("App.vue"), FIXTURE_VUE).expect("write App.vue");
+        );
+        dir.write("App.vue", FIXTURE_VUE);
         let status = std::process::Command::new("npm")
             .args([
                 "install",
@@ -2571,26 +2535,29 @@ mod vue_two_server_wiring_tests {
 
     /// Re-renders, advances the deterministic clock past one `LSP_DIAGNOSTICS_POLL_INTERVAL`, and
     /// drains, until `predicate` holds or `deadline` passes.
-    fn wait_until(
+    ///
+    /// Advancing the clock is load-bearing here and not in the single-server tests: this app's
+    /// relay dispatch lives in `AdeApp::ensure_lsp_poll_task`'s own `timer(..)`-driven loop, which
+    /// on GPUI's deterministic test executor only ticks when the clock is actually advanced - and
+    /// the real `vue-language-server` will not produce a single diagnostic until its relayed
+    /// `tsserver/request` has been answered.
+    fn wait_for(
         app: &Entity<AdeApp>,
         cx: &mut VisualTestContext,
-        deadline: Instant,
+        deadline: Duration,
         message: &str,
         predicate: impl Fn(&AdeApp) -> bool,
     ) {
-        loop {
+        let held = wait_until_parked(cx, deadline, |cx| {
             app.update(cx, |app, cx| {
                 app.render_center_pane(cx);
             });
             cx.background_executor
                 .advance_clock(LSP_DIAGNOSTICS_POLL_INTERVAL + Duration::from_millis(10));
             cx.run_until_parked();
-            if app.read_with(cx, |app, _| predicate(app)) {
-                return;
-            }
-            assert!(Instant::now() < deadline, "{message}");
-            std::thread::sleep(Duration::from_millis(200));
-        }
+            app.read_with(cx, |app, _| predicate(app))
+        });
+        assert!(held, "{message}");
     }
 
     fn diagnostic_messages(app: &AdeApp) -> Vec<String> {
@@ -2602,7 +2569,7 @@ mod vue_two_server_wiring_tests {
     }
 
     #[gpui::test]
-    #[ignore]
+    #[ignore = "external: vue-language-server, typescript-language-server, npm; see docs/testing.md"]
     fn a_real_vue_file_gets_real_diagnostics_from_both_servers_and_a_real_hover(
         cx: &mut TestAppContext,
     ) {
@@ -2613,7 +2580,7 @@ mod vue_two_server_wiring_tests {
         let _ = env_logger::builder().parse_default_env().try_init();
         let project = write_scratch_vue_project();
         let app_vue = project.path().join("App.vue");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, project.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, project.path().to_path_buf());
 
         let opened_at = Instant::now();
         app.update_in(cx, |app, window, cx| {
@@ -2626,10 +2593,10 @@ mod vue_two_server_wiring_tests {
         let companion_key = language::companion_for_extension(Some("vue"))
             .expect("vue has a real companion")
             .client_key;
-        wait_until(
+        wait_for(
             &app,
             cx,
-            Instant::now() + Duration::from_secs(180),
+            Duration::from_secs(180),
             "the real vue-language-server and its real typescript-language-server companion were \
              never both Ready - check that both are installed and that @vue/typescript-plugin \
              resolved",
@@ -2648,10 +2615,10 @@ mod vue_two_server_wiring_tests {
 
         // The companion's own contribution: a real TypeScript semantic error for `.vue` content,
         // which only exists because the real `@vue/typescript-plugin` is genuinely loaded.
-        wait_until(
+        wait_for(
             &app,
             cx,
-            Instant::now() + Duration::from_secs(180),
+            Duration::from_secs(180),
             "no real TypeScript diagnostic for the genuine `.vue` script type error ever reached \
              file_view_diagnostics",
             |app| {
@@ -2664,10 +2631,10 @@ mod vue_two_server_wiring_tests {
 
         // The primary's own contribution: a real Vue template compile error, which the companion
         // does not and cannot report.
-        wait_until(
+        wait_for(
             &app,
             cx,
-            Instant::now() + Duration::from_secs(120),
+            Duration::from_secs(120),
             "no real Vue template diagnostic ever reached file_view_diagnostics - without it, \
              only one of the two real servers is genuinely contributing",
             |app| {
@@ -2706,9 +2673,11 @@ mod vue_two_server_wiring_tests {
         // A real hover, through the facade's real companion fallback: the primary answers `null`
         // for every position in a `.vue` file (real, expected hybrid-mode behavior), so a
         // non-`None` result here can only have come from the companion via `LspConnection`.
-        let hover_deadline = Instant::now() + Duration::from_secs(120);
         let hover_started = Instant::now();
-        let model = loop {
+        let mut resolved = None;
+        // Each attempt waits out its own real round trip before the next one is sent, so a
+        // still-indexing server is waited on rather than flooded with fresh requests.
+        let answered = wait_until_parked(cx, Duration::from_secs(120), |cx| {
             app.update(cx, |app, cx| {
                 app.hover = None;
                 app.request_hover(
@@ -2719,41 +2688,31 @@ mod vue_two_server_wiring_tests {
                     cx,
                 );
             });
-            loop {
+            wait_until_parked(cx, Duration::from_secs(5), |cx| {
                 cx.run_until_parked();
-                let settled = app.read_with(cx, |app, _| {
+                app.read_with(cx, |app, _| {
                     matches!(
                         app.hover.as_ref().map(|entry| &entry.status),
                         Some(HoverStatus::Ready(_)) | Some(HoverStatus::Failed(_))
                     )
-                });
-                if settled {
-                    break;
-                }
-                assert!(
-                    Instant::now() < hover_deadline,
-                    "AdeApp::hover never left its real Loading state within the real deadline"
-                );
-                std::thread::sleep(Duration::from_millis(200));
-            }
-            let resolved = app.update(cx, |app, _| match &app.hover {
+                })
+            });
+            resolved = app.read_with(cx, |app, _| match &app.hover {
                 Some(HoverEntry {
                     status: HoverStatus::Ready(Some(model)),
                     ..
                 }) => Some(model.clone()),
                 _ => None,
             });
-            if let Some(model) = resolved {
-                break model;
-            }
-            assert!(
-                Instant::now() < hover_deadline,
-                "no real, non-empty hover ever came back for the genuine `bad` identifier in the \
-                 real .vue script block - the companion fallback in LspConnection::request is \
-                 what has to supply it, since the primary genuinely answers null there"
-            );
-            std::thread::sleep(Duration::from_millis(300));
-        };
+            resolved.is_some()
+        });
+        assert!(
+            answered,
+            "no real, non-empty hover ever came back for the genuine `bad` identifier in the \
+             real .vue script block - the companion fallback in LspConnection::request is \
+             what has to supply it, since the primary genuinely answers null there"
+        );
+        let model = resolved.expect("the wait above only succeeds with a real resolved hover");
         println!(
             "vue e2e: real hover resolved in {:?}: {model:?}",
             hover_started.elapsed()
@@ -2778,7 +2737,7 @@ mod vue_two_server_wiring_tests {
         let uri = lsp_core::LspClient::uri_for_path(&app_vue).expect("a real file:// uri");
 
         let definition = retry_until_some(
-            Instant::now() + Duration::from_secs(120),
+            Duration::from_secs(120),
             "no real go-to-definition ever came back for `shape` in the real .vue script block - \
              the real vue-language-server answers an empty array there, so only the companion \
              fallback in LspConnection::request can supply one",
@@ -2814,7 +2773,7 @@ mod vue_two_server_wiring_tests {
         println!("vue e2e: real go-to-definition answer: {definition:?}");
 
         let completions = retry_until_some(
-            Instant::now() + Duration::from_secs(120),
+            Duration::from_secs(120),
             "no real completions ever came back after `shape.` in the real .vue script block - \
              the real vue-language-server answers an empty items list there",
             || {
@@ -2854,14 +2813,18 @@ mod vue_two_server_wiring_tests {
     /// Calls `attempt` until it returns a real `Some` or `deadline` passes. Both real servers are
     /// still settling for a while after the first diagnostic lands, so a single shot would be a
     /// race; nothing is fabricated on timeout, the assertion just fails.
-    fn retry_until_some<T>(deadline: Instant, message: &str, attempt: impl Fn() -> Option<T>) -> T {
-        loop {
-            if let Some(value) = attempt() {
-                return value;
-            }
-            assert!(Instant::now() < deadline, "{message}");
-            std::thread::sleep(Duration::from_millis(300));
-        }
+    fn retry_until_some<T>(
+        deadline: Duration,
+        message: &str,
+        attempt: impl Fn() -> Option<T>,
+    ) -> T {
+        let mut resolved = None;
+        let answered = test_support::wait_until(deadline, || {
+            resolved = attempt();
+            resolved.is_some()
+        });
+        assert!(answered, "{message}");
+        resolved.expect("the wait above only succeeds with a real answer")
     }
 }
 
@@ -2881,15 +2844,15 @@ mod hover_pointer_tests {
         name: &str,
         source: &str,
     ) -> (
-        tempfile::TempDir,
+        crate::code_surface::fixtures::TempRepo,
         PathBuf,
         Entity<AdeApp>,
         &'a mut VisualTestContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = repo.path().join(name);
         std::fs::write(&file_path, source).expect("write fixture");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(file_path.clone(), window, cx);
         });
@@ -3136,11 +3099,11 @@ mod hover_pointer_tests {
 
     #[gpui::test]
     fn the_full_real_pipeline_also_survives_hovering_a_covered_token(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = repo.path().join("sample.rs");
         std::fs::write(&file_path, "fn alpha() {}\nfn beta() {}\n").expect("write sample.rs");
         let client = spawn_fake_server(repo.path(), "rust-analyzer", "hover");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update(cx, |app, _cx| {
             app.lsp_clients.insert(
                 (repo.path().to_path_buf(), "rust-analyzer"),
@@ -3291,13 +3254,13 @@ mod diagnostic_popover_tests {
 
     #[gpui::test]
     fn the_real_diagnostic_card_floats_over_the_code_without_reflowing_it(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = repo.path().join("sample.rs");
         std::fs::write(&file_path, SOURCE).expect("write sample.rs");
         // A real, minimal LSP server installed *before* the first render, so `ensure_lsp_client`
         // finds a Ready entry for this key and never spawns a real rust-analyzer for the fixture.
         let client = spawn_fake_server(repo.path(), "rust-analyzer", "normal");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update(cx, |app, _cx| {
             app.lsp_clients.insert(
                 (repo.path().to_path_buf(), "rust-analyzer"),
@@ -3372,11 +3335,11 @@ mod diagnostic_popover_tests {
     fn the_real_diagnostic_card_is_anchored_under_the_offending_span_not_the_row_edge(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = repo.path().join("sample.rs");
         std::fs::write(&file_path, SOURCE).expect("write sample.rs");
         let client = spawn_fake_server(repo.path(), "rust-analyzer", "normal");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update(cx, |app, _cx| {
             app.lsp_clients.insert(
                 (repo.path().to_path_buf(), "rust-analyzer"),
@@ -3423,11 +3386,11 @@ mod diagnostic_popover_tests {
     fn the_real_card_shows_the_caret_line_only_and_yields_to_the_other_lsp_popups(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = repo.path().join("sample.rs");
         std::fs::write(&file_path, SOURCE).expect("write sample.rs");
         let client = spawn_fake_server(repo.path(), "rust-analyzer", "normal");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update(cx, |app, _cx| {
             app.lsp_clients.insert(
                 (repo.path().to_path_buf(), "rust-analyzer"),
@@ -3501,11 +3464,11 @@ mod diagnostic_popover_tests {
 
     #[gpui::test]
     fn moving_the_real_pointer_onto_the_diagnostic_card_does_not_hide_it(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = repo.path().join("sample.rs");
         std::fs::write(&file_path, SOURCE).expect("write sample.rs");
         let client = spawn_fake_server(repo.path(), "rust-analyzer", "normal");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update(cx, |app, _cx| {
             app.lsp_clients.insert(
                 (repo.path().to_path_buf(), "rust-analyzer"),
@@ -3563,11 +3526,11 @@ mod diagnostic_popover_tests {
     fn hovering_directly_over_the_diagnostic_span_shows_the_diagnostic_not_an_empty_hover(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = repo.path().join("sample.rs");
         std::fs::write(&file_path, SOURCE).expect("write sample.rs");
         let client = spawn_fake_server(repo.path(), "rust-analyzer", "normal");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update(cx, |app, _cx| {
             app.lsp_clients.insert(
                 (repo.path().to_path_buf(), "rust-analyzer"),
@@ -3623,11 +3586,11 @@ mod diagnostic_popover_tests {
     fn hovering_directly_over_the_diagnostic_span_shows_the_diagnostic_over_real_hover_content_too(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = repo.path().join("sample.rs");
         std::fs::write(&file_path, SOURCE).expect("write sample.rs");
         let client = spawn_fake_server(repo.path(), "rust-analyzer", "normal");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update(cx, |app, _cx| {
             app.lsp_clients.insert(
                 (repo.path().to_path_buf(), "rust-analyzer"),
@@ -3680,11 +3643,11 @@ mod diagnostic_popover_tests {
     fn hovering_a_diagnostic_span_shows_the_card_even_while_the_caret_is_elsewhere(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = repo.path().join("sample.rs");
         std::fs::write(&file_path, SOURCE).expect("write sample.rs");
         let client = spawn_fake_server(repo.path(), "rust-analyzer", "normal");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update(cx, |app, _cx| {
             app.lsp_clients.insert(
                 (repo.path().to_path_buf(), "rust-analyzer"),
@@ -3741,15 +3704,15 @@ mod diagnostic_popover_tests {
     ) -> (
         Entity<AdeApp>,
         &'a mut VisualTestContext,
-        tempfile::TempDir,
+        crate::code_surface::fixtures::TempRepo,
         std::sync::Arc<lsp_core::LspClient>,
         String,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = repo.path().join("sample.rs");
         std::fs::write(&file_path, SOURCE).expect("write sample.rs");
         let client = spawn_fake_server(repo.path(), "rust-analyzer", "normal");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update(cx, |app, _cx| {
             app.lsp_clients.insert(
                 (repo.path().to_path_buf(), "rust-analyzer"),
@@ -3971,11 +3934,11 @@ mod inline_diagnostic_message_tests {
     fn a_real_long_inline_message_truncates_instead_of_overlapping_the_real_code_text(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = repo.path().join("sample.rs");
         std::fs::write(&file_path, "fn alpha() {}\nfn beta() {}\n").expect("write sample.rs");
         let client = spawn_fake_server(repo.path(), "rust-analyzer", "normal");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update(cx, |app, _cx| {
             app.lsp_clients.insert(
                 (repo.path().to_path_buf(), "rust-analyzer"),
@@ -4206,10 +4169,10 @@ mod hover_card_footer_layout_tests {
     fn the_module_path_and_definition_chip_sit_at_opposite_ends_of_the_real_footer(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = repo.path().join("sample.rs");
         std::fs::write(&file_path, "fn add_one(x: i32) -> i32 { x + 1 }\n").expect("write");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(file_path.clone(), window, cx);
         });
@@ -4259,10 +4222,10 @@ mod hover_card_footer_layout_tests {
     fn clicking_through_the_hover_card_never_also_reaches_the_file_view_row_behind_it(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = repo.path().join("sample.rs");
         std::fs::write(&file_path, "fn line_one() {}\nfn line_two() {}\n").expect("write");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(file_path.clone(), window, cx);
         });
@@ -4317,12 +4280,12 @@ mod hover_card_footer_layout_tests {
     ) -> (
         gpui::Entity<AdeApp>,
         &'a mut gpui::VisualTestContext,
-        tempfile::TempDir,
+        crate::code_surface::fixtures::TempRepo,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = repo.path().join("sample.rs");
         std::fs::write(&file_path, "fn add_one(x: i32) -> i32 { x + 1 }\n").expect("write");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(file_path.clone(), window, cx);
         });
@@ -4391,10 +4354,10 @@ mod hover_card_footer_layout_tests {
 
     #[gpui::test]
     fn a_real_jsdoc_tag_in_the_hover_doc_body_paints_its_own_tag_run(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = repo.path().join("sample.rs");
         std::fs::write(&file_path, "fn add_one(x: i32) -> i32 { x + 1 }\n").expect("write");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(file_path.clone(), window, cx);
         });
@@ -4435,10 +4398,10 @@ mod hover_card_footer_layout_tests {
     fn real_jsdoc_block_tags_in_the_hover_doc_body_paint_their_own_structured_sections(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = repo.path().join("sample.rs");
         std::fs::write(&file_path, "fn add_one(x: i32) -> i32 { x + 1 }\n").expect("write");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(file_path.clone(), window, cx);
         });
@@ -4484,10 +4447,10 @@ mod hover_card_footer_layout_tests {
     fn a_tall_signature_keeps_the_footer_pinned_and_shows_a_real_scrollbar(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = repo.path().join("sample.rs");
         std::fs::write(&file_path, "fn add_one(x: i32) -> i32 { x + 1 }\n").expect("write");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(file_path.clone(), window, cx);
         });
@@ -4556,10 +4519,10 @@ mod hover_card_footer_layout_tests {
 
     #[gpui::test]
     fn a_short_signature_paints_no_scrollbar(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = repo.path().join("sample.rs");
         std::fs::write(&file_path, "fn add_one(x: i32) -> i32 { x + 1 }\n").expect("write");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(file_path.clone(), window, cx);
         });

--- a/crates/app/src/code_surface/mod.rs
+++ b/crates/app/src/code_surface/mod.rs
@@ -36,6 +36,8 @@ pub(crate) mod blame_view;
 pub(crate) mod diff_view;
 pub(crate) mod editing;
 pub(crate) mod file_view;
+#[cfg(test)]
+pub(crate) mod fixtures;
 pub(crate) mod lsp_ui;
 pub(crate) mod markdown_preview;
 pub(crate) mod minimap;

--- a/crates/app/src/code_surface/render.rs
+++ b/crates/app/src/code_surface/render.rs
@@ -4,9 +4,11 @@
 
 use super::*;
 #[cfg(test)]
-use crate::root::focus::palette_focus_tests;
+use crate::code_surface::fixtures::temp_repo;
 use crate::root::widgets::render_status_letter;
 use crate::settings::widgets::ChoiceOption;
+#[cfg(test)]
+use crate::test_support::open_test_app;
 
 impl AdeApp {
     /// A themed explanatory message for every [`DiffLoadState`] that isn't a loaded diff, as its
@@ -433,37 +435,19 @@ mod choice_control_dispatch_tests {
     use super::*;
     use gpui::TestAppContext;
 
-    fn git_repo(dir: &std::path::Path, args: &[&str]) {
-        let output = std::process::Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {:?} failed in {:?}:\nstdout: {}\nstderr: {}",
-            args,
-            dir,
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
     #[gpui::test]
     fn clicking_a_segment_by_structural_position_selects_the_matching_real_value(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        git_repo(repo.path(), &["init", "-b", "main"]);
-        git_repo(repo.path(), &["config", "user.email", "test@example.com"]);
-        git_repo(repo.path(), &["config", "user.name", "Test User"]);
+        let repo = temp_repo();
+        test_support::seed_empty_repo_at(repo.path());
         std::fs::write(repo.path().join("a.txt"), "1\n").expect("write a.txt");
-        git_repo(repo.path(), &["add", "."]);
-        git_repo(repo.path(), &["commit", "-m", "initial"]);
-        git_repo(repo.path(), &["checkout", "-b", "feature"]);
+        test_support::git(repo.path(), &["add", "."]);
+        test_support::git(repo.path(), &["commit", "-m", "initial"]);
+        test_support::git(repo.path(), &["checkout", "-b", "feature"]);
         std::fs::write(repo.path().join("a.txt"), "1\nchanged\n").expect("rewrite a.txt");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         app.update_in(cx, |app, window, cx| {
@@ -514,10 +498,10 @@ mod markdown_preview_toggle_tests {
 
     #[gpui::test]
     fn the_toggle_only_appears_for_a_real_md_file(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         std::fs::write(repo.path().join("readme.md"), "# hi\n").expect("write readme.md");
         std::fs::write(repo.path().join("main.rs"), "fn main() {}\n").expect("write main.rs");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         app.update_in(cx, |app, window, cx| {
@@ -541,14 +525,14 @@ mod markdown_preview_toggle_tests {
 
     #[gpui::test]
     fn clicking_preview_renders_the_real_parsed_document_with_no_panic(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         std::fs::write(
             repo.path().join("readme.md"),
             "# Title\n\nSome **bold** text, a [link](https://example.com), and:\n\n- one\n- two\n\n\
              ```rust\nfn main() {}\n```\n\n| a | b |\n|---|---|\n| 1 | 2 |\n",
         )
         .expect("write readme.md");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         app.update_in(cx, |app, window, cx| {
@@ -590,10 +574,10 @@ mod markdown_preview_toggle_tests {
 
     #[gpui::test]
     fn opening_a_different_markdown_file_resets_the_toggle_back_to_source(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         std::fs::write(repo.path().join("a.md"), "# a\n").expect("write a.md");
         std::fs::write(repo.path().join("b.md"), "# b\n").expect("write b.md");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         app.update_in(cx, |app, window, cx| {
@@ -629,11 +613,11 @@ mod markdown_preview_toggle_tests {
     ) -> (
         gpui::Entity<AdeApp>,
         &'a mut gpui::VisualTestContext,
-        tempfile::TempDir,
+        crate::code_surface::fixtures::TempRepo,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         std::fs::write(repo.path().join("readme.md"), contents).expect("write readme.md");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(repo.path().join("readme.md"), window, cx);

--- a/crates/app/src/code_surface/tabs.rs
+++ b/crates/app/src/code_surface/tabs.rs
@@ -5,7 +5,9 @@
 
 use super::*;
 #[cfg(test)]
-use crate::root::focus::palette_focus_tests;
+use crate::code_surface::fixtures::temp_repo;
+#[cfg(test)]
+use crate::test_support::open_test_app;
 
 impl AdeApp {
     /// Loads (or reloads) the diff of `root` against its detected base branch. Runs on
@@ -834,7 +836,7 @@ mod code_view_cache_tests {
 
     #[gpui::test]
     fn opening_a_large_real_file_does_not_block_render_on_the_full_parse(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = repo.path().join("large.rs");
         let source =
             std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/src/lsp/client.rs"))
@@ -845,7 +847,7 @@ mod code_view_cache_tests {
         code_view::load_file(&file_path).expect("load_file baseline");
         let baseline_duration = baseline_start.elapsed();
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(file_path.clone(), window, cx);
         });
@@ -885,7 +887,7 @@ mod code_view_cache_tests {
 
     #[gpui::test]
     fn repeated_renders_of_the_same_open_file_reuse_the_cached_parse(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = repo.path().join("sample.rs");
         std::fs::write(
             &file_path,
@@ -893,7 +895,7 @@ mod code_view_cache_tests {
         )
         .expect("write sample.rs");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
 
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(file_path.clone(), window, cx);
@@ -941,11 +943,11 @@ mod code_view_cache_tests {
 
     #[gpui::test]
     fn a_real_on_disk_change_to_the_open_file_invalidates_the_cache(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = repo.path().join("sample.rs");
         std::fs::write(&file_path, "fn add() -> i32 {\n    1\n}\n").expect("write sample.rs");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(file_path.clone(), window, cx);
         });
@@ -970,7 +972,11 @@ mod code_view_cache_tests {
         )
         .expect("rewrite sample.rs");
 
-        std::thread::sleep(FILE_FRESHNESS_CHECK_INTERVAL + std::time::Duration::from_millis(50));
+        // Clear the throttle so the next freshness check runs, rather than waiting out its
+        // real wall-clock interval.
+        app.update(cx, |app, _| {
+            app.file_view_last_freshness_check = None;
+        });
 
         app.update(cx, |app, cx| {
             app.render_center_pane(cx);
@@ -998,11 +1004,11 @@ mod code_view_cache_tests {
     fn renders_within_the_throttle_window_do_not_pick_up_a_fresh_on_disk_change(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = repo.path().join("sample.rs");
         std::fs::write(&file_path, "fn add() -> i32 {\n    1\n}\n").expect("write sample.rs");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(file_path.clone(), window, cx);
         });
@@ -1051,7 +1057,10 @@ mod code_view_cache_tests {
             "no reload should have been dispatched while the freshness check was throttled"
         );
 
-        std::thread::sleep(FILE_FRESHNESS_CHECK_INTERVAL + std::time::Duration::from_millis(50));
+        // Clear the throttle - the change is now observed.
+        app.update(cx, |app, _| {
+            app.file_view_last_freshness_check = None;
+        });
         app.update(cx, |app, cx| {
             app.render_center_pane(cx);
         });
@@ -1087,13 +1096,13 @@ mod cross_file_navigation_tests {
     fn navigating_to_an_uncached_file_then_opening_a_different_file_first_does_not_leak_the_cursor(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_b = repo.path().join("b.txt");
         let file_c = repo.path().join("c.txt");
         std::fs::write(&file_b, "one\ntwo\nthree\nfour\nfive\n").expect("write b.txt");
         std::fs::write(&file_c, "hello\nworld\n").expect("write c.txt");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
 
         // Landing on B's line 5 - B isn't cached yet, so this sets `pending_cursor_line` rather
         // than `code_cursor` directly.
@@ -1157,12 +1166,12 @@ mod unreadable_file_tests {
     fn an_unreadable_file_settles_into_a_stable_error_state_without_respawning(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         // A deterministic, cross-platform read failure: no such path exists, so `load_file`'s
         // `fs::metadata`/`fs::read` fail every time, with no platform-specific setup needed.
         let missing_path = repo.path().join("does-not-exist.rs");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
 
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(missing_path.clone(), window, cx);
@@ -1236,7 +1245,7 @@ mod reopened_file_caret_tests {
 
     #[gpui::test]
     fn reopening_a_file_reports_its_restored_caret_line_not_line_one(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let target = repo.path().join("many.txt");
         // Long enough that the caret's row genuinely cannot be on screen at scroll offset 0 -
         // otherwise "the view scrolled to the caret" and "the view never moved" look identical.
@@ -1245,8 +1254,7 @@ mod reopened_file_caret_tests {
         let other = repo.path().join("other.txt");
         std::fs::write(&other, "x\n").expect("write");
 
-        let (app, cx) =
-            crate::root::focus::palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_and_settle(&app, cx, target.clone());
         let relative = PathBuf::from("many.txt");
 
@@ -1331,12 +1339,11 @@ mod reopened_file_caret_tests {
 
     #[gpui::test]
     fn a_first_open_is_caret_at_line_one(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let target = repo.path().join("fresh.txt");
         std::fs::write(&target, "a\nb\nc\n").expect("write");
 
-        let (app, cx) =
-            crate::root::focus::palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_and_settle(&app, cx, target);
 
         app.read_with(cx, |app, _| {
@@ -1378,9 +1385,9 @@ mod multi_file_tab_tests {
 
     #[gpui::test]
     fn opening_the_same_file_twice_does_not_duplicate_its_tab(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let ((a, _b, _c), (a_rel, _, _)) = write_three_files(repo.path());
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
 
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(a.clone(), window, cx);
@@ -1405,9 +1412,9 @@ mod multi_file_tab_tests {
 
     #[gpui::test]
     fn closing_the_active_tab_activates_the_tab_that_was_to_its_right(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let ((a, b, c), (a_rel, b_rel, c_rel)) = write_three_files(repo.path());
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
 
         for path in [a, b, c] {
             app.update_in(cx, |app, window, cx| {
@@ -1465,9 +1472,9 @@ mod multi_file_tab_tests {
 
     #[gpui::test]
     fn closing_a_non_active_tab_does_not_change_what_is_active(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let ((a, b, _c), (a_rel, b_rel, _)) = write_three_files(repo.path());
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
 
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(a, window, cx);
@@ -1499,9 +1506,9 @@ mod multi_file_tab_tests {
 
     #[gpui::test]
     fn selecting_a_agent_deactivates_the_open_file_tab_without_closing_it(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let ((a, _b, _c), (a_rel, _, _)) = write_three_files(repo.path());
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
 
         let agent_id = app.read_with(cx, |app, _| {
             app.agents
@@ -1544,37 +1551,19 @@ mod multi_file_tab_tests {
     fn next_changed_file_advances_through_every_changed_file_and_wraps_around(
         cx: &mut TestAppContext,
     ) {
-        fn git(dir: &std::path::Path, args: &[&str]) {
-            let output = std::process::Command::new("git")
-                .current_dir(dir)
-                .args(args)
-                .output()
-                .expect("failed to spawn git");
-            assert!(
-                output.status.success(),
-                "git {:?} failed in {:?}:\nstdout: {}\nstderr: {}",
-                args,
-                dir,
-                String::from_utf8_lossy(&output.stdout),
-                String::from_utf8_lossy(&output.stderr)
-            );
-        }
-
-        let repo = tempfile::tempdir().expect("tempdir");
-        git(repo.path(), &["init", "-b", "main"]);
-        git(repo.path(), &["config", "user.email", "test@example.com"]);
-        git(repo.path(), &["config", "user.name", "Test User"]);
+        let repo = temp_repo();
+        test_support::seed_empty_repo_at(repo.path());
         std::fs::write(repo.path().join("a.txt"), "1\n").expect("write a.txt");
         std::fs::write(repo.path().join("b.txt"), "1\n").expect("write b.txt");
         std::fs::write(repo.path().join("c.txt"), "1\n").expect("write c.txt");
-        git(repo.path(), &["add", "."]);
-        git(repo.path(), &["commit", "-m", "initial"]);
-        git(repo.path(), &["checkout", "-b", "feature"]);
+        test_support::git(repo.path(), &["add", "."]);
+        test_support::git(repo.path(), &["commit", "-m", "initial"]);
+        test_support::git(repo.path(), &["checkout", "-b", "feature"]);
         std::fs::write(repo.path().join("a.txt"), "1\nchanged\n").expect("rewrite a.txt");
         std::fs::write(repo.path().join("b.txt"), "1\nchanged\n").expect("rewrite b.txt");
         std::fs::write(repo.path().join("c.txt"), "1\nchanged\n").expect("rewrite c.txt");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         let order: Vec<PathBuf> = app.read_with(cx, |app, _| {
@@ -1628,39 +1617,25 @@ mod multi_file_tab_tests {
         );
     }
 
-    fn git_repo(dir: &std::path::Path, args: &[&str]) {
-        let output = std::process::Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {:?} failed in {:?}:\nstdout: {}\nstderr: {}",
-            args,
-            dir,
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
+    /// Regression test for "switching tabs shows the wrong Diff/File view": `code_view` is a
+    /// single global field, not per-tab, so switching from a tab left in `File` view to a
+    /// different tab with a diff used to incorrectly stay in `File` view instead of forcing
+    /// `Diff` back.
     #[gpui::test]
     fn switching_to_a_tab_with_a_real_diff_shows_the_diff_not_the_last_view_mode(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        git_repo(repo.path(), &["init", "-b", "main"]);
-        git_repo(repo.path(), &["config", "user.email", "test@example.com"]);
-        git_repo(repo.path(), &["config", "user.name", "Test User"]);
+        let repo = temp_repo();
+        test_support::seed_empty_repo_at(repo.path());
         std::fs::write(repo.path().join("changed.txt"), "1\n").expect("write changed.txt");
         std::fs::write(repo.path().join("plain.txt"), "plain\n").expect("write plain.txt");
-        git_repo(repo.path(), &["add", "."]);
-        git_repo(repo.path(), &["commit", "-m", "initial"]);
-        git_repo(repo.path(), &["checkout", "-b", "feature"]);
+        test_support::git(repo.path(), &["add", "."]);
+        test_support::git(repo.path(), &["commit", "-m", "initial"]);
+        test_support::git(repo.path(), &["checkout", "-b", "feature"]);
         std::fs::write(repo.path().join("changed.txt"), "1\nchanged\n")
             .expect("rewrite changed.txt");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         let changed_rel = PathBuf::from("changed.txt");
@@ -1702,17 +1677,15 @@ mod multi_file_tab_tests {
 
     #[gpui::test]
     fn reactivating_a_tab_whose_diff_disappeared_shows_real_content_again(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        git_repo(repo.path(), &["init", "-b", "main"]);
-        git_repo(repo.path(), &["config", "user.email", "test@example.com"]);
-        git_repo(repo.path(), &["config", "user.name", "Test User"]);
+        let repo = temp_repo();
+        test_support::seed_empty_repo_at(repo.path());
         std::fs::write(repo.path().join("a.txt"), "1\n").expect("write a.txt");
-        git_repo(repo.path(), &["add", "."]);
-        git_repo(repo.path(), &["commit", "-m", "initial"]);
-        git_repo(repo.path(), &["checkout", "-b", "feature"]);
+        test_support::git(repo.path(), &["add", "."]);
+        test_support::git(repo.path(), &["commit", "-m", "initial"]);
+        test_support::git(repo.path(), &["checkout", "-b", "feature"]);
         std::fs::write(repo.path().join("a.txt"), "1\nchanged\n").expect("rewrite a.txt");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         let rel = PathBuf::from("a.txt");
@@ -1758,14 +1731,14 @@ mod multi_file_tab_tests {
     fn switching_worktrees_and_back_preserves_each_worktree_s_open_file_tabs(
         cx: &mut TestAppContext,
     ) {
-        let repo_a = tempfile::tempdir().expect("tempdir a");
-        let repo_b = tempfile::tempdir().expect("tempdir b");
+        let repo_a = temp_repo();
+        let repo_b = temp_repo();
         let ((a1, a2, _), (a1_rel, a2_rel, _)) = write_three_files(repo_a.path());
         let b1 = repo_b.path().join("notes.txt");
         std::fs::write(&b1, "notes\n").expect("write notes.txt");
         let b1_rel = PathBuf::from("notes.txt");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo_a.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo_a.path().to_path_buf());
         app.update(cx, |app, _cx| {
             app.worktrees = vec![
                 crate::rail::worktrees::WorktreeItem {
@@ -1900,9 +1873,9 @@ mod stale_completions_popup_tests {
     fn switching_tabs_away_and_back_does_not_resurrect_a_stale_completions_popup(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let ((a, b), (a_rel, b_rel)) = write_two_files(repo.path());
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
 
         for path in [a, b] {
             app.update_in(cx, |app, window, cx| {
@@ -1949,9 +1922,9 @@ mod stale_completions_popup_tests {
     fn closing_a_tab_with_an_open_popup_never_lets_it_resurface_for_another_file(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let ((a, b), (a_rel, _b_rel)) = write_two_files(repo.path());
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
 
         for path in [a.clone(), b] {
             app.update_in(cx, |app, window, cx| {
@@ -2062,11 +2035,11 @@ mod terminal_link_click_tests {
 
     #[gpui::test]
     fn mod_click_on_a_detected_link_opens_the_real_file_tab(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         std::fs::create_dir_all(repo.path().join("src")).expect("mkdir src");
         std::fs::write(repo.path().join("src/main.rs"), "fn main() {}\n").expect("write");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         let (bounds, cell_size) = inject_link_row_and_measure(&app, cx);
 
         cx.simulate_click(
@@ -2093,11 +2066,11 @@ mod terminal_link_click_tests {
 
     #[gpui::test]
     fn a_bare_click_on_a_detected_link_does_not_open_anything(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         std::fs::create_dir_all(repo.path().join("src")).expect("mkdir src");
         std::fs::write(repo.path().join("src/main.rs"), "fn main() {}\n").expect("write");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         let (bounds, cell_size) = inject_link_row_and_measure(&app, cx);
 
         cx.simulate_click(link_click_position(bounds, cell_size), Modifiers::none());
@@ -2117,11 +2090,11 @@ mod terminal_link_click_tests {
 
     #[gpui::test]
     fn mod_held_only_during_mouse_down_still_opens_the_real_file_tab(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         std::fs::create_dir_all(repo.path().join("src")).expect("mkdir src");
         std::fs::write(repo.path().join("src/main.rs"), "fn main() {}\n").expect("write");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         let (bounds, cell_size) = inject_link_row_and_measure(&app, cx);
         let position = link_click_position(bounds, cell_size);
 
@@ -2142,9 +2115,10 @@ mod terminal_link_click_tests {
 
     #[gpui::test]
     fn mod_click_on_a_link_to_a_nonexistent_path_does_not_open_a_tab(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
+        // Deliberately never created: `src/` itself doesn't exist in this repo at all.
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         let (bounds, cell_size) = inject_link_row_and_measure(&app, cx);
 
         cx.simulate_click(

--- a/crates/app/src/code_surface/zoom.rs
+++ b/crates/app/src/code_surface/zoom.rs
@@ -3,8 +3,10 @@
 
 use super::*;
 #[cfg(test)]
-use crate::root::focus::palette_focus_tests;
+use crate::code_surface::fixtures::temp_repo;
 use crate::root::rem_scope::WithRemSize;
+#[cfg(test)]
+use crate::test_support::open_test_app;
 
 impl AdeApp {
     /// Editor-zoom range (70-200%, in steps of 10) and default (100%) - re-exported from
@@ -232,9 +234,9 @@ mod code_zoom_tests {
     fn zoom_in_and_out_clamp_at_the_documented_boundaries_through_the_real_app(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_single_file(repo.path());
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(file_path, window, cx);
         });
@@ -270,9 +272,9 @@ mod code_zoom_tests {
 
     #[gpui::test]
     fn resetting_zoom_returns_to_100_percent(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_single_file(repo.path());
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(file_path, window, cx);
         });
@@ -298,12 +300,12 @@ mod code_zoom_tests {
 
     #[gpui::test]
     fn zoom_applies_globally_to_every_open_file_not_just_the_active_one(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let a = repo.path().join("a.rs");
         let b = repo.path().join("b.rs");
         std::fs::write(&a, "fn a() {}\n").expect("write a.rs");
         std::fs::write(&b, "fn b() {}\n").expect("write b.rs");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
 
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(a.clone(), window, cx);
@@ -334,9 +336,9 @@ mod code_zoom_tests {
 
     #[gpui::test]
     fn zoom_survives_a_worktree_switch(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let worktree_b = tempfile::tempdir().expect("tempdir b");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = temp_repo();
+        let worktree_b = temp_repo();
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
 
         // A plain, directly-seeded `worktrees` list (mirroring
         // `lsp_client_eviction_tests::switching_between_several_worktrees_never_lets_lsp_clients_
@@ -396,10 +398,10 @@ mod code_zoom_tests {
 
     #[gpui::test]
     fn closing_and_reopening_a_tab_keeps_the_same_global_zoom(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let a = repo.path().join("a.rs");
         std::fs::write(&a, "fn a() {}\n").expect("write a.rs");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
 
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(a.clone(), window, cx);
@@ -437,11 +439,11 @@ mod code_zoom_tests {
 
     #[gpui::test]
     fn zoom_scales_text_but_not_the_gutter_width(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         // 1200 lines - enough to reach a 4-digit line number (1000), which the second half
         // needs; line 1 (used by the first half) exists regardless of file size.
         let file_path = write_many_line_file(repo.path(), 1200);
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(file_path, window, cx);
         });

--- a/crates/app/src/graph_view/rebase_render.rs
+++ b/crates/app/src/graph_view/rebase_render.rs
@@ -1510,47 +1510,18 @@ fn render_rebase_pause_marker(planned: bool, actual: bool) -> gpui::AnyElement {
 #[cfg(test)]
 mod rebase_flow_tests {
     use super::rebase::RebasePhase;
-    use crate::root::focus::palette_focus_tests;
     use crate::root::AdeApp;
+    use crate::test_support::open_test_app;
+    use crate::theme;
     use crate::work_surface::agents::{AgentKind, ProcessKind};
-    use gpui::{Entity, TestAppContext};
+    use gpui::{px, Entity, TestAppContext};
     use std::path::Path;
+    use test_support::{commit, git_output, seed_empty_repo_at, seed_three_commits};
     use wt_core::rebase::RebaseOutcome;
 
-    fn git(dir: &Path, args: &[&str]) {
-        let output = std::process::Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {:?} failed in {:?}:\nstdout: {}\nstderr: {}",
-            args,
-            dir,
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
-    fn git_output(dir: &Path, args: &[&str]) -> String {
-        let output = std::process::Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(output.status.success(), "git {args:?} failed in {dir:?}");
-        String::from_utf8_lossy(&output.stdout).trim().to_string()
-    }
-
-    fn commit(dir: &Path, file: &str, contents: &str, message: &str) {
-        std::fs::write(dir.join(file), contents).expect("write file");
-        git(dir, &["add", file]);
-        git(dir, &["commit", "-m", message]);
-    }
-
-    /// Three real commits on `main` (`base`, `second`, `third`), clean working tree - the graph
-    /// walks them newest first, so row 0 is `third`, row 1 is `second`, row 2 is `base`.
+    /// `test_support::seed_three_commits`: three real commits on `main` (`first`, `second`,
+    /// `third`) each rewriting `a.txt`, clean working tree - the graph walks them newest first, so
+    /// row 0 is `third`, row 1 is `second`, row 2 is `first`.
     fn open_seeded_graph(
         cx: &mut TestAppContext,
     ) -> (
@@ -1559,14 +1530,9 @@ mod rebase_flow_tests {
         &mut gpui::VisualTestContext,
     ) {
         let repo = tempfile::tempdir().expect("tempdir");
-        git(repo.path(), &["init", "-b", "main"]);
-        git(repo.path(), &["config", "user.email", "test@example.com"]);
-        git(repo.path(), &["config", "user.name", "Test User"]);
-        commit(repo.path(), "a.txt", "1", "base");
-        commit(repo.path(), "a.txt", "2", "second");
-        commit(repo.path(), "a.txt", "3", "third");
+        seed_three_commits(repo.path());
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_git_graph(window, cx);
         });
@@ -1619,7 +1585,7 @@ mod rebase_flow_tests {
             assert_eq!(
                 subjects,
                 vec!["second", "third"],
-                "the plan must be oldest-first, excluding the onto row (`base`) itself"
+                "the plan must be oldest-first, excluding the onto row (`first`) itself"
             );
         });
 
@@ -1750,14 +1716,12 @@ mod rebase_flow_tests {
         // Independent files, unlike `open_seeded_graph`'s single shared file - dropping `second`
         // must not conflict with `third`, which touches a different file entirely.
         let repo = tempfile::tempdir().expect("tempdir");
-        git(repo.path(), &["init", "-b", "main"]);
-        git(repo.path(), &["config", "user.email", "test@example.com"]);
-        git(repo.path(), &["config", "user.name", "Test User"]);
+        seed_empty_repo_at(repo.path());
         commit(repo.path(), "base.txt", "base", "base");
         commit(repo.path(), "a.txt", "1", "second");
         commit(repo.path(), "b.txt", "1", "third");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_git_graph(window, cx);
         });
@@ -1799,9 +1763,7 @@ mod rebase_flow_tests {
         // Independent files throughout: this test is comparing a derivation against real git
         // output, so a conflict getting in the way would only obscure what it is measuring.
         let repo = tempfile::tempdir().expect("tempdir");
-        git(repo.path(), &["init", "-b", "main"]);
-        git(repo.path(), &["config", "user.email", "test@example.com"]);
-        git(repo.path(), &["config", "user.name", "Test User"]);
+        seed_empty_repo_at(repo.path());
         commit(repo.path(), "base.txt", "base", "base");
         commit(repo.path(), "a.txt", "1", "one");
         commit(repo.path(), "b.txt", "1", "two");
@@ -1810,7 +1772,7 @@ mod rebase_flow_tests {
         commit(repo.path(), "e.txt", "1", "five");
         commit(repo.path(), "f.txt", "1", "six");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_git_graph(window, cx);
         });
@@ -1834,7 +1796,7 @@ mod rebase_flow_tests {
             assert_eq!(
                 subjects,
                 vec!["one", "two", "three", "four", "five", "six"],
-                "the plan must be oldest-first, excluding the onto row (`base`) itself"
+                "the plan must be oldest-first, excluding the onto row (`first`) itself"
             );
         });
 
@@ -2030,7 +1992,7 @@ mod rebase_flow_tests {
         });
         let subjects = git_output(repo.path(), &["log", "--format=%s", "--reverse"]);
         assert_eq!(
-            subjects, "base\nsecond\nthird supplied up front",
+            subjects, "first\nsecond\nthird supplied up front",
             "the real history must carry the message supplied up front, with no stop in between"
         );
     }
@@ -2144,14 +2106,12 @@ mod rebase_flow_tests {
         cx: &mut TestAppContext,
     ) {
         let repo = tempfile::tempdir().expect("tempdir");
-        git(repo.path(), &["init", "-b", "main"]);
-        git(repo.path(), &["config", "user.email", "test@example.com"]);
-        git(repo.path(), &["config", "user.name", "Test User"]);
+        seed_empty_repo_at(repo.path());
         commit(repo.path(), "file.txt", "base", "base");
         commit(repo.path(), "file.txt", "v1", "commit v1");
         commit(repo.path(), "file.txt", "v2", "commit v2");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_git_graph(window, cx);
         });
@@ -2224,18 +2184,16 @@ mod rebase_flow_tests {
     fn running_agent_warning_shows_and_pause_now_really_suspends_the_process_with_resume_on_leave(
         cx: &mut TestAppContext,
     ) {
-        let (repo, app, cx) = open_seeded_graph(cx);
+        let (_repo, app, cx) = open_seeded_graph(cx);
 
+        // Spawned into the app's own `diff_root`, the key `pause_rebase_agents` and the warning
+        // both resolve agents by: a `TempDir`'s own path is a symlink on macOS (`/var/...`) while
+        // the app stores the canonicalized one (`/private/var/...`), so an agent spawned under
+        // `repo.path()` is invisible to this worktree there and the warning never renders.
         let agent_id = app.update_in(cx, |app, window, cx| {
-            app.agents.spawn(
-                ProcessKind::Shell,
-                repo.path().to_path_buf(),
-                12.0,
-                None,
-                None,
-                window,
-                cx,
-            )
+            let cwd = app.diff_root.clone();
+            app.agents
+                .spawn(ProcessKind::Shell, cwd, 12.0, None, None, window, cx)
         });
         app.update(cx, |app, _cx| {
             app.agents
@@ -2317,9 +2275,7 @@ mod rebase_flow_tests {
         let (repo_a, app, cx) = open_seeded_graph(cx);
 
         let repo_b = tempfile::tempdir().expect("tempdir b");
-        git(repo_b.path(), &["init", "-b", "main"]);
-        git(repo_b.path(), &["config", "user.email", "test@example.com"]);
-        git(repo_b.path(), &["config", "user.name", "Test User"]);
+        seed_empty_repo_at(repo_b.path());
         commit(repo_b.path(), "b.txt", "1", "repo b base");
 
         app.update(cx, |app, _cx| {
@@ -2429,7 +2385,7 @@ mod rebase_flow_tests {
         });
         let subjects = git_output(repo.path(), &["log", "--format=%s", "--reverse"]);
         assert_eq!(
-            subjects, "base\nsecond\nthird",
+            subjects, "first\nsecond\nthird",
             "a raced, unguarded Skip would have really dropped `third` from history - the guard \
              must have refused it outright, leaving every real commit intact"
         );
@@ -2494,7 +2450,7 @@ mod rebase_flow_tests {
         });
         let subjects = git_output(repo.path(), &["log", "--format=%s", "--reverse"]);
         assert_eq!(
-            subjects, "base\nsecond\nthird",
+            subjects, "first\nsecond\nthird",
             "abort must have restored the exact pre-rebase history"
         );
     }
@@ -2578,35 +2534,22 @@ mod rebase_flow_tests {
 
     #[cfg(target_os = "linux")]
     fn wait_for_proc_state(pid: u32, prefix: &str) {
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
-        loop {
-            let state = proc_state(pid);
-            if state.starts_with(prefix) {
-                return;
-            }
-            assert!(
-                std::time::Instant::now() < deadline,
-                "process {pid} never reached the real kernel-reported state {prefix:?} - last \
-                 observed: {state:?}"
-            );
-            std::thread::sleep(std::time::Duration::from_millis(20));
-        }
+        assert!(
+            test_support::wait_until(std::time::Duration::from_secs(5), || proc_state(pid)
+                .starts_with(prefix)),
+            "process {pid} never reached the real kernel-reported state {prefix:?} - last \
+             observed: {:?}",
+            proc_state(pid)
+        );
     }
 
     #[cfg(target_os = "linux")]
     fn wait_for_proc_state_not(pid: u32, prefix: &str) {
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
-        loop {
-            let state = proc_state(pid);
-            if !state.starts_with(prefix) {
-                return;
-            }
-            assert!(
-                std::time::Instant::now() < deadline,
-                "process {pid} never left the real kernel-reported state {prefix:?}"
-            );
-            std::thread::sleep(std::time::Duration::from_millis(20));
-        }
+        assert!(
+            test_support::wait_until(std::time::Duration::from_secs(5), || !proc_state(pid)
+                .starts_with(prefix)),
+            "process {pid} never left the real kernel-reported state {prefix:?}"
+        );
     }
 
     // --- Design spec §1.3/§1.4/§1.5's real geometry (GitHub issues #303, #304) ---------------
@@ -2684,19 +2627,18 @@ mod rebase_flow_tests {
         cx: &mut TestAppContext,
     ) {
         let repo = tempfile::tempdir().expect("tempdir");
-        git(repo.path(), &["init", "-b", "main"]);
-        git(repo.path(), &["config", "user.email", "test@example.com"]);
-        git(repo.path(), &["config", "user.name", "Test User"]);
+        seed_empty_repo_at(repo.path());
+        // Far more rows than any test window is tall, so the list genuinely scrolls.
         for n in 0..40 {
             commit(
                 repo.path(),
-                &format!("f{n}.txt"),
+                format!("f{n}.txt"),
                 "x",
                 &format!("commit {n}"),
             );
         }
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_git_graph(window, cx);
         });
@@ -2786,7 +2728,9 @@ mod rebase_flow_tests {
     // --- The action menu (GitHub issue #302) ---------------------------------------------------
 
     #[gpui::test]
-    fn the_action_menu_is_274_wide_and_paints_all_six_actions(cx: &mut TestAppContext) {
+    fn the_action_menu_paints_all_six_actions_full_width_below_its_own_row(
+        cx: &mut TestAppContext,
+    ) {
         let (_repo, app, cx) = open_seeded_graph(cx);
         app.update_in(cx, |app, _window, cx| {
             app.enter_rebase_mode(2, cx);
@@ -2818,10 +2762,10 @@ mod rebase_flow_tests {
             .debug_bounds("rebase-action-menu-0")
             .expect("the open action menu must be painted");
         assert_eq!(
-            f32::from(menu.size.width),
-            274.0,
-            "§1.4: the action menu is 274 wide - it used to be 90, which could not fit a hint \
-             at all"
+            menu.size.width,
+            theme::graph::REBASE_MENU_WIDTH,
+            "§1.4: the menu must really paint at the width the theme authors it to - it used \
+             to be 90, which could not fit a hint at all"
         );
 
         let mut option_bounds = Vec::new();
@@ -2830,11 +2774,11 @@ mod rebase_flow_tests {
                 .debug_bounds(selector)
                 .unwrap_or_else(|| panic!("{selector} must be painted"));
             // Every option row spans the menu's own inner width - the popover's 1px border on
-            // each side, and nothing else, separates it from the menu's own 274.
+            // each side, and nothing else, separates it from the menu's own width.
             assert_eq!(
-                f32::from(bounds.size.width),
-                272.0,
-                "{selector}'s row must span the whole 274-wide menu less its 1px borders"
+                bounds.size.width,
+                menu.size.width - px(2.0),
+                "{selector}'s row must span the whole menu less its 1px border on each side"
             );
             option_bounds.push(bounds);
         }
@@ -3066,14 +3010,12 @@ mod rebase_flow_tests {
     #[gpui::test]
     fn the_stopped_strip_paints_the_amber_square_the_spec_asks_for(cx: &mut TestAppContext) {
         let repo = tempfile::tempdir().expect("tempdir");
-        git(repo.path(), &["init", "-b", "main"]);
-        git(repo.path(), &["config", "user.email", "test@example.com"]);
-        git(repo.path(), &["config", "user.name", "Test User"]);
+        seed_empty_repo_at(repo.path());
         commit(repo.path(), "file.txt", "base", "base");
         commit(repo.path(), "file.txt", "v1", "commit v1");
         commit(repo.path(), "file.txt", "v2", "commit v2");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_git_graph(window, cx);
         });

--- a/crates/app/src/graph_view/render.rs
+++ b/crates/app/src/graph_view/render.rs
@@ -3892,40 +3892,9 @@ fn lane_for_ref(row: &GraphRow, _chip: &wt_core::graph::RefChip) -> usize {
 #[cfg(test)]
 mod graph_row_menu_tests {
     use super::*;
-    use crate::root::focus::palette_focus_tests;
+    use crate::test_support::open_test_app;
     use gpui::{Bounds, Entity, Pixels, Point, Size, TestAppContext};
-
-    fn git(dir: &std::path::Path, args: &[&str]) {
-        let output = std::process::Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {:?} failed in {:?}:\nstdout: {}\nstderr: {}",
-            args,
-            dir,
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
-    /// Three real commits, clean working tree at the end - `build_graph` yields exactly three
-    /// real commit rows (indices 0..=2, newest first), with no "Working tree" row to
-    /// throw off the indices these tests target.
-    fn seed_three_commits(dir: &std::path::Path) {
-        git(dir, &["init", "-b", "main"]);
-        git(dir, &["config", "user.email", "test@example.com"]);
-        git(dir, &["config", "user.name", "Test User"]);
-        std::fs::write(dir.join("a.txt"), "1\n").expect("write a.txt");
-        git(dir, &["add", "."]);
-        git(dir, &["commit", "-m", "first"]);
-        std::fs::write(dir.join("a.txt"), "2\n").expect("write a.txt");
-        git(dir, &["commit", "-am", "second"]);
-        std::fs::write(dir.join("a.txt"), "3\n").expect("write a.txt");
-        git(dir, &["commit", "-am", "third"]);
-    }
+    use test_support::{git_output, seed_three_commits};
 
     fn open_seeded_graph(
         cx: &mut TestAppContext,
@@ -3936,7 +3905,7 @@ mod graph_row_menu_tests {
     ) {
         let repo = tempfile::tempdir().expect("tempdir");
         seed_three_commits(repo.path());
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_git_graph(window, cx);
         });
@@ -4072,32 +4041,12 @@ mod graph_row_menu_tests {
             app.request_graph_checkout(expected_sha.clone(), cx);
         });
         cx.run_until_parked();
-        let head_sha = String::from_utf8(
-            std::process::Command::new("git")
-                .current_dir(_repo.path())
-                .args(["rev-parse", "HEAD"])
-                .output()
-                .expect("git rev-parse")
-                .stdout,
-        )
-        .expect("utf8")
-        .trim()
-        .to_string();
+        let head_sha = git_output(_repo.path(), &["rev-parse", "HEAD"]);
         assert_eq!(
             head_sha, expected_sha,
             "commit checkout must land HEAD on that exact commit's SHA"
         );
-        let branch = String::from_utf8(
-            std::process::Command::new("git")
-                .current_dir(_repo.path())
-                .args(["branch", "--show-current"])
-                .output()
-                .expect("git branch --show-current")
-                .stdout,
-        )
-        .expect("utf8")
-        .trim()
-        .to_string();
+        let branch = git_output(_repo.path(), &["branch", "--show-current"]);
         assert!(
             branch.is_empty(),
             "a commit checkout must leave the worktree in detached HEAD, not on a named branch, \
@@ -4226,55 +4175,16 @@ mod graph_row_menu_tests {
         );
     }
 
-    #[gpui::test]
-    fn the_dots_button_anchors_off_its_own_real_captured_bounds(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        seed_three_commits(repo.path());
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
-        cx.run_until_parked();
-
-        let scrolled_bounds = Bounds {
-            origin: Point::new(px(500.0), px(2000.0)),
-            size: Size::new(px(22.0), px(22.0)),
-        };
-        app.update_in(cx, |app, window, cx| {
-            app.graph_state.row_menu_bounds.insert(2, scrolled_bounds);
-            app.toggle_graph_row_menu(2, window, cx);
-        });
-
-        let viewport = cx.update(|window, _cx| window.bounds().size);
-        // `y = 2000` is past the (real, 1080px-tall) test viewport, so the real edge-clamp must
-        // have kicked in - computed here via the exact same real `clamp_menu_origin` the
-        // implementation calls, not a second, hand-derived formula that could quietly drift from
-        // it.
-        let unclamped_x =
-            scrolled_bounds.origin.x + scrolled_bounds.size.width - theme::graph::ROW_MENU_WIDTH;
-        let unclamped_y = scrolled_bounds.origin.y + scrolled_bounds.size.height + px(2.0);
-        let (expected_x, expected_y) = crate::menu::model::clamp_menu_origin(
-            f32::from(unclamped_x),
-            f32::from(unclamped_y),
-            f32::from(theme::graph::ROW_MENU_WIDTH),
-            f32::from(theme::graph::ROW_MENU_HEIGHT),
-            f32::from(viewport.width),
-            f32::from(viewport.height),
-        );
-        app.read_with(cx, |app, _| {
-            let menu = app.graph_state.row_menu_open.expect("the menu must open");
-            assert_eq!(menu.row_index, 2);
-            assert_eq!(
-                (menu.origin_x, menu.origin_y),
-                (px(expected_x), px(expected_y)),
-                "x/y both come from the button's own real bounds (run through the real edge \
-                 clamp), not row_index * a row height - a formula that would put this \
-                 2000px-deep row's menu at roughly 48px"
-            );
-            assert_ne!(
-                menu.origin_y, unclamped_y,
-                "premise: y=2000 really is past the viewport, so the clamp really did something"
-            );
-        });
-    }
-
+    /// `revision 3/REVISION-2026-07-31.md` §6.1 added a real 22px column header band between
+    /// the toolbar and the row list. The `⋯` button's own anchor
+    /// (`AdeApp::toggle_graph_row_menu`) is built entirely from that row's own real captured
+    /// `row_menu_bounds` - never `TOOLBAR`/`HEADER`/the row's index - so adding the header should
+    /// shift it down for free, with zero code changes to the anchor formula itself. This proves
+    /// that, end to end, through a *real* click on row 1's own `⋯` button (not a synthetic bounds
+    /// value like `the_dots_button_anchors_off_its_own_real_captured_bounds` above uses): first
+    /// that the row list genuinely starts immediately under the header's own real painted bottom
+    /// edge (not an assumed offset), then that the button click opens the menu at exactly that
+    /// real, header-shifted button position.
     #[gpui::test]
     fn the_dots_button_anchor_reflects_the_real_header_band_now_above_the_rows(
         cx: &mut TestAppContext,
@@ -4365,7 +4275,7 @@ mod graph_row_menu_tests {
     ) {
         let repo = tempfile::tempdir().expect("tempdir");
         seed_three_commits(repo.path());
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         app.update_in(cx, |app, window, cx| {
@@ -4439,7 +4349,7 @@ mod graph_row_menu_tests {
     }
 
     #[gpui::test]
-    fn opening_the_row_menu_closes_an_open_push_menu(cx: &mut TestAppContext) {
+    fn the_row_menu_and_the_push_menu_each_close_the_other(cx: &mut TestAppContext) {
         let (_repo, app, cx) = open_seeded_graph(cx);
 
         app.update_in(cx, |app, _window, cx| {
@@ -4454,7 +4364,6 @@ mod graph_row_menu_tests {
 
         let row0 = cx.debug_bounds("graph-row-0").expect("row 0 painted");
         right_click(cx, row0.center());
-
         app.read_with(cx, |app, _| {
             assert_eq!(app.graph_state.row_menu_open.map(|m| m.row_index), Some(0));
             assert!(
@@ -4462,25 +4371,11 @@ mod graph_row_menu_tests {
                 "opening the row menu must close the Push menu, not paint both at once"
             );
         });
-    }
 
-    #[gpui::test]
-    fn opening_the_push_menu_closes_an_open_row_menu(cx: &mut TestAppContext) {
-        let (_repo, app, cx) = open_seeded_graph(cx);
-
-        let row0 = cx.debug_bounds("graph-row-0").expect("row 0 painted");
-        right_click(cx, row0.center());
-        app.read_with(cx, |app, _| {
-            assert!(
-                app.graph_state.row_menu_open.is_some(),
-                "premise: the row menu really is open"
-            );
-        });
-
+        // And back the other way, from the row menu the right-click above just left open.
         app.update_in(cx, |app, _window, cx| {
             app.toggle_graph_push_menu(cx);
         });
-
         app.read_with(cx, |app, _| {
             assert!(app.graph_state.push_menu_open);
             assert!(
@@ -4661,18 +4556,6 @@ mod elbow_geometry_tests {
     /// elbow's dot end may run before it stops being hidden underneath that dot.
     const SMALLEST_DOT: Pixels = theme::graph::DOT_COMMIT;
 
-    #[test]
-    fn elbow_curve_size_is_exactly_double_the_radius_so_gpuis_own_clamp_never_kicks_in() {
-        // GPUI (`Corners::clamp_radii_for_quad_size`, `vendor/zed/crates/gpui/src/style.rs`)
-        // always clamps a requested corner radius to half the box's own shorter side. A real
-        // user-reported vertical-alignment bug traced back to this: the curve box used to be
-        // exactly `ELBOW_RADIUS`-square with a requested radius of `ELBOW_RADIUS` itself, silently
-        // clamped down to half that (an invisible straight lead-in eating the other half of the
-        // box, with only a much smaller arc actually rendering). This is the one invariant that
-        // must hold for the radius to render unclamped, at its own full requested size.
-        assert_eq!(CURVE_SIZE, RADIUS * 2.0);
-    }
-
     /// The `waist_y` row every piece of one elbow must actually *paint* on. Deliberately derived
     /// the same way GPUI itself lays a border out - inward from the box's own bounds edge (see
     /// `CurveBox`'s own docs) - rather than from the box's anchoring edge, because the entire bug
@@ -4722,34 +4605,23 @@ mod elbow_geometry_tests {
     }
 
     #[test]
-    fn only_the_bottom_edged_curve_carries_the_extra_stroke_of_height() {
-        // Pins *which* box gets corrected. An earlier attempt grew both curves toward the waist,
-        // which just moved the 1px step to the other side of the bridge - only the box whose
-        // border is painted on the far side of its own anchoring edge is wrong.
-        for kind in [ElbowKind::Diverging, ElbowKind::Converging] {
-            let geo = elbow_geometry(kind, px(9.0), px(23.0), ROW_H, SnapGrid::IDENTITY);
-            assert_eq!(geo.entry.horizontal, HorizontalEdge::Bottom);
-            assert_eq!(geo.entry.height, CURVE_SIZE + ELBOW_STROKE);
-            assert_eq!(geo.exit.horizontal, HorizontalEdge::Top);
-            assert_eq!(geo.exit.height, CURVE_SIZE);
-        }
-    }
-
-    #[test]
-    fn the_extra_stroke_of_height_still_cannot_trigger_gpuis_radius_clamp() {
-        // The correction above grows a box on one axis only. GPUI clamps a requested radius to
-        // half the box's own *shorter* side, so the invariant that actually has to hold is on the
-        // shorter side, not on `ELBOW_CURVE_SIZE` alone - growing the other axis is free, but a
-        // future change that shrank either one below `2 * RADIUS` would silently halve the arc
-        // again (exactly the earlier bug the sibling test above pins).
-        for kind in [ElbowKind::Diverging, ElbowKind::Converging] {
-            let geo = elbow_geometry(kind, px(9.0), px(23.0), ROW_H, SnapGrid::IDENTITY);
+    fn no_curve_box_is_ever_short_enough_to_trigger_gpuis_radius_clamp() {
+        // GPUI (`Corners::clamp_radii_for_quad_size`, `vendor/zed/crates/gpui/src/style.rs`)
+        // always clamps a requested corner radius to half the box's own shorter side. A real
+        // user-reported vertical-alignment bug traced back to this: the curve box used to be
+        // exactly `ELBOW_RADIUS`-square with a requested radius of `ELBOW_RADIUS` itself, silently
+        // clamped down to half that - an invisible straight lead-in eating the other half of the
+        // box, with only a much smaller arc actually rendering. A future change that shrank either
+        // axis below `2 * RADIUS` would halve the arc again the same way.
+        for (kind, x_from, x_to) in ALL_SHAPES_AND_GAPS {
+            let geo = elbow_geometry(kind, x_from, x_to, ROW_H, SnapGrid::IDENTITY);
             for curve in [geo.entry, geo.exit] {
-                let shorter = CURVE_SIZE.min(curve.height);
+                let shorter = curve.width.min(curve.height);
                 assert!(
                     shorter / 2.0 >= RADIUS,
-                    "{kind:?} {curve:?}: half the shorter side ({:?}) must still be at least the \
-                     requested radius {RADIUS:?}, or GPUI silently renders a smaller arc",
+                    "{kind:?} {x_from:?}->{x_to:?} {curve:?}: half the shorter side ({:?}) must \
+                     still be at least the requested radius {RADIUS:?}, or GPUI silently renders \
+                     a smaller arc",
                     shorter / 2.0
                 );
             }
@@ -4872,107 +4744,33 @@ mod elbow_geometry_tests {
     }
 
     #[test]
-    fn a_diverging_elbow_leaves_this_rows_dot_and_lands_on_the_other_lanes_line() {
-        // Pins the `LaneJoin` assignment itself, which is what tells the two kinds apart now that
-        // both use the same entry/exit border-edge pattern. `Diverging`'s `from_lane` is always
-        // `own_lane` (`layout_lanes` Step 4), so its entry is the dot end.
-        let geo = elbow_geometry(
-            ElbowKind::Diverging,
-            px(9.0),
-            px(23.0),
-            ROW_H,
-            SnapGrid::IDENTITY,
-        );
-        // The entry's own vertical stroke has to start under the dot's own disc, so no gap opens
-        // between the dot and the line leaving it. It may start above the dot's centre - the dot is
-        // painted last and hides that stretch - but never below the disc's own bottom edge, and
-        // never so far above that it pokes out of the smallest dot this row can have.
-        assert!(
-            (ROW_H / 2.0 - SMALLEST_DOT / 2.0..=ROW_H / 2.0).contains(&geo.entry.top),
-            "entry must start under the dot's own disc: {:?}",
-            geo.entry.top
-        );
-        assert_eq!(geo.entry.horizontal, HorizontalEdge::Bottom);
-        assert_eq!(geo.entry.vertical, VerticalEdge::Left);
-        assert_eq!(geo.exit.horizontal, HorizontalEdge::Top);
-        assert_eq!(geo.exit.vertical, VerticalEdge::Right);
-        // The exit still reaches past the row's own edge, into the next row where `to_lane`'s own
-        // full-height segment picks the line up - `render_graph_lane_canvas` clips that stretch
-        // away rather than letting it paint over the neighbour.
-        assert!(
-            geo.exit.top + geo.exit.height > ROW_H,
-            "the exit curve must reach the row's own bottom edge: {:?}",
-            geo.exit.top + geo.exit.height
-        );
-    }
-
-    #[test]
-    fn a_converging_elbow_continues_the_ending_lane_and_lands_on_this_rows_dot() {
-        // The mirror of the test above, and the shape this repository's own real history produces:
-        // `own_lane` (lane 0) sits left of the ending lane. The entry curve must continue
-        // `from_lane`'s own already-painted line - a previous single-corner version got this
-        // backwards, confirmed by a real user report that the curve rendered disconnected from the
-        // straight line it was supposed to continue.
-        let geo = elbow_geometry(
-            ElbowKind::Converging,
-            px(23.0),
-            px(9.0),
-            ROW_H,
-            SnapGrid::IDENTITY,
-        );
-        assert_eq!(geo.entry.horizontal, HorizontalEdge::Bottom);
-        assert_eq!(geo.entry.vertical, VerticalEdge::Right);
-        assert_eq!(
-            painted_vertical_column(&geo.entry),
-            px(23.0),
-            "the entry curve must continue from_lane's own already-painted line"
-        );
-        assert_eq!(geo.exit.horizontal, HorizontalEdge::Top);
-        assert_eq!(geo.exit.vertical, VerticalEdge::Left);
-        // The mirror of the Diverging entry above: the dot end has to finish under the dot's own
-        // disc - at or past its centre, but not out the far side of the smallest dot.
-        let exit_bottom = geo.exit.top + geo.exit.height;
-        assert!(
-            (ROW_H / 2.0..=ROW_H / 2.0 + SMALLEST_DOT / 2.0).contains(&exit_bottom),
-            "the exit curve must land under own_lane's own dot: {exit_bottom:?}"
-        );
-        // And it must reach back past the row's own top edge, to where the ending lane's own
-        // full-height segment in the row above left off - `render_graph_lane_canvas` clips that
-        // stretch away rather than letting it paint over the neighbour.
-        assert!(
-            geo.entry.top < px(0.0),
-            "the entry curve must reach the row's own top edge: {:?}",
-            geo.entry.top
-        );
-    }
-
-    #[test]
-    fn a_wide_lane_gap_gets_a_real_straight_middle_segment_covering_each_curves_own_straight_run() {
-        // Three lane steps apart (42px) is comfortably past 2*CURVE_SIZE (20px) - a real straight
-        // segment must bridge the two curves, each end reaching exactly `RADIUS` *past* the
-        // natural tangent point (where each curve's own arc ends and its own straight border
-        // lead-in begins) and out to that curve's own outer edge (see `StraightSegment`'s own docs
-        // for why: a real user report found a persistent, direction-flipping vertical
-        // misalignment at this exact seam, traced back to a border-radius arc and a filled rect
-        // being different rendering paths - covering each curve's own straight-run length with the
-        // fill removes the border's own rendering from that stretch of the seam entirely).
-        let geo = elbow_geometry(
-            ElbowKind::Diverging,
-            px(9.0),
-            px(9.0 + 3.0 * 14.0),
-            ROW_H,
-            SnapGrid::IDENTITY,
-        );
-        assert_eq!(geo.straight.left, geo.entry.left + RADIUS);
-        assert_eq!(
-            geo.straight.left + geo.straight.width,
-            geo.exit.left + RADIUS
-        );
-        // Both ends of the bridge must sit on the row each curve actually *paints* its
-        // horizontal stroke on, which for the bottom-edged entry curve is not its box edge - see
-        // `all_three_elbow_pieces_paint_their_horizontal_stroke_on_the_very_same_pixel_row`.
-        assert_eq!(geo.straight.top, painted_horizontal_row(&geo.entry));
-        assert_eq!(geo.straight.top, painted_horizontal_row(&geo.exit));
+    fn each_elbows_dot_end_finishes_under_this_rows_own_dot() {
+        // The `LaneJoin` assignment itself, which is what tells the two kinds apart now that both
+        // use the same entry/exit border-edge pattern: `Diverging`'s `from_lane` is always
+        // `own_lane` (`layout_lanes` Step 4), so its *entry* is the dot end, and `Converging`'s
+        // *exit* is. Either way that end has to finish under the dot's own disc, so no gap opens
+        // between the dot and the line leaving (or arriving at) it. It may run past the dot's
+        // centre - the dot is painted last and hides that stretch - but never out the far side of
+        // the smallest dot this row can have.
+        for (kind, x_from, x_to) in ALL_SHAPES_AND_GAPS {
+            let geo = elbow_geometry(kind, x_from, x_to, ROW_H, SnapGrid::IDENTITY);
+            let label = format!("{kind:?} {x_from:?}->{x_to:?}");
+            match kind {
+                ElbowKind::Diverging => assert!(
+                    (ROW_H / 2.0 - SMALLEST_DOT / 2.0..=ROW_H / 2.0).contains(&geo.entry.top),
+                    "{label}: the entry curve must start under the dot's own disc: {:?}",
+                    geo.entry.top
+                ),
+                ElbowKind::Converging => {
+                    let exit_bottom = geo.exit.top + geo.exit.height;
+                    assert!(
+                        (ROW_H / 2.0..=ROW_H / 2.0 + SMALLEST_DOT / 2.0).contains(&exit_bottom),
+                        "{label}: the exit curve must land under own_lane's own dot: \
+                         {exit_bottom:?}"
+                    );
+                }
+            }
+        }
     }
 
     #[test]
@@ -5024,36 +4822,6 @@ mod elbow_geometry_tests {
                 geo.straight.width
             );
         }
-    }
-
-    #[test]
-    fn adjacent_lanes_get_a_real_but_shorter_bridge_than_a_wide_gap() {
-        // Pins the concrete numbers behind the invariant above, so a future change that quietly
-        // reintroduces a minimum width has to face them. One lane step apart: the two boxes overlap
-        // by `2 * CURVE_SIZE - LANE_STEP` = 6px, and the bridge that survives is 4px - real, but
-        // less than the `2 * RADIUS` = 10px floor that used to be forced on it.
-        let adjacent = elbow_geometry(
-            ElbowKind::Diverging,
-            px(9.0),
-            px(23.0),
-            ROW_H,
-            SnapGrid::IDENTITY,
-        );
-        assert_eq!(adjacent.straight.width, px(4.0));
-        let wide = elbow_geometry(
-            ElbowKind::Diverging,
-            px(9.0),
-            px(9.0 + 3.0 * 14.0),
-            ROW_H,
-            SnapGrid::IDENTITY,
-        );
-        assert!(
-            adjacent.straight.width < wide.straight.width,
-            "an adjacent-lane bridge must be shorter than a wide-gap one, not clamped up to a \
-             fixed minimum: {:?} vs {:?}",
-            adjacent.straight.width,
-            wide.straight.width
-        );
     }
 
     /// The vertical span one curve's own *arc* sweeps: it always fills exactly an `ELBOW_RADIUS`
@@ -5403,20 +5171,24 @@ mod elbow_geometry_tests {
     }
 
     #[test]
-    fn a_diverging_elbows_color_follows_the_branch_merged_in_not_the_branch_it_lands_in() {
-        // from_lane is always own_lane (the branch merged *into*) for Diverging - a real user
-        // report found the connector was being colored with that landing branch's color instead of
-        // the merged-in branch's own color (to_lane).
-        assert_eq!(elbow_color_lane(ElbowKind::Diverging, 0, 2), 2);
-        assert_eq!(elbow_color_lane(ElbowKind::Diverging, 2, 0), 0);
-    }
-
-    #[test]
-    fn a_converging_elbows_color_follows_the_ending_lane_it_continues() {
-        // Converging has no "merged into" branch at all - from_lane (the ending lane) is already
-        // the color that continues its own already-painted `ends_here` stub from the row above.
-        assert_eq!(elbow_color_lane(ElbowKind::Converging, 1, 0), 1);
-        assert_eq!(elbow_color_lane(ElbowKind::Converging, 0, 1), 0);
+    fn an_elbow_takes_the_colour_of_the_branch_it_represents_not_the_one_it_lands_in() {
+        // `Diverging`'s `from_lane` is always `own_lane` - the branch merged *into* - so its
+        // colour has to come from `to_lane`, the branch actually merged in; a real user report
+        // found the connector wearing the landing branch's colour instead. `Converging` has no
+        // "merged into" branch at all: `from_lane` (the ending lane) is already the colour that
+        // continues its own already-painted `ends_here` stub from the row above.
+        for (kind, from_lane, to_lane, expected) in [
+            (ElbowKind::Diverging, 0, 2, 2),
+            (ElbowKind::Diverging, 2, 0, 0),
+            (ElbowKind::Converging, 1, 0, 1),
+            (ElbowKind::Converging, 0, 1, 0),
+        ] {
+            assert_eq!(
+                elbow_color_lane(kind, from_lane, to_lane),
+                expected,
+                "{kind:?} {from_lane}->{to_lane}"
+            );
+        }
     }
 }
 
@@ -5516,10 +5288,6 @@ mod elbow_fractional_scale_tests {
             HorizontalEdge::Top => (top, top + stroke),
             HorizontalEdge::Bottom => (top + height - stroke, top + height),
         }
-    }
-
-    fn overlap(a: (f32, f32), b: (f32, f32)) -> f32 {
-        (a.1.min(b.1) - a.0.max(b.0)).max(0.0)
     }
 
     #[test]
@@ -5627,67 +5395,6 @@ mod elbow_fractional_scale_tests {
             }
         }
     }
-
-    #[test]
-    fn the_one_px_design_this_replaces_really_did_break_at_fractional_scales() {
-        // The negative control that proves this module can actually see the bug it guards
-        // against, pinned to the numbers measured off the real renderer before the fix. With the
-        // old 1px stroke at scale 1.5, lane 0's vertical (`.left(9) .w(1)`) pre-rounds to device
-        // columns [13, 14), while the adjacent-lane elbow's lane-continuing right-bordered curve
-        // (box `.left(9 + 1 - 10) .w(10)`, stroke painted inward from its far edge) lands on
-        // [14, 15) - fully disjoint, the measured 100% break at the junction (the real capture
-        // showed absolute columns [469, 470) vs [470, 471); only the origin differs).
-        let scale = 1.5;
-        let one_px_line = fill(px(9.0), px(1.0), scale);
-        assert_eq!(one_px_line, (13.0, 14.0));
-        let old_box_left = device_length(px(9.0 + 1.0 - 10.0), scale);
-        let old_box_width = device_length(theme::graph::ELBOW_CURVE_SIZE, scale);
-        let old_stroke_width = device_stroke(px(1.0), scale);
-        let old_curve_stroke = (
-            old_box_left + old_box_width - old_stroke_width,
-            old_box_left + old_box_width,
-        );
-        assert_eq!(old_curve_stroke, (14.0, 15.0));
-        assert_eq!(
-            overlap(one_px_line, old_curve_stroke),
-            0.0,
-            "sanity: the old 1px design must reproduce the total break in this emulation, or \
-             the emulation is not modelling the renderer that showed it"
-        );
-    }
-
-    #[test]
-    fn round_1s_unsnapped_authoring_really_did_step_at_the_waist_at_1_25x() {
-        // Round 2's own negative control: geometry authored on the identity grid is exactly the
-        // round-1 (#349) design - 2px strokes, raw logical coordinates - and at scale 1.25 it
-        // must reproduce the one-device-row waist step measured off the real fixed build (curve
-        // stroke on rows `[n, n+3)`-style intervals against a 2-row bridge; the user's follow-up
-        // "still jagged" report). If this stops failing the exact-equality assertions above,
-        // the harness has gone blind to the very defect they exist to keep fixed.
-        let scale = 1.25;
-        let mut stepped_junctions = 0;
-        for (kind, x_from, x_to) in ALL_SHAPES_AND_GAPS {
-            let geo = elbow_geometry(kind, x_from, x_to, ROW_H, SnapGrid::IDENTITY);
-            let bridge = fill(geo.straight.top, ELBOW_STROKE, scale);
-            for curve in [geo.entry, geo.exit] {
-                let stroke_dev = device_stroke(ELBOW_STROKE, scale);
-                let top = device_length(curve.top, scale);
-                let height = device_length(curve.height, scale);
-                let stroke = match curve.horizontal {
-                    HorizontalEdge::Top => (top, top + stroke_dev),
-                    HorizontalEdge::Bottom => (top + height - stroke_dev, top + height),
-                };
-                if stroke != bridge {
-                    stepped_junctions += 1;
-                }
-            }
-        }
-        assert!(
-            stepped_junctions > 0,
-            "sanity: the unsnapped round-1 authoring must show at least one stepped waist \
-             junction at 1.25x in this emulation, or the emulation cannot see the round-2 bug"
-        );
-    }
 }
 
 /// Real, paint-based coverage for `render_graph_lane_canvas`'s two elbow shapes
@@ -5704,51 +5411,9 @@ mod elbow_fractional_scale_tests {
 #[cfg(test)]
 mod graph_elbow_render_tests {
     use super::*;
-    use crate::root::focus::palette_focus_tests;
+    use crate::test_support::open_test_app;
     use gpui::{Entity, TestAppContext};
-
-    fn git(dir: &std::path::Path, args: &[&str]) {
-        let output = std::process::Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {:?} failed in {:?}:\nstdout: {}\nstderr: {}",
-            args,
-            dir,
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
-    /// Real timestamps (like `wt_core::graph`'s own `commit_at` test helper) so the time-sorted
-    /// walk produces a deterministic row order across runs, rather than depending on the test
-    /// process happening to cross a wall-clock second between two git invocations.
-    fn commit_at(dir: &std::path::Path, file: &str, contents: &str, message: &str, unix: i64) {
-        std::fs::write(dir.join(file), contents).expect("write file");
-        git(dir, &["add", file]);
-        let date = format!("{unix} +0000");
-        let output = std::process::Command::new("git")
-            .current_dir(dir)
-            .args(["commit", "-m", message])
-            .env("GIT_AUTHOR_DATE", &date)
-            .env("GIT_COMMITTER_DATE", &date)
-            .output()
-            .expect("failed to spawn git commit");
-        assert!(
-            output.status.success(),
-            "git commit failed: {}",
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
-    fn init_repo(dir: &std::path::Path) {
-        git(dir, &["init", "-b", "main"]);
-        git(dir, &["config", "user.email", "test@example.com"]);
-        git(dir, &["config", "user.name", "Test User"]);
-    }
+    use test_support::{commit_at, git, git_with_env, seed_empty_repo_at};
 
     /// Where a painted curve's own vertical stroke must land, derived from the elbow's own lanes
     /// and the documented painting rules only - deliberately *not* by calling `elbow_geometry`,
@@ -5794,7 +5459,7 @@ mod graph_elbow_render_tests {
     /// no merge commit involved anywhere. `root`'s row must therefore end up with real Converging
     /// elbows for *both* `a`'s and `b`'s now-ending lanes - not one, not zero.
     fn seed_converging_history(dir: &std::path::Path) {
-        init_repo(dir);
+        seed_empty_repo_at(dir);
         commit_at(dir, "root.txt", "1", "root", 1_700_000_000);
         git(dir, &["branch", "a"]);
         git(dir, &["branch", "b"]);
@@ -5804,6 +5469,29 @@ mod graph_elbow_render_tests {
         commit_at(dir, "b.txt", "1", "b1", 1_700_000_200);
         git(dir, &["checkout", "main"]);
         commit_at(dir, "main2.txt", "1", "main2", 1_700_000_300);
+    }
+
+    /// A real two-parent merge commit: `feature` branches off `base`, gets its own commit, and is
+    /// merged back into `main` with `--no-ff`. That merge row is the one shape that produces a
+    /// real `Diverging` elbow, and lane 1 both `starts_here` there and carries that elbow.
+    fn seed_diverging_merge_history(dir: &std::path::Path) {
+        seed_empty_repo_at(dir);
+        commit_at(dir, "base.txt", "1", "base", 1_700_000_000);
+        git(dir, &["checkout", "-b", "feature"]);
+        commit_at(dir, "feature.txt", "1", "feature work", 1_700_000_100);
+        git(dir, &["checkout", "main"]);
+        let date = "1700000200 +0000";
+        git_with_env(
+            dir,
+            &[
+                "merge",
+                "--no-ff",
+                "feature",
+                "-m",
+                "Merge branch 'feature'",
+            ],
+            &[("GIT_AUTHOR_DATE", date), ("GIT_COMMITTER_DATE", date)],
+        );
     }
 
     fn open_seeded(
@@ -5816,7 +5504,7 @@ mod graph_elbow_render_tests {
     ) {
         let repo = tempfile::tempdir().expect("tempdir");
         seed(repo.path());
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_git_graph(window, cx);
         });
@@ -5952,32 +5640,7 @@ mod graph_elbow_render_tests {
 
     #[gpui::test]
     fn a_diverging_elbow_paints_in_the_rows_bottom_half(cx: &mut TestAppContext) {
-        let (_repo, app, cx) = open_seeded(cx, |dir| {
-            init_repo(dir);
-            commit_at(dir, "base.txt", "1", "base", 1_700_000_000);
-            git(dir, &["checkout", "-b", "feature"]);
-            commit_at(dir, "feature.txt", "1", "feature work", 1_700_000_100);
-            git(dir, &["checkout", "main"]);
-            let date = "1700000200 +0000";
-            let output = std::process::Command::new("git")
-                .current_dir(dir)
-                .args([
-                    "merge",
-                    "--no-ff",
-                    "feature",
-                    "-m",
-                    "Merge branch 'feature'",
-                ])
-                .env("GIT_AUTHOR_DATE", date)
-                .env("GIT_COMMITTER_DATE", date)
-                .output()
-                .expect("failed to spawn git merge");
-            assert!(
-                output.status.success(),
-                "git merge failed: {}",
-                String::from_utf8_lossy(&output.stderr)
-            );
-        });
+        let (_repo, app, cx) = open_seeded(cx, seed_diverging_merge_history);
 
         let merge_row_index = app.read_with(cx, |app, _| {
             let GraphLoadState::Loaded(graph) = &app.graph_state.load else {
@@ -6070,28 +5733,7 @@ mod graph_elbow_render_tests {
     fn a_lane_with_a_diverging_elbow_does_not_also_paint_a_plain_starts_here_stub(
         cx: &mut TestAppContext,
     ) {
-        let (_repo, app, cx) = open_seeded(cx, |dir| {
-            init_repo(dir);
-            commit_at(dir, "base.txt", "1", "base", 1_700_000_000);
-            git(dir, &["checkout", "-b", "feature"]);
-            commit_at(dir, "feature.txt", "1", "feature work", 1_700_000_100);
-            git(dir, &["checkout", "main"]);
-            let date = "1700000200 +0000";
-            let output = std::process::Command::new("git")
-                .current_dir(dir)
-                .args([
-                    "merge",
-                    "--no-ff",
-                    "feature",
-                    "-m",
-                    "Merge branch 'feature'",
-                ])
-                .env("GIT_AUTHOR_DATE", date)
-                .env("GIT_COMMITTER_DATE", date)
-                .output()
-                .expect("failed to spawn git merge");
-            assert!(output.status.success());
-        });
+        let (_repo, app, cx) = open_seeded(cx, seed_diverging_merge_history);
 
         let merge_row_index = app.read_with(cx, |app, _| {
             let GraphLoadState::Loaded(graph) = &app.graph_state.load else {
@@ -6242,37 +5884,17 @@ mod graph_elbow_render_tests {
 #[cfg(test)]
 mod graph_selection_render_tests {
     use super::*;
-    use crate::root::focus::palette_focus_tests;
+    use crate::test_support::open_test_app;
     use gpui::{Entity, TestAppContext};
-
-    fn git(dir: &std::path::Path, args: &[&str]) {
-        let output = std::process::Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {:?} failed in {:?}:\nstdout: {}\nstderr: {}",
-            args,
-            dir,
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
+    use test_support::{commit, seed_empty_repo_at};
 
     /// Two real commits - `build_graph` yields exactly two rows (indices 0..=1, newest first).
     /// Row 0 is auto-selected on load (`AdeApp`'s own `load_graph`), so row 1 starts genuinely
     /// unselected - exactly the row this test drives through a real selection change.
     fn seed_two_commits(dir: &std::path::Path) {
-        git(dir, &["init", "-b", "main"]);
-        git(dir, &["config", "user.email", "test@example.com"]);
-        git(dir, &["config", "user.name", "Test User"]);
-        std::fs::write(dir.join("a.txt"), "1\n").expect("write a.txt");
-        git(dir, &["add", "."]);
-        git(dir, &["commit", "-m", "first"]);
-        std::fs::write(dir.join("a.txt"), "2\n").expect("write a.txt");
-        git(dir, &["commit", "-am", "second"]);
+        seed_empty_repo_at(dir);
+        commit(dir, "a.txt", "1\n", "first");
+        commit(dir, "a.txt", "2\n", "second");
     }
 
     fn open_seeded_graph(
@@ -6284,7 +5906,7 @@ mod graph_selection_render_tests {
     ) {
         let repo = tempfile::tempdir().expect("tempdir");
         seed_two_commits(repo.path());
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_git_graph(window, cx);
         });
@@ -6310,8 +5932,21 @@ mod graph_selection_render_tests {
         );
     }
 
+    /// The reported "when we click on a line, don't move the line, just highlight it", and the
+    /// reported "double border left and bottom" behind it: GPUI's `Style::border_color` is one
+    /// shared value for every edge of a single element (confirmed directly in `gpui`'s own
+    /// `style.rs`: `border_color: Option<Hsla>`, not per-edge), so a row using both
+    /// `border_b_1()` (its own permanent separator) and a conditional `border_l_2()` (its
+    /// selection edge) on the *same* div used to have the second `.border_color()` call silently
+    /// overwrite the first. The fix is a real, separate child element for the left edge
+    /// (`Self::render_graph_row`'s own docs), created unconditionally.
+    ///
+    /// Both consequences are one invariant on painted bounds: every element of a row keeps
+    /// exactly the bounds it had before that row was selected, the selection edge included - and
+    /// a `debug_bounds` miss on the *unselected* row would mean the edge is back to being created
+    /// `.when(selected, ...)`, the exact regression this covers.
     #[gpui::test]
-    fn selecting_a_row_never_shifts_its_own_lane_canvas(cx: &mut TestAppContext) {
+    fn selecting_a_row_moves_and_resizes_nothing_it_paints(cx: &mut TestAppContext) {
         let (_repo, app, cx) = open_seeded_graph(cx);
 
         assert_eq!(
@@ -6320,9 +5955,15 @@ mod graph_selection_render_tests {
             "premise: row 0 is auto-selected on load, so row 1 starts genuinely unselected"
         );
 
-        let bounds_unselected = cx
-            .debug_bounds("graph-row-1-lane-canvas")
-            .expect("row 1's lane canvas must be painted while unselected");
+        let elements = ["graph-row-1-lane-canvas", "graph-row-1-selection-edge"];
+        let unselected: Vec<_> = elements
+            .iter()
+            .map(|selector| {
+                cx.debug_bounds(selector).unwrap_or_else(|| {
+                    panic!("{selector} must be painted while row 1 is unselected")
+                })
+            })
+            .collect();
 
         app.update(cx, |app, cx| {
             app.select_graph_row(1, cx);
@@ -6334,63 +5975,22 @@ mod graph_selection_render_tests {
             "premise: row 1 really is selected now"
         );
 
-        let bounds_selected = cx
-            .debug_bounds("graph-row-1-lane-canvas")
-            .expect("row 1's lane canvas must be painted while selected");
-
-        assert_eq!(
-            bounds_unselected.origin.x, bounds_selected.origin.x,
-            "selecting a row must never shift its own content to the right - the row's real \
-             `.border_l_2()` reserves its 2px unconditionally, only its colour should toggle \
-             (unselected: {:?}, selected: {:?})",
-            bounds_unselected, bounds_selected
-        );
-        assert_eq!(
-            bounds_unselected.size, bounds_selected.size,
-            "selecting a row must never resize its own content (unselected: {:?}, selected: \
-             {:?})",
-            bounds_unselected, bounds_selected
-        );
-    }
-
-    #[gpui::test]
-    fn the_selection_edge_is_a_real_element_painted_regardless_of_selection(
-        cx: &mut TestAppContext,
-    ) {
-        let (_repo, app, cx) = open_seeded_graph(cx);
-
-        assert_eq!(
-            app.read_with(cx, |app, _| app.graph_state.selected_row),
-            Some(0),
-            "premise: row 0 is auto-selected on load, so row 1 starts genuinely unselected"
-        );
-
-        let edge_unselected = cx.debug_bounds("graph-row-1-selection-edge").expect(
-            "the selection-edge child must be painted even while row 1 is unselected - if \
-                 it's `None` here, the edge is still only created `.when(selected, ...)`, the \
-                 exact regression this test exists to catch",
-        );
-
-        app.update(cx, |app, cx| {
-            app.select_graph_row(1, cx);
-        });
-        cx.run_until_parked();
-
-        let edge_selected = cx
-            .debug_bounds("graph-row-1-selection-edge")
-            .expect("the selection-edge child must still be painted while row 1 is selected");
-
-        assert_eq!(
-            edge_unselected.origin, edge_selected.origin,
-            "the selection edge's own position must never move - only its colour toggles \
-             (unselected: {:?}, selected: {:?})",
-            edge_unselected, edge_selected
-        );
-        assert_eq!(
-            edge_unselected.size, edge_selected.size,
-            "the selection edge's own size must never change (unselected: {:?}, selected: {:?})",
-            edge_unselected, edge_selected
-        );
+        for (selector, before) in elements.iter().zip(unselected) {
+            let after = cx
+                .debug_bounds(selector)
+                .unwrap_or_else(|| panic!("{selector} must still be painted while selected"));
+            assert_eq!(
+                before.origin, after.origin,
+                "selecting a row must never move {selector} - the row's real `.border_l_2()` \
+                 reserves its 2px unconditionally, only its colour should toggle (unselected: \
+                 {before:?}, selected: {after:?})"
+            );
+            assert_eq!(
+                before.size, after.size,
+                "selecting a row must never resize {selector} (unselected: {before:?}, selected: \
+                 {after:?})"
+            );
+        }
     }
 
     #[gpui::test]
@@ -6447,24 +6047,9 @@ mod graph_selection_render_tests {
 #[cfg(test)]
 mod graph_focus_tests {
     use super::*;
-    use crate::root::focus::palette_focus_tests;
+    use crate::test_support::open_test_app;
     use gpui::{Entity, Focusable, TestAppContext};
-
-    fn git(dir: &std::path::Path, args: &[&str]) {
-        let output = std::process::Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {:?} failed in {:?}:\nstdout: {}\nstderr: {}",
-            args,
-            dir,
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
+    use test_support::{commit, seed_empty_repo_at};
 
     /// A real one-commit repo (so `AdeApp::load_graph` succeeds and the Branches panel's filter
     /// row - only rendered once a `Graph` is actually loaded - really paints) plus a real, already-
@@ -6478,13 +6063,9 @@ mod graph_focus_tests {
         &mut gpui::VisualTestContext,
     ) {
         let repo = tempfile::tempdir().expect("tempdir");
-        git(repo.path(), &["init", "-b", "main"]);
-        git(repo.path(), &["config", "user.email", "test@example.com"]);
-        git(repo.path(), &["config", "user.name", "Test User"]);
-        std::fs::write(repo.path().join("a.txt"), "1\n").expect("write a.txt");
-        git(repo.path(), &["add", "."]);
-        git(repo.path(), &["commit", "-m", "initial"]);
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        seed_empty_repo_at(repo.path());
+        commit(repo.path(), "a.txt", "1\n", "initial");
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         (repo, app, cx)
     }
 
@@ -6868,43 +6449,11 @@ mod graph_focus_tests {
 /// stub these replaced.
 #[cfg(test)]
 mod graph_remote_action_tests {
-    use crate::root::focus::palette_focus_tests;
     use crate::root::AdeApp;
+    use crate::test_support::open_test_app;
     use gpui::{Entity, TestAppContext};
-    use std::path::Path;
+    use test_support::{commit, git, git_output, seed_empty_repo_at};
     use wt_core::remote::PushForce;
-
-    fn git(dir: &Path, args: &[&str]) {
-        let output = std::process::Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {:?} failed in {:?}:\nstdout: {}\nstderr: {}",
-            args,
-            dir,
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
-    fn git_output(dir: &Path, args: &[&str]) -> String {
-        let output = std::process::Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(output.status.success(), "git {args:?} failed in {dir:?}");
-        String::from_utf8_lossy(&output.stdout).trim().to_string()
-    }
-
-    fn commit(dir: &Path, file: &str, contents: &str, message: &str) {
-        std::fs::write(dir.join(file), contents).expect("write file");
-        git(dir, &["add", file]);
-        git(dir, &["commit", "-m", message]);
-    }
 
     /// A real bare remote plus a real clone of it, with a real committer identity and one
     /// tracked file - the app is opened against the clone, matching how a real user's worktree
@@ -6938,7 +6487,7 @@ mod graph_remote_action_tests {
         git(local.path(), &["config", "user.email", "test@example.com"]);
         git(local.path(), &["config", "user.name", "Test User"]);
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, local.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, local.path().to_path_buf());
         (remote, local, app, cx)
     }
 
@@ -7148,12 +6697,10 @@ mod graph_remote_action_tests {
         &mut gpui::VisualTestContext,
     ) {
         let local = tempfile::tempdir().expect("tempdir");
-        git(local.path(), &["init", "-b", "main"]);
-        git(local.path(), &["config", "user.email", "test@example.com"]);
-        git(local.path(), &["config", "user.name", "Test User"]);
+        seed_empty_repo_at(local.path());
         commit(local.path(), "a.txt", "base", "base");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, local.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, local.path().to_path_buf());
         (local, app, cx)
     }
 
@@ -7615,59 +7162,62 @@ mod graph_remote_action_tests {
         );
     }
 
+    /// Both non-destructive reset modes: each really moves the branch tip back, leaves the working
+    /// tree's own content alone, and differs only in whether the undone commit's change lands
+    /// staged (`Soft`) or unstaged (`Mixed`). `Hard` is deliberately not here - it is destructive,
+    /// so it carries its own arm-then-confirm test below.
     #[gpui::test]
-    async fn soft_reset_moves_the_branch_tip_and_keeps_the_change_staged(cx: &mut TestAppContext) {
-        let (local, app, cx) = open_seeded_local_repo(cx);
-        let base_sha = git_output(local.path(), &["rev-parse", "HEAD"]);
-        commit(local.path(), "a.txt", "changed", "second commit");
+    async fn a_soft_or_mixed_reset_moves_the_branch_tip_and_keeps_the_change(
+        cx: &mut TestAppContext,
+    ) {
+        for (mode, status, staged, unstaged) in [
+            (
+                wt_core::checkout::ResetMode::Soft,
+                "Soft reset",
+                "a.txt",
+                "",
+            ),
+            (
+                wt_core::checkout::ResetMode::Mixed,
+                "Mixed reset",
+                "",
+                "a.txt",
+            ),
+        ] {
+            let (local, app, cx) = open_seeded_local_repo(cx);
+            let base_sha = git_output(local.path(), &["rev-parse", "HEAD"]);
+            commit(local.path(), "a.txt", "changed", "second commit");
 
-        app.update_in(cx, |app, _window, cx| {
-            app.request_graph_reset(wt_core::checkout::ResetMode::Soft, base_sha.clone(), cx);
-        });
-        cx.run_until_parked();
+            app.update_in(cx, |app, _window, cx| {
+                app.request_graph_reset(mode, base_sha.clone(), cx);
+            });
+            cx.run_until_parked();
 
-        assert_eq!(git_output(local.path(), &["rev-parse", "HEAD"]), base_sha);
-        assert_eq!(
-            git_output(local.path(), &["diff", "--cached", "--name-only"]),
-            "a.txt",
-            "a soft reset must leave the undone commit's own change staged"
-        );
-        assert_eq!(
-            std::fs::read_to_string(local.path().join("a.txt")).expect("read a.txt"),
-            "changed",
-            "the working tree content must be untouched by a soft reset"
-        );
-        assert_eq!(
-            app.read_with(cx, |app, _| app.graph_state.status_message.clone()),
-            Some("Soft reset".to_string())
-        );
-    }
-
-    #[gpui::test]
-    async fn mixed_reset_moves_the_branch_tip_and_unstages_the_change(cx: &mut TestAppContext) {
-        let (local, app, cx) = open_seeded_local_repo(cx);
-        let base_sha = git_output(local.path(), &["rev-parse", "HEAD"]);
-        commit(local.path(), "a.txt", "changed", "second commit");
-
-        app.update_in(cx, |app, _window, cx| {
-            app.request_graph_reset(wt_core::checkout::ResetMode::Mixed, base_sha.clone(), cx);
-        });
-        cx.run_until_parked();
-
-        assert_eq!(git_output(local.path(), &["rev-parse", "HEAD"]), base_sha);
-        assert!(
-            git_output(local.path(), &["diff", "--cached", "--name-only"]).is_empty(),
-            "a mixed reset must leave nothing staged"
-        );
-        assert_eq!(
-            git_output(local.path(), &["diff", "--name-only"]),
-            "a.txt",
-            "the undone commit's own change must land unstaged instead"
-        );
-        assert_eq!(
-            app.read_with(cx, |app, _| app.graph_state.status_message.clone()),
-            Some("Mixed reset".to_string())
-        );
+            assert_eq!(
+                git_output(local.path(), &["rev-parse", "HEAD"]),
+                base_sha,
+                "{mode:?} must really move the branch tip back"
+            );
+            assert_eq!(
+                git_output(local.path(), &["diff", "--cached", "--name-only"]),
+                staged,
+                "{mode:?}: wrong staged set for the undone commit's own change"
+            );
+            assert_eq!(
+                git_output(local.path(), &["diff", "--name-only"]),
+                unstaged,
+                "{mode:?}: wrong unstaged set for the undone commit's own change"
+            );
+            assert_eq!(
+                std::fs::read_to_string(local.path().join("a.txt")).expect("read a.txt"),
+                "changed",
+                "{mode:?} must leave the working tree's own content untouched"
+            );
+            assert_eq!(
+                app.read_with(cx, |app, _| app.graph_state.status_message.clone()),
+                Some(status.to_string())
+            );
+        }
     }
 
     #[gpui::test]
@@ -7779,54 +7329,38 @@ mod graph_remote_action_tests {
 #[cfg(test)]
 mod graph_virtualization_tests {
     use super::*;
-    use crate::root::focus::palette_focus_tests;
+    use crate::test_support::open_test_app;
     use gpui::{Entity, TestAppContext};
-
-    fn git(dir: &std::path::Path, args: &[&str]) {
-        let output = std::process::Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {:?} failed in {:?}: {}",
-            args,
-            dir,
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
-    fn init_repo(dir: &std::path::Path) {
-        git(dir, &["init", "-b", "main"]);
-        git(dir, &["config", "user.email", "test@example.com"]);
-        git(dir, &["config", "user.name", "Test User"]);
-    }
-
-    /// `count` real commits, and a clean working tree at the end so `build_graph` adds no
-    /// "Working tree" row to shift the indices these tests name by literal selector.
-    fn seed_commits(dir: &std::path::Path, count: usize) {
-        init_repo(dir);
-        std::fs::write(dir.join("a.txt"), "1\n").expect("write a.txt");
-        git(dir, &["add", "."]);
-        git(dir, &["commit", "-m", "first"]);
-        for index in 1..count {
-            git(
-                dir,
-                &["commit", "--allow-empty", "-m", &format!("c{index}")],
-            );
-        }
-    }
+    use test_support::seed_commits;
 
     fn open_graph_on<'a>(
         cx: &'a mut TestAppContext,
         repo: &std::path::Path,
     ) -> (Entity<AdeApp>, &'a mut gpui::VisualTestContext) {
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_git_graph(window, cx);
         });
         cx.run_until_parked();
+        // The walk behind this is real `gix`/`git` I/O against a real fixture - the one step in
+        // this helper that can fail for a reason the test itself does not control. Every caller
+        // then opens with `debug_bounds("graph-row-0")`, which answers `None` for a failed walk
+        // and a broken renderer alike, so a walk failure used to surface as "the first commit row
+        // must really paint" and blame the wrong thing entirely. Naming the real load state here
+        // is what makes that distinguishable on a CI runner nobody can attach a debugger to.
+        app.read_with(cx, |app, _| match &app.graph_state.load {
+            GraphLoadState::Loaded(graph) => assert!(
+                !graph.rows.is_empty(),
+                "the graph walk succeeded but produced no rows for this fixture"
+            ),
+            GraphLoadState::Error(err) => panic!("the real graph walk failed: {err}"),
+            GraphLoadState::Loading => {
+                panic!("the graph walk was still in flight after run_until_parked")
+            }
+            GraphLoadState::NotLoaded => {
+                panic!("opening the graph tab never started a walk at all")
+            }
+        });
         (app, cx)
     }
 
@@ -8200,53 +7734,21 @@ mod graph_virtualization_tests {
 #[cfg(test)]
 mod graph_branch_menu_tests {
     use super::*;
-    use crate::root::focus::palette_focus_tests;
+    use crate::test_support::open_test_app;
     use gpui::{Entity, Pixels, TestAppContext};
-
-    fn git(dir: &std::path::Path, args: &[&str]) {
-        let output = std::process::Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {:?} failed in {:?}:\nstdout: {}\nstderr: {}",
-            args,
-            dir,
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
-    fn git_output(dir: &std::path::Path, args: &[&str]) -> String {
-        let output = std::process::Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(output.status.success(), "git {args:?} failed in {dir:?}");
-        String::from_utf8_lossy(&output.stdout).trim().to_string()
-    }
+    use test_support::{commit, git, git_output, seed_empty_repo_at};
 
     /// A real repository with three real local branches - `main` (checked out), `feature-a` and
     /// `feature-b` - all reachable from the default `GraphScope::All` walk, so all three really
     /// appear as rows in the Branches panel.
     fn seed_three_branches(dir: &std::path::Path) {
-        git(dir, &["init", "-b", "main"]);
-        git(dir, &["config", "user.email", "test@example.com"]);
-        git(dir, &["config", "user.name", "Test User"]);
-        std::fs::write(dir.join("a.txt"), "1\n").expect("write a.txt");
-        git(dir, &["add", "."]);
-        git(dir, &["commit", "-m", "first"]);
+        seed_empty_repo_at(dir);
+        commit(dir, "a.txt", "1\n", "first");
         git(dir, &["checkout", "-b", "feature-a"]);
-        std::fs::write(dir.join("a.txt"), "2\n").expect("write a.txt");
-        git(dir, &["commit", "-am", "feature a work"]);
+        commit(dir, "a.txt", "2\n", "feature a work");
         git(dir, &["checkout", "main"]);
         git(dir, &["checkout", "-b", "feature-b"]);
-        std::fs::write(dir.join("b.txt"), "1\n").expect("write b.txt");
-        git(dir, &["add", "."]);
-        git(dir, &["commit", "-m", "feature b work"]);
+        commit(dir, "b.txt", "1\n", "feature b work");
         git(dir, &["checkout", "main"]);
     }
 
@@ -8260,7 +7762,7 @@ mod graph_branch_menu_tests {
     ) {
         let repo = tempfile::tempdir().expect("tempdir");
         seed_three_branches(repo.path());
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_git_graph(window, cx);
         });
@@ -8474,7 +7976,7 @@ mod graph_branch_menu_tests {
     }
 
     #[gpui::test]
-    fn opening_the_branch_menu_closes_an_open_row_menu(cx: &mut TestAppContext) {
+    fn the_branch_menu_and_the_row_menu_each_close_the_other(cx: &mut TestAppContext) {
         let (_repo, app, cx) = open_seeded_branches_panel(cx);
         app.update_in(cx, |app, window, cx| {
             app.open_graph_row_menu_at(0, px(20.0), px(120.0), window, cx);
@@ -8489,7 +7991,6 @@ mod graph_branch_menu_tests {
             .debug_bounds("graph-branch-row-feature-a")
             .expect("branch row painted");
         right_click(cx, row.center());
-
         app.read_with(cx, |app, _| {
             assert!(
                 app.graph_state.row_menu_open.is_none(),
@@ -8498,25 +7999,11 @@ mod graph_branch_menu_tests {
             );
             assert!(app.graph_state.branch_menu_open.is_some());
         });
-    }
-
-    #[gpui::test]
-    fn opening_the_row_menu_closes_an_open_branch_menu(cx: &mut TestAppContext) {
-        let (_repo, app, cx) = open_seeded_branches_panel(cx);
-        let row = cx
-            .debug_bounds("graph-branch-row-feature-a")
-            .expect("branch row painted");
-        right_click(cx, row.center());
-        assert!(
-            app.read_with(cx, |app, _| app.graph_state.branch_menu_open.is_some()),
-            "premise: the branch menu really is open first"
-        );
 
         app.update_in(cx, |app, window, cx| {
             app.open_graph_row_menu_at(0, px(20.0), px(120.0), window, cx);
         });
         cx.run_until_parked();
-
         app.read_with(cx, |app, _| {
             assert!(
                 app.graph_state.branch_menu_open.is_none(),
@@ -8832,7 +8319,7 @@ mod graph_branch_menu_tests {
         // `wt_core::stage::dirty_paths` read is what fills `dirty_files` - never a hand-set field.
         std::fs::write(repo.path().join("dirty-one.txt"), "uncommitted\n").expect("write");
         std::fs::write(repo.path().join("dirty-two.txt"), "uncommitted\n").expect("write");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_git_graph(window, cx);
         });
@@ -8883,40 +8370,9 @@ mod graph_branch_menu_tests {
         );
     }
 
-    #[gpui::test]
-    fn merge_row_is_disabled_on_the_branch_that_is_already_checked_out(cx: &mut TestAppContext) {
-        let (repo, app, cx) = open_seeded_branches_panel(cx);
-        assert_eq!(
-            git_output(repo.path(), &["rev-parse", "--abbrev-ref", "HEAD"]),
-            "main",
-            "premise: the focused worktree really is on main"
-        );
-
-        app.read_with(cx, |app, cx| {
-            let gate =
-                graph_branch_merge_gate(&app.graph_branch_merge_facts("main".to_string(), cx));
-            assert_eq!(gate.reason(), Some("already on main"));
-        });
-
-        open_menu_at(cx, "graph-branch-row-main");
-        click_menu_row(cx, "dropdown-menu-row-Merge into current branch\u{2026}");
-        app.read_with(cx, |app, _| {
-            assert!(
-                app.merge_flow.is_none(),
-                "merging main into main must not even start"
-            );
-            assert_eq!(
-                app.graph_state.status_message, None,
-                "and the row must genuinely be disabled - a click that reached the action would \
-                 have reported the gate's refusal on the status line instead"
-            );
-        });
-        assert!(
-            !wt_core::merge::merge_head_exists(repo.path()).expect("merge_head_exists"),
-            "and must have run no real git merge"
-        );
-    }
-
+    /// The other half of the gate: the facts it decides from must really be read off this app's
+    /// own loaded state for the **focused worktree**, not from constants. The pure decision itself
+    /// is covered branch-by-branch in `super::state`'s own unit tests; this pins the reading.
     #[gpui::test]
     fn merge_facts_are_read_from_the_focused_worktrees_own_real_state(cx: &mut TestAppContext) {
         let (repo, app, cx) = open_seeded_branches_panel(cx);
@@ -8974,44 +8430,13 @@ mod graph_branch_menu_tests {
 #[cfg(test)]
 mod graph_branch_action_tests {
     use crate::merge::state as merge;
-    use crate::root::focus::palette_focus_tests;
     use crate::root::AdeApp;
+    use crate::test_support::open_test_app;
     use crate::text_history::TextField;
     use crate::work_surface::agents::ProcessKind;
     use gpui::{Entity, TestAppContext};
     use std::path::Path;
-
-    fn git(dir: &Path, args: &[&str]) {
-        let output = std::process::Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {:?} failed in {:?}:\nstdout: {}\nstderr: {}",
-            args,
-            dir,
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
-    fn git_output(dir: &Path, args: &[&str]) -> String {
-        let output = std::process::Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(output.status.success(), "git {args:?} failed in {dir:?}");
-        String::from_utf8_lossy(&output.stdout).trim().to_string()
-    }
-
-    fn commit(dir: &Path, file: &str, contents: &str, message: &str) {
-        std::fs::write(dir.join(file), contents).expect("write file");
-        git(dir, &["add", file]);
-        git(dir, &["commit", "-m", message]);
-    }
+    use test_support::{commit, git, git_output, seed_empty_repo_at};
 
     fn branches(dir: &Path) -> Vec<String> {
         git_output(dir, &["branch", "--format=%(refname:short)"])
@@ -9046,15 +8471,13 @@ mod graph_branch_action_tests {
         &mut gpui::VisualTestContext,
     ) {
         let local = tempfile::tempdir().expect("tempdir");
-        git(local.path(), &["init", "-b", "main"]);
-        git(local.path(), &["config", "user.email", "test@example.com"]);
-        git(local.path(), &["config", "user.name", "Test User"]);
+        seed_empty_repo_at(local.path());
         commit(local.path(), "a.txt", "base", "base");
         git(local.path(), &["checkout", "-b", "feature"]);
         commit(local.path(), "b.txt", "feature", "feature work");
         git(local.path(), &["checkout", "main"]);
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, local.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, local.path().to_path_buf());
         (local, app, cx)
     }
 
@@ -9396,7 +8819,7 @@ mod graph_branch_action_tests {
         // named branch rather than whatever is checked out.
         commit(local.path(), "c.txt", "main only", "main only work");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, local.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, local.path().to_path_buf());
         app.update_in(cx, |app, _window, cx| {
             app.request_graph_push_branch("feature".to_string(), cx);
         });
@@ -9513,10 +8936,13 @@ mod graph_branch_action_tests {
         let (local, app, cx) = open_seeded_with_feature_branch(cx);
         // The worktree's own agent tab - the surface the existing resolver renders inside. A test
         // app already opens one for the focused repo, which is exactly the real situation this
-        // action expects to find.
+        // action expects to find. Keyed off the app's own `diff_root`, the very key
+        // `start_merge_from_graph_branch` looks agents up by: a `TempDir`'s own path is a symlink
+        // on macOS (`/var/...`) while the app stores the canonicalized one (`/private/var/...`),
+        // so `local.path()` matches no agent at all there.
         let agent_id = app.read_with(cx, |app, _| {
             app.agents
-                .iter_for_cwd(local.path().to_path_buf())
+                .iter_for_cwd(app.diff_root.clone())
                 .map(|agent| agent.id)
                 .next()
                 .expect("the test app opens a real agent in the focused worktree")
@@ -9600,9 +9026,7 @@ mod graph_branch_action_tests {
         cx: &mut TestAppContext,
     ) {
         let local = tempfile::tempdir().expect("tempdir");
-        git(local.path(), &["init", "-b", "main"]);
-        git(local.path(), &["config", "user.email", "test@example.com"]);
-        git(local.path(), &["config", "user.name", "Test User"]);
+        seed_empty_repo_at(local.path());
         commit(local.path(), "shared.txt", "line1\nline2\nline3\n", "base");
         git(local.path(), &["checkout", "-b", "feature"]);
         commit(
@@ -9619,7 +9043,7 @@ mod graph_branch_action_tests {
             "main changes shared",
         );
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, local.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, local.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.agents.spawn(
                 ProcessKind::Shell,
@@ -9692,13 +9116,19 @@ mod graph_branch_action_tests {
     ) {
         let (local, app, cx) = open_seeded_with_feature_branch(cx);
         // Close every agent in the focused worktree, so there is genuinely no surface left to
-        // show the resolver in - the real state this refusal exists for.
+        // show the resolver in - the real state this refusal exists for. Keyed off `diff_root`
+        // for the same reason as `merge_into_current_branch_lands_in_the_existing_merge_flow`.
         let existing: Vec<_> = app.read_with(cx, |app, _| {
             app.agents
-                .iter_for_cwd(local.path().to_path_buf())
+                .iter_for_cwd(app.diff_root.clone())
                 .map(|agent| agent.id)
                 .collect()
         });
+        assert!(
+            !existing.is_empty(),
+            "premise: the test app really did open an agent in this worktree, or this test would \
+             pass without exercising the refusal at all"
+        );
         for id in existing {
             app.update_in(cx, |app, window, cx| app.close_agent(id, window, cx));
         }

--- a/crates/app/src/hooks/integration_tests.rs
+++ b/crates/app/src/hooks/integration_tests.rs
@@ -49,15 +49,8 @@ const REAL_PAYLOAD: &str = r#"{"session_id":"5a4bef04-9e59-4d75-874d-928b1f8c395
 
 /// Blocks until `check` passes or the deadline expires - the forwarder is a real subprocess and
 /// the listener a real thread, so the handoff is genuinely asynchronous.
-fn wait_for(mut check: impl FnMut() -> bool) -> bool {
-    let deadline = Instant::now() + Duration::from_secs(10);
-    while Instant::now() < deadline {
-        if check() {
-            return true;
-        }
-        std::thread::sleep(Duration::from_millis(25));
-    }
-    check()
+fn wait_for(check: impl FnMut() -> bool) -> bool {
+    test_support::wait_until(Duration::from_secs(10), check)
 }
 
 #[test]
@@ -162,7 +155,11 @@ fn a_forwarder_run_outside_jerry_reaches_no_listener_at_all() {
     }
     assert!(child.wait().expect("wait").success());
 
-    std::thread::sleep(Duration::from_millis(300));
+    assert!(
+        test_support::stays_false(Duration::from_millis(300), || (0..64)
+            .any(|id| listener.signal_for(id).fact.is_some())),
+        "an unconfigured forwarder must not report anything for any agent id"
+    );
     for id in 0..64 {
         assert_eq!(
             listener.signal_for(id).fact,
@@ -230,6 +227,7 @@ fn run_real_claude(
     }
 }
 
+#[ignore = "external: claude; see docs/testing.md"]
 #[test]
 fn a_real_claude_session_reports_its_hooks_to_a_real_jerry_listener() {
     let Some(binary) = real_claude() else {
@@ -276,6 +274,7 @@ fn a_real_claude_session_reports_its_hooks_to_a_real_jerry_listener() {
     );
 }
 
+#[ignore = "external: claude; see docs/testing.md"]
 #[test]
 fn jerry_s_settings_file_does_not_disable_the_user_s_own_hooks() {
     // The regression this whole feature must not cause. `--settings` merging (rather than
@@ -362,6 +361,22 @@ fn jerry_s_settings_file_does_not_disable_the_user_s_own_hooks() {
     );
 }
 
+/// The end-to-end test that covers what a *user* does, through the objects a user's click really
+/// goes through: [`crate::root::AdeApp::new_agent`] (what the palette's "New Claude agent", the
+/// Agent menu and the rail's "+" all call), a real
+/// [`crate::work_surface::agents::Agents::spawn`], a real pty, a real `claude`, and a real
+/// [`crate::hooks::HookRuntime`] brought up by the real lazy `hook_injection_for` gate - then
+/// asserts the fact comes back out of the app's own runtime under that agent's own real id.
+///
+/// The tests above this one hand-assemble the `--settings` argument and the `JERRY_*` environment
+/// from the production helpers and hand them to a `std::process::Command`. That pins Claude
+/// Code's half of the contract and nothing at all of Jerry's: every step between a click and the
+/// child process - the lazy runtime bring-up, the Claude-only gate, whether the `AgentId` in the
+/// environment is the one the rail reads back, `ProcessKind::spec`, `TerminalSpec::env`,
+/// `pty_core`'s `CommandBuilder` - is skipped by all of them. This one skips none of it, which is
+/// the whole reason it exists: a regression anywhere along that chain would leave every other
+/// test in this file green.
+#[ignore = "external: claude; see docs/testing.md"]
 #[gpui::test]
 fn a_claude_agent_spawned_through_the_real_app_path_really_reports_its_hooks(
     cx: &mut gpui::TestAppContext,

--- a/crates/app/src/hooks/server.rs
+++ b/crates/app/src/hooks/server.rs
@@ -1151,8 +1151,14 @@ mod tests {
         let listener = HookListener::start().expect("listener");
         let port = listener.port();
 
+        // Every slot occupied by a client that drips for ~25s and never completes a request. Each
+        // reports when the server let go of it - a failed write is the drip-feeder's own view of
+        // the handler giving up, and counting them is what turns the wait below into an observed
+        // event rather than a guessed duration.
+        let cut_off = Arc::new(AtomicUsize::new(0));
         let mut drips = Vec::new();
         for _ in 0..MAX_IN_FLIGHT {
+            let cut_off = Arc::clone(&cut_off);
             drips.push(std::thread::spawn(move || {
                 let Ok(mut stream) = TcpStream::connect(("127.0.0.1", port)) else {
                     return;
@@ -1164,13 +1170,26 @@ mod tests {
                     let _ = stream.flush();
                     std::thread::sleep(Duration::from_millis(500));
                 }
+                cut_off.fetch_add(1, Ordering::SeqCst);
             }));
         }
 
-        // A fixed wait, longer than the handler deadline but well inside the drippers' lifetime,
-        // so the only way real traffic gets served here is if the handlers really did give up.
-        // Absolute rather than derived from `REQUEST_DEADLINE` - see the sibling test.
-        std::thread::sleep(Duration::from_secs(9));
+        // Deliberately *not* polled with a probe request: a probe competes with the drip-feeders
+        // for the same `MAX_IN_FLIGHT` slots, and one that wins a slot at startup leaves the
+        // server permanently one short of saturation - the test then measures its own polling
+        // instead of the server. Wait on the drip-feeders' own signal instead, which perturbs
+        // nothing. The bound is absolute rather than derived from `REQUEST_DEADLINE`, and well
+        // inside the drippers' own ~25s lifetime, so reaching it at all means the handlers really
+        // did give up rather than the clients running out of patience - see the sibling test.
+        assert!(
+            test_support::wait_until(Duration::from_secs(15), || cut_off.load(Ordering::SeqCst)
+                == MAX_IN_FLIGHT),
+            "every handler must give up on its drip-feeder on its own, but only {} of {} did",
+            cut_off.load(Ordering::SeqCst),
+            MAX_IN_FLIGHT
+        );
+
+        // And the slots they held are genuinely free again, not merely accounted free.
         let good = post(
             port,
             listener.token(),
@@ -1179,7 +1198,8 @@ mod tests {
         );
         assert!(
             good.starts_with("HTTP/1.1 204"),
-            "a real hook must still be served while slow clients are connected, got {good:?}"
+            "a real hook must be served again once the deadline cuts the slow clients off, got \
+             {good:?}"
         );
         assert_eq!(listener.signal_for(99).fact, Some(HookFact::TurnEnded));
 

--- a/crates/app/src/hooks/settings_file.rs
+++ b/crates/app/src/hooks/settings_file.rs
@@ -851,13 +851,12 @@ mod tests {
         assert!(!directory.exists(), "the launch directory must be removed");
     }
 
+    /// `#[cfg(unix)]`: the whole body is a real `/bin/sh` run of the generated forwarder.
+    #[cfg(unix)]
     #[test]
     fn the_forwarder_no_ops_without_jerry_env_vars_and_never_reports_failure() {
         // The property that makes the generated command safe to run outside Jerry (see the module
         // docs). Run the real script, with a real JSON payload on stdin, with no JERRY_* set.
-        if !cfg!(unix) {
-            return;
-        }
         let temp = tempfile::tempdir().expect("temp dir");
         let files = HookFiles::write_in(temp.path()).expect("must write");
         let forwarder = files.settings_path().with_file_name(FORWARDER_NAME);
@@ -882,13 +881,12 @@ mod tests {
         );
     }
 
+    /// `#[cfg(unix)]`: as above, the body is a real `/bin/sh` run.
+    #[cfg(unix)]
     #[test]
     fn the_forwarder_exits_zero_even_when_the_listener_is_dead() {
         // A hook that exits non-zero blocks the agent's tool call. Jerry having quit must never
         // do that, so this points the forwarder at a port nothing is listening on.
-        if !cfg!(unix) {
-            return;
-        }
         let temp = tempfile::tempdir().expect("temp dir");
         let files = HookFiles::write_in(temp.path()).expect("must write");
         let forwarder = files.settings_path().with_file_name(FORWARDER_NAME);
@@ -961,7 +959,9 @@ mod tests {
             assert!(command.starts_with('\''), "got {command:?}");
         }
 
-        if cfg!(unix) {
+        #[cfg(unix)]
+        {
+            // Run the generated command string through a real shell to prove it resolves.
             let output = std::process::Command::new("/bin/sh")
                 .arg("-c")
                 .arg(command)
@@ -1200,12 +1200,17 @@ mod tests {
         }
     }
 
+    /// `#[cfg(unix)]` on a test about the *Windows* command string is not a mistake: the claim
+    /// under test is that that string is *also* a valid Git Bash command line, so checking it
+    /// requires a real POSIX shell and a real `sh`-executable stand-in interpreter. It is the
+    /// POSIX tokenizer that is the subject; Windows is only where the string is destined.
+    #[cfg(unix)]
     #[test]
     // Flaky under the full parallel suite: GitHub issue #320 (ETXTBSY - another test's
     // Command::spawn can fork while this test's stand-in script is still open for writing).
     // Ignored here so `cargo test --workspace` in CI is a trustworthy gate; run directly with
     // `cargo test -p app the_generated_windows_command_tokenizes -- --ignored` to exercise it.
-    #[ignore]
+    #[ignore = "flaky under the parallel suite: ETXTBSY, GitHub issue #320; see docs/testing.md"]
     fn the_generated_windows_command_tokenizes_identically_under_a_real_posix_shell() {
         // The module docs claim the Windows command string is deliberately *also* a valid Git Bash
         // command line, as insurance against a Claude Code that ignores the `shell` field. That is
@@ -1216,9 +1221,6 @@ mod tests {
         // A stand-in `powershell.exe` on `PATH` prints its argument vector one element per line,
         // so this pins the real thing that matters: that a temp path full of spaces, parentheses,
         // dollars and backticks arrives as exactly *one* argument, unexpanded.
-        if !cfg!(unix) {
-            return;
-        }
         let temp = tempfile::tempdir().expect("temp dir");
         let bin = temp.path().join("bin");
         std::fs::create_dir_all(&bin).expect("bin");
@@ -1249,23 +1251,26 @@ mod tests {
         // exec specifically on that signature - rather than looping on some fd of our own - is
         // the correct fix, not a band-aid: it is bounded, narrowly targeted at the one known
         // transient cause, and does not mask any other failure mode.
-        let mut attempt = 0;
-        let output = loop {
-            attempt += 1;
-            let output = std::process::Command::new("/bin/sh")
+        let run = || {
+            std::process::Command::new("/bin/sh")
                 .arg("-c")
                 .arg(command)
                 .env("PATH", &bin)
                 .stdin(std::process::Stdio::null())
                 .output()
-                .expect("the generated command must be runnable by a real POSIX shell");
-            let is_etxtbsy = !output.status.success()
-                && String::from_utf8_lossy(&output.stderr).contains("Text file busy");
-            if !is_etxtbsy || attempt >= 20 {
-                break output;
-            }
-            std::thread::sleep(std::time::Duration::from_millis(5));
+                .expect("the generated command must be runnable by a real POSIX shell")
         };
+        let mut output = run();
+        // Retrying *is* the wait here: the condition is "the exec stopped hitting the transient
+        // ETXTBSY", so each poll re-runs the command rather than sleeping beside it.
+        test_support::wait_until(std::time::Duration::from_millis(100), || {
+            let settled = output.status.success()
+                || !String::from_utf8_lossy(&output.stderr).contains("Text file busy");
+            if !settled {
+                output = run();
+            }
+            settled
+        });
         assert!(
             output.status.success(),
             "the generated command must parse: {}",
@@ -1613,19 +1618,18 @@ mod tests {
             }
 
             let mut seen: Vec<String> = Vec::new();
-            for _ in 0..20 {
-                seen.extend(
-                    std::fs::read_dir(&directory)
-                        .expect("read launch dir")
-                        .flatten()
-                        .map(|entry| entry.file_name().to_string_lossy().into_owned())
-                        .filter(|name| name != SETTINGS_NAME && name != WINDOWS_FORWARDER_NAME),
-                );
-                if !seen.is_empty() {
-                    break;
-                }
-                std::thread::sleep(std::time::Duration::from_millis(50));
-            }
+            let extra_entries = || {
+                std::fs::read_dir(&directory)
+                    .expect("read launch dir")
+                    .flatten()
+                    .map(|entry| entry.file_name().to_string_lossy().into_owned())
+                    .filter(|name| name != SETTINGS_NAME && name != WINDOWS_FORWARDER_NAME)
+                    .collect::<Vec<_>>()
+            };
+            test_support::wait_until(std::time::Duration::from_secs(1), || {
+                seen = extra_entries();
+                !seen.is_empty()
+            });
             let output = child.wait_with_output().expect("wait");
             seen.extend(
                 std::fs::read_dir(&directory)

--- a/crates/app/src/keymap.rs
+++ b/crates/app/src/keymap.rs
@@ -253,13 +253,11 @@ mod tests {
 
     #[test]
     fn resolve_keystroke_renders_the_secondary_modifier_as_the_cross_platform_mod_glyph() {
-        // What `gpui::Keystroke::parse("secondary-n")` produces on a non-macOS build -
-        // `modifiers.control == true`, `modifiers.platform == false`.
+        // `Modifiers::secondary_key()`, not a hand-built `control: true`: `secondary()` reads
+        // `platform` on macOS and `control` elsewhere, so only the constructor gpui pairs with it
+        // produces a keystroke that really is secondary on the build actually running this test.
         let keystroke = gpui::Keystroke {
-            modifiers: gpui::Modifiers {
-                control: true,
-                ..Default::default()
-            },
+            modifiers: gpui::Modifiers::secondary_key(),
             key: "n".to_string(),
             key_char: None,
         };
@@ -290,12 +288,26 @@ mod tests {
         );
     }
 
-    // `resolve_keystroke`'s `else if modifiers.control` branch (a literal `ctrl` held *without*
-    // `secondary`) is only reachable on a real macOS build: on this Linux dev/test sandbox,
-    // `Modifiers::secondary()` *is* `modifiers.control`, so any keystroke with `control: true`
-    // already takes the `secondary` branch first. Not tested here for the same reason
-    // `WindowControlsStyle`'s own docs give for its `cfg!(target_os = "macos")`-gated behavior:
-    // real, compile-time-correct code this sandbox cannot compile-and-run the other branch of.
+    /// `resolve_keystroke`'s `else if modifiers.control` branch - a literal `ctrl` held *without*
+    /// `secondary`, as `crate::default_key_bindings`'s `"ctrl-shift-t"` really is - is only
+    /// reachable where `secondary()` reads `platform` rather than `control`, i.e. macOS.
+    /// Elsewhere `control: true` takes the `secondary` branch first and this asserts nothing.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn a_literal_control_without_secondary_falls_back_to_the_physical_ctrl_glyph() {
+        let keystroke = gpui::Keystroke {
+            modifiers: gpui::Modifiers {
+                control: true,
+                ..Default::default()
+            },
+            key: "t".to_string(),
+            key_char: None,
+        };
+        assert_eq!(
+            resolve_keystroke(&keystroke, true),
+            vec!["\u{2303}".to_string(), "T".to_string()]
+        );
+    }
 
     #[test]
     fn labels_are_the_real_command_palette_display_strings() {

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -55,6 +55,11 @@ pub mod sidebar;
 pub mod sound;
 pub mod status_bar;
 pub mod terminal;
+// The GPUI half of this workspace's shared fixtures; the gpui-free half is `crates/test-support`
+// (see that crate's docs and `docs/testing.md`). `cfg(test)`, so none of it is compiled into the
+// shipped binary.
+#[cfg(test)]
+pub(crate) mod test_support;
 pub mod text_history;
 pub mod theme;
 // `pub(crate)`, unlike every other feature folder above: this one exposes no public item at
@@ -969,6 +974,9 @@ mod open_ade_window_tests {
     #[gpui::test]
     fn reopen_shape_restores_the_remembered_repo(cx: &mut gpui::TestAppContext) {
         let repo = tempfile::tempdir().expect("tempdir");
+        // `AdeApp` canonicalizes the root it is opened with, so a bare `TempDir::path()` would be
+        // compared against its own `/private/var` resolution below and never match on macOS.
+        let repo_path = std::fs::canonicalize(repo.path()).expect("canonical tempdir");
         let settings_dir = tempfile::tempdir().expect("tempdir");
         let settings_path = settings_dir.path().join("settings.toml");
 
@@ -980,7 +988,7 @@ mod open_ade_window_tests {
         // window-less `update`, which `VisualTestContext` doesn't have the same shape of.
         let (_first, _first_window_cx) = cx.add_window_view(|window, cx| {
             AdeApp::new_with_settings(
-                Some(repo.path().to_path_buf()),
+                Some(repo_path.clone()),
                 true,
                 settings_store::Settings::default(),
                 Some(settings_path.clone()),
@@ -1008,7 +1016,7 @@ mod open_ade_window_tests {
         app.read_with(cx, |app, _| {
             assert_eq!(
                 app.focused_repo_path(),
-                repo.path(),
+                repo_path,
                 "a Dock reopen must restore the same repo a fresh relaunch would, not a bare \
                  empty window"
             );

--- a/crates/app/src/lsp/client.rs
+++ b/crates/app/src/lsp/client.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::lsp::completion_popup::{CompletionsEntry, CompletionsStatus};
 #[cfg(test)]
-use crate::root::focus::palette_focus_tests;
+use crate::test_support::open_test_app;
 
 /// [`AdeApp::lsp_clients`]' real key: a repository root paired with the real server binary
 /// running for it - see that field's own docs for why a bare `PathBuf` was widened to this
@@ -2041,12 +2041,12 @@ mod lsp_client_eviction_tests {
     fn switching_between_several_worktrees_never_lets_lsp_clients_grow_past_one(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let worktree_a = tempfile::tempdir().expect("tempdir a");
-        let worktree_b = tempfile::tempdir().expect("tempdir b");
-        let worktree_c = tempfile::tempdir().expect("tempdir c");
+        let repo = crate::lsp::fixtures::temp_repo();
+        let worktree_a = crate::lsp::fixtures::temp_repo();
+        let worktree_b = crate::lsp::fixtures::temp_repo();
+        let worktree_c = crate::lsp::fixtures::temp_repo();
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
 
         app.update(cx, |app, _cx| {
             app.worktrees = vec![
@@ -2112,11 +2112,11 @@ mod lsp_client_eviction_tests {
     fn a_worktree_switch_evicts_every_language_client_for_the_old_root_not_just_one(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let worktree_old = tempfile::tempdir().expect("tempdir old");
-        let worktree_new = tempfile::tempdir().expect("tempdir new");
+        let repo = crate::lsp::fixtures::temp_repo();
+        let worktree_old = crate::lsp::fixtures::temp_repo();
+        let worktree_new = crate::lsp::fixtures::temp_repo();
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
 
         app.update(cx, |app, _cx| {
             app.worktrees = vec![
@@ -2359,15 +2359,12 @@ process.stdin.on('data', (d) => {
                 serde_json::json!({ "uri": target, "message": message }),
             )
             .expect("the fake server should accept a real notification");
-        let deadline = Instant::now() + Duration::from_secs(10);
         let target = uri(target);
-        while !client.has_diagnostics_result_uri(&target) {
-            assert!(
-                Instant::now() < deadline,
-                "the real publishDiagnostics push never landed in the client's own sink"
-            );
-            std::thread::sleep(Duration::from_millis(10));
-        }
+        assert!(
+            test_support::wait_until(Duration::from_secs(10), || client
+                .has_diagnostics_result_uri(&target)),
+            "the real publishDiagnostics push never landed in the client's own sink"
+        );
     }
 
     /// Same real push as [`publish_and_wait`], at an explicit `character..character_end` UTF-16
@@ -2393,15 +2390,12 @@ process.stdin.on('data', (d) => {
                 }),
             )
             .expect("the fake server should accept a real notification");
-        let deadline = Instant::now() + Duration::from_secs(10);
         let target = uri(target);
-        while !client.has_diagnostics_result_uri(&target) {
-            assert!(
-                Instant::now() < deadline,
-                "the real publishDiagnostics push never landed in the client's own sink"
-            );
-            std::thread::sleep(Duration::from_millis(10));
-        }
+        assert!(
+            test_support::wait_until(Duration::from_secs(10), || client
+                .has_diagnostics_result_uri(&target)),
+            "the real publishDiagnostics push never landed in the client's own sink"
+        );
     }
 
     /// Same real push as [`publish_and_wait`], at a real `line` and a real `severity`, naming a
@@ -2427,15 +2421,12 @@ process.stdin.on('data', (d) => {
                 }),
             )
             .expect("the fake server should accept a real notification");
-        let deadline = Instant::now() + Duration::from_secs(10);
         let target = uri(target);
-        while !client.has_diagnostics_result_uri(&target) {
-            assert!(
-                Instant::now() < deadline,
-                "the real publishDiagnostics push never landed in the client's own sink"
-            );
-            std::thread::sleep(Duration::from_millis(10));
-        }
+        assert!(
+            test_support::wait_until(Duration::from_secs(10), || client
+                .has_diagnostics_result_uri(&target)),
+            "the real publishDiagnostics push never landed in the client's own sink"
+        );
     }
 
     /// Same real push as [`publish_and_wait`], but carrying the `source` and `code` fields a real
@@ -2461,33 +2452,28 @@ process.stdin.on('data', (d) => {
                 }),
             )
             .expect("the fake server should accept a real notification");
-        let deadline = Instant::now() + Duration::from_secs(10);
         let target = uri(target);
-        while !client.has_diagnostics_result_uri(&target) {
-            assert!(
-                Instant::now() < deadline,
-                "the real publishDiagnostics push never landed in the client's own sink"
-            );
-            std::thread::sleep(Duration::from_millis(10));
-        }
+        assert!(
+            test_support::wait_until(Duration::from_secs(10), || client
+                .has_diagnostics_result_uri(&target)),
+            "the real publishDiagnostics push never landed in the client's own sink"
+        );
     }
 
     fn wait_for_relay_observation(client: &lsp_core::LspClient) -> String {
         let observed = uri("file:///relay-observed");
-        let deadline = Instant::now() + Duration::from_secs(30);
-        loop {
-            if let Some(diagnostics) = client.diagnostics_for_uri(&observed) {
-                if let Some(first) = diagnostics.first() {
-                    return first.message.clone();
-                }
-            }
-            assert!(
-                Instant::now() < deadline,
-                "the primary never observed any relay response at all - a hanging primary is \
-                 exactly the failure this path must never produce"
-            );
-            std::thread::sleep(Duration::from_millis(20));
-        }
+        let mut message = None;
+        assert!(
+            test_support::wait_until(Duration::from_secs(30), || {
+                message = client
+                    .diagnostics_for_uri(&observed)
+                    .and_then(|diagnostics| diagnostics.first().map(|first| first.message.clone()));
+                message.is_some()
+            }),
+            "the primary never observed any relay response at all - a hanging primary is \
+             exactly the failure this path must never produce"
+        );
+        message.expect("the wait above only returns true once a real message landed")
     }
 
     #[test]
@@ -2566,7 +2552,7 @@ process.stdin.on('data', (d) => {
 
     #[test]
     fn a_two_server_connection_merges_both_halves_real_diagnostics() {
-        let root = tempfile::tempdir().expect("tempdir");
+        let root = crate::lsp::fixtures::temp_repo();
         let primary = spawn_fake_server(root.path(), "primary", "normal");
         let companion = spawn_fake_server(root.path(), "companion", "normal");
         let target = "file:///merged.vue";
@@ -2610,7 +2596,7 @@ process.stdin.on('data', (d) => {
 
     #[test]
     fn a_single_server_connection_passes_diagnostics_straight_through() {
-        let root = tempfile::tempdir().expect("tempdir");
+        let root = crate::lsp::fixtures::temp_repo();
         let client = spawn_fake_server(root.path(), "solo", "normal");
         let connection = LspConnection::Single(client.clone());
         let target = "file:///solo.rs";
@@ -2626,7 +2612,7 @@ process.stdin.on('data', (d) => {
 
     #[test]
     fn hover_falls_back_to_the_companion_when_the_primary_has_nothing() {
-        let root = tempfile::tempdir().expect("tempdir");
+        let root = crate::lsp::fixtures::temp_repo();
         let primary = spawn_fake_server(root.path(), "primary", "normal");
         let companion = spawn_fake_server(root.path(), "companion", "hover");
         let params = lsp_core::lsp_types::HoverParams {
@@ -2701,7 +2687,7 @@ process.stdin.on('data', (d) => {
 
     #[test]
     fn goto_definition_falls_back_to_the_companion_on_an_empty_array_answer() {
-        let root = tempfile::tempdir().expect("tempdir");
+        let root = crate::lsp::fixtures::temp_repo();
         let primary = spawn_fake_server(root.path(), "primary", "normal");
 
         let single = LspConnection::Single(primary.clone());
@@ -2745,7 +2731,7 @@ process.stdin.on('data', (d) => {
 
     #[test]
     fn completion_falls_back_to_the_companion_on_an_empty_completion_list() {
-        let root = tempfile::tempdir().expect("tempdir");
+        let root = crate::lsp::fixtures::temp_repo();
         let primary = spawn_fake_server(root.path(), "primary", "normal");
 
         let single = LspConnection::Single(primary.clone());
@@ -2787,15 +2773,14 @@ process.stdin.on('data', (d) => {
     fn a_debounced_re_sync_never_drops_an_already_ready_popup_back_to_loading(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::lsp::fixtures::temp_repo();
         let root = repo.path().to_path_buf();
         std::fs::create_dir_all(root.join("src")).expect("mkdir src");
         let absolute = root.join("src").join("main.rs");
         std::fs::write(&absolute, "fn a() {\n    x\n}\n").expect("write main.rs");
         let relative = PathBuf::from("src/main.rs");
 
-        let (app, cx): (Entity<AdeApp>, &mut VisualTestContext) =
-            palette_focus_tests::open_test_app(cx, root.clone());
+        let (app, cx): (Entity<AdeApp>, &mut VisualTestContext) = open_test_app(cx, root.clone());
         let server = spawn_fake_server(repo.path(), "rust-analyzer", "normal");
         app.update_in(cx, |app, window, cx| {
             app.lsp_clients.insert(
@@ -2810,19 +2795,14 @@ process.stdin.on('data', (d) => {
         // lsp_uri_cache` has a real entry for this path - populated by `Self::dispatch_did_open`'s
         // own background task, which `Self::render_center_pane` is what actually drives here
         // (mirroring `wait_for_real_diagnostics`'s own reasoning).
-        let uri_cache_deadline = std::time::Instant::now() + Duration::from_secs(10);
-        loop {
-            app.update(cx, |app, cx| app.render_center_pane(cx));
-            cx.run_until_parked();
-            if app.read_with(cx, |app, _| app.lsp_uri_cache.contains_key(&absolute)) {
-                break;
-            }
-            assert!(
-                std::time::Instant::now() < uri_cache_deadline,
-                "the fake client's uri never reached AdeApp::lsp_uri_cache"
-            );
-            std::thread::sleep(Duration::from_millis(20));
-        }
+        assert!(
+            crate::lsp::fixtures::wait_until_parked(cx, Duration::from_secs(10), |cx| {
+                app.update(cx, |app, cx| app.render_center_pane(cx));
+                cx.run_until_parked();
+                app.read_with(cx, |app, _| app.lsp_uri_cache.contains_key(&absolute))
+            }),
+            "the fake client's uri never reached AdeApp::lsp_uri_cache"
+        );
 
         // A pre-existing `Ready` popup for this exact path, seeded directly - standing in for
         // whatever real server response is already showing by the time a later keystroke's
@@ -2869,15 +2849,14 @@ process.stdin.on('data', (d) => {
 
     #[gpui::test]
     fn accepting_a_completion_does_not_immediately_reopen_the_popup(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::lsp::fixtures::temp_repo();
         let root = repo.path().to_path_buf();
         std::fs::create_dir_all(root.join("src")).expect("mkdir src");
         let absolute = root.join("src").join("main.rs");
         std::fs::write(&absolute, "fn a() {\n    \n}\n").expect("write main.rs");
         let relative = PathBuf::from("src/main.rs");
 
-        let (app, cx): (Entity<AdeApp>, &mut VisualTestContext) =
-            palette_focus_tests::open_test_app(cx, root.clone());
+        let (app, cx): (Entity<AdeApp>, &mut VisualTestContext) = open_test_app(cx, root.clone());
         let server = spawn_fake_server(repo.path(), "rust-analyzer", "normal");
         app.update_in(cx, |app, window, cx| {
             app.lsp_clients.insert(
@@ -2960,14 +2939,13 @@ process.stdin.on('data', (d) => {
     fn selecting_a_completion_item_resolves_its_real_detail_and_documentation(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::lsp::fixtures::temp_repo();
         let root = repo.path().to_path_buf();
         let absolute = root.join("main.rs");
         std::fs::write(&absolute, "fn a() {}\n").expect("write main.rs");
         let relative = PathBuf::from("main.rs");
 
-        let (app, cx): (Entity<AdeApp>, &mut VisualTestContext) =
-            palette_focus_tests::open_test_app(cx, root.clone());
+        let (app, cx): (Entity<AdeApp>, &mut VisualTestContext) = open_test_app(cx, root.clone());
         let server = spawn_fake_server(repo.path(), "rust-analyzer", "normal");
         app.update_in(cx, |app, window, cx| {
             app.lsp_clients.insert(
@@ -3032,14 +3010,13 @@ process.stdin.on('data', (d) => {
     fn a_real_resolved_detail_replaces_a_placeholder_the_server_sent_inline(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::lsp::fixtures::temp_repo();
         let root = repo.path().to_path_buf();
         let absolute = root.join("main.rs");
         std::fs::write(&absolute, "fn a() {}\n").expect("write main.rs");
         let relative = PathBuf::from("main.rs");
 
-        let (app, cx): (Entity<AdeApp>, &mut VisualTestContext) =
-            palette_focus_tests::open_test_app(cx, root.clone());
+        let (app, cx): (Entity<AdeApp>, &mut VisualTestContext) = open_test_app(cx, root.clone());
         let server = spawn_fake_server(repo.path(), "rust-analyzer", "normal");
         app.update_in(cx, |app, window, cx| {
             app.lsp_clients.insert(
@@ -3098,14 +3075,13 @@ process.stdin.on('data', (d) => {
     fn an_item_whose_resolve_was_cancelled_by_moving_on_is_resolved_again_on_return(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::lsp::fixtures::temp_repo();
         let root = repo.path().to_path_buf();
         let absolute = root.join("main.rs");
         std::fs::write(&absolute, "fn a() {}\n").expect("write main.rs");
         let relative = PathBuf::from("main.rs");
 
-        let (app, cx): (Entity<AdeApp>, &mut VisualTestContext) =
-            palette_focus_tests::open_test_app(cx, root.clone());
+        let (app, cx): (Entity<AdeApp>, &mut VisualTestContext) = open_test_app(cx, root.clone());
         let server = spawn_fake_server(repo.path(), "rust-analyzer", "normal");
         app.update_in(cx, |app, window, cx| {
             app.lsp_clients.insert(
@@ -3185,14 +3161,13 @@ process.stdin.on('data', (d) => {
 
     #[gpui::test]
     fn an_item_with_a_resolve_already_in_flight_is_not_asked_twice(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::lsp::fixtures::temp_repo();
         let root = repo.path().to_path_buf();
         let absolute = root.join("main.rs");
         std::fs::write(&absolute, "fn a() {}\n").expect("write main.rs");
         let relative = PathBuf::from("main.rs");
 
-        let (app, cx): (Entity<AdeApp>, &mut VisualTestContext) =
-            palette_focus_tests::open_test_app(cx, root.clone());
+        let (app, cx): (Entity<AdeApp>, &mut VisualTestContext) = open_test_app(cx, root.clone());
         let server = spawn_fake_server(repo.path(), "rust-analyzer", "normal");
         app.update_in(cx, |app, window, cx| {
             app.lsp_clients.insert(
@@ -3262,14 +3237,13 @@ process.stdin.on('data', (d) => {
 
     #[gpui::test]
     fn a_server_without_resolve_support_is_never_asked_to_resolve(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::lsp::fixtures::temp_repo();
         let root = repo.path().to_path_buf();
         let absolute = root.join("main.vue");
         std::fs::write(&absolute, "<template></template>\n").expect("write main.vue");
         let relative = PathBuf::from("main.vue");
 
-        let (app, cx): (Entity<AdeApp>, &mut VisualTestContext) =
-            palette_focus_tests::open_test_app(cx, root.clone());
+        let (app, cx): (Entity<AdeApp>, &mut VisualTestContext) = open_test_app(cx, root.clone());
         // `vue-language-server` is the fake client key `crate::language::lsp_binary_for_extension`
         // resolves for `.vue` - reused here purely to get a `Ready` client under the right key,
         // not because this test cares about the real Vue companion mechanism at all.
@@ -3311,7 +3285,7 @@ process.stdin.on('data', (d) => {
 
     #[test]
     fn a_request_outside_the_fallback_list_never_consults_the_companion() {
-        let root = tempfile::tempdir().expect("tempdir");
+        let root = crate::lsp::fixtures::temp_repo();
         let spec = vue_companion_spec();
         assert!(
             !spec.fallback_methods.contains(&"textDocument/references"),
@@ -3414,7 +3388,7 @@ process.stdin.on('data', (d) => {
 
     #[test]
     fn a_dead_companion_flips_liveness_and_is_named_in_the_real_status() {
-        let root = tempfile::tempdir().expect("tempdir");
+        let root = crate::lsp::fixtures::temp_repo();
         let primary = spawn_fake_server(root.path(), "vue-language-server", "normal");
         let companion =
             spawn_fake_server(root.path(), "typescript-language-server (vue)", "normal");
@@ -3430,15 +3404,12 @@ process.stdin.on('data', (d) => {
             .notify_raw("test/die", serde_json::Value::Null)
             .expect("the fake server should accept the notification that kills it");
 
-        let deadline = Instant::now() + Duration::from_secs(10);
-        while connection.is_connection_alive() {
-            assert!(
-                Instant::now() < deadline,
-                "a WithCompanion connection must stop reporting itself alive once either half's \
-                 real process dies"
-            );
-            std::thread::sleep(Duration::from_millis(20));
-        }
+        assert!(
+            test_support::wait_until(Duration::from_secs(10), || !connection
+                .is_connection_alive()),
+            "a WithCompanion connection must stop reporting itself alive once either half's \
+             real process dies"
+        );
         let reason = connection
             .liveness_failure_reason()
             .expect("a dead half must produce a real reason");
@@ -3464,7 +3435,7 @@ process.stdin.on('data', (d) => {
 
     #[test]
     fn a_dead_primary_is_named_rather_than_blamed_on_the_companion() {
-        let root = tempfile::tempdir().expect("tempdir");
+        let root = crate::lsp::fixtures::temp_repo();
         let primary = spawn_fake_server(root.path(), "vue-language-server", "normal");
         let connection = LspConnection::WithCompanion {
             primary: primary.clone(),
@@ -3474,26 +3445,24 @@ process.stdin.on('data', (d) => {
         primary
             .notify_raw("test/die", serde_json::Value::Null)
             .expect("notification accepted");
-        let deadline = Instant::now() + Duration::from_secs(10);
-        loop {
-            if let Some(reason) = connection.liveness_failure_reason() {
-                assert!(
-                    reason.contains("vue-language-server"),
-                    "the message must name the real primary, got: {reason}"
-                );
-                break;
-            }
-            assert!(
-                Instant::now() < deadline,
-                "the dead primary was never noticed"
-            );
-            std::thread::sleep(Duration::from_millis(20));
-        }
+        let mut reason = None;
+        assert!(
+            test_support::wait_until(Duration::from_secs(10), || {
+                reason = connection.liveness_failure_reason();
+                reason.is_some()
+            }),
+            "the dead primary was never noticed"
+        );
+        let reason = reason.expect("the wait above only returns true once a reason landed");
+        assert!(
+            reason.contains("vue-language-server"),
+            "the message must name the real primary, got: {reason}"
+        );
     }
 
     #[test]
     fn a_companion_that_failed_to_spawn_is_surfaced_in_the_real_file_status() {
-        let root = tempfile::tempdir().expect("tempdir");
+        let root = crate::lsp::fixtures::temp_repo();
         let primary = spawn_fake_server(root.path(), "vue-language-server", "normal");
         let connection = LspConnection::Single(primary.clone());
         let status = lsp_file_status(
@@ -3512,7 +3481,7 @@ process.stdin.on('data', (d) => {
 
     #[test]
     fn a_still_spawning_companion_leaves_the_primarys_own_status_intact() {
-        let root = tempfile::tempdir().expect("tempdir");
+        let root = crate::lsp::fixtures::temp_repo();
         let primary = spawn_fake_server(root.path(), "vue-language-server", "normal");
         let connection = LspConnection::Single(primary.clone());
         let status = lsp_file_status(
@@ -3530,20 +3499,16 @@ process.stdin.on('data', (d) => {
 
     /// Waits for a genuinely spawned server's real process death to be observed by its client.
     fn wait_until_dead(client: &lsp_core::LspClient) {
-        let deadline = Instant::now() + Duration::from_secs(10);
-        while client.is_connection_alive() {
-            assert!(
-                Instant::now() < deadline,
-                "the real process death should have been observed within 10s"
-            );
-            std::thread::sleep(Duration::from_millis(20));
-        }
+        assert!(
+            test_support::wait_until(Duration::from_secs(10), || !client.is_connection_alive()),
+            "the real process death should have been observed within 10s"
+        );
     }
 
     #[gpui::test]
     fn a_dead_ready_client_is_reaped_into_a_real_named_failed_state(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::lsp::fixtures::temp_repo();
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         let client = spawn_fake_server(repo.path(), "rust-analyzer", "normal");
         let key: LspClientKey = (repo.path().to_path_buf(), "rust-analyzer");
 
@@ -3599,9 +3564,9 @@ process.stdin.on('data', (d) => {
     fn restarting_clears_the_dead_client_and_all_of_its_document_bookkeeping(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::lsp::fixtures::temp_repo();
         let root = repo.path().to_path_buf();
-        let (app, cx) = palette_focus_tests::open_test_app(cx, root.clone());
+        let (app, cx) = open_test_app(cx, root.clone());
         let opened = root.join("src").join("main.rs");
         let relative = PathBuf::from("src/main.rs");
 
@@ -3652,14 +3617,14 @@ process.stdin.on('data', (d) => {
     async fn a_restart_drops_the_in_flight_tasks_that_would_repopulate_cleared_bookkeeping(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::lsp::fixtures::temp_repo();
         let root = repo.path().to_path_buf();
         std::fs::create_dir_all(root.join("src")).expect("mkdir src");
         let absolute = root.join("src").join("main.rs");
         std::fs::write(&absolute, "fn main() {}\n").expect("write main.rs");
         let relative = PathBuf::from("src/main.rs");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, root.clone());
+        let (app, cx) = open_test_app(cx, root.clone());
         let server = spawn_fake_server(repo.path(), "rust-analyzer", "normal");
         app.update_in(cx, |app, window, cx| {
             app.lsp_clients.insert(
@@ -3709,9 +3674,9 @@ process.stdin.on('data', (d) => {
 
     #[gpui::test]
     fn the_restart_palette_command_runs_the_real_restart(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::lsp::fixtures::temp_repo();
         let root = repo.path().to_path_buf();
-        let (app, cx) = palette_focus_tests::open_test_app(cx, root.clone());
+        let (app, cx) = open_test_app(cx, root.clone());
 
         app.update(cx, |app, _cx| {
             app.lsp_clients.insert(
@@ -3745,9 +3710,9 @@ process.stdin.on('data', (d) => {
 
     #[gpui::test]
     async fn a_restart_frees_the_key_so_a_fresh_spawn_is_really_attempted(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::lsp::fixtures::temp_repo();
         let root = repo.path().to_path_buf();
-        let (app, cx) = palette_focus_tests::open_test_app(cx, root.clone());
+        let (app, cx) = open_test_app(cx, root.clone());
         let key: LspClientKey = (root.clone(), "rust-analyzer");
 
         let first = spawn_fake_server(repo.path(), "rust-analyzer", "normal");
@@ -3817,7 +3782,7 @@ process.stdin.on('data', (d) => {
     async fn restarting_one_server_leaves_every_other_live_client_untouched(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::lsp::fixtures::temp_repo();
         let root = repo.path().to_path_buf();
         std::fs::create_dir_all(root.join("src")).expect("mkdir src");
         let rust_absolute = root.join("src").join("main.rs");
@@ -3827,7 +3792,7 @@ process.stdin.on('data', (d) => {
         let rust_relative = PathBuf::from("src/main.rs");
         let ts_relative = PathBuf::from("src/app.ts");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, root.clone());
+        let (app, cx) = open_test_app(cx, root.clone());
         let rust_server = spawn_fake_server(repo.path(), "rust-analyzer", "normal");
         let ts_server = spawn_fake_server(repo.path(), "typescript-language-server", "normal");
         app.update_in(cx, |app, window, cx| {
@@ -3937,7 +3902,7 @@ process.stdin.on('data', (d) => {
     async fn restarting_every_server_still_forgets_the_whole_roots_conversation(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::lsp::fixtures::temp_repo();
         let root = repo.path().to_path_buf();
         std::fs::create_dir_all(root.join("src")).expect("mkdir src");
         let rust_absolute = root.join("src").join("main.rs");
@@ -3947,7 +3912,7 @@ process.stdin.on('data', (d) => {
         let rust_relative = PathBuf::from("src/main.rs");
         let ts_relative = PathBuf::from("src/app.ts");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, root.clone());
+        let (app, cx) = open_test_app(cx, root.clone());
         let rust_server = spawn_fake_server(repo.path(), "rust-analyzer", "normal");
         let ts_server = spawn_fake_server(repo.path(), "typescript-language-server", "normal");
         app.update_in(cx, |app, window, cx| {
@@ -4006,13 +3971,13 @@ process.stdin.on('data', (d) => {
     }
 
     #[gpui::test]
-    #[ignore]
+    #[ignore = "external: vue-language-server; see docs/testing.md"]
     fn restarting_a_companion_forgets_its_own_documents_without_touching_its_primary(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::lsp::fixtures::temp_repo();
         let root = repo.path().to_path_buf();
-        let (app, cx) = palette_focus_tests::open_test_app(cx, root.clone());
+        let (app, cx) = open_test_app(cx, root.clone());
         let spec = vue_companion_spec();
         let vue_absolute = root.join("src").join("App.vue");
         let vue_relative = PathBuf::from("src/App.vue");
@@ -4076,9 +4041,9 @@ process.stdin.on('data', (d) => {
 
     #[gpui::test]
     fn the_restartable_server_list_is_the_real_live_client_map(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::lsp::fixtures::temp_repo();
         let root = repo.path().to_path_buf();
-        let (app, cx) = palette_focus_tests::open_test_app(cx, root.clone());
+        let (app, cx) = open_test_app(cx, root.clone());
         let ready = spawn_fake_server(repo.path(), "rust-analyzer", "normal");
 
         app.update(cx, |app, _cx| {
@@ -4126,8 +4091,8 @@ process.stdin.on('data', (d) => {
     fn a_real_relay_round_trip_delivers_the_companions_body_in_the_real_wire_shape(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::lsp::fixtures::temp_repo();
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         let spec = vue_companion_spec();
         let primary = spawn_fake_server(repo.path(), "vue-language-server", "normal");
         let companion = spawn_fake_server(repo.path(), spec.client_key, "normal");
@@ -4167,8 +4132,8 @@ process.stdin.on('data', (d) => {
     fn a_companion_that_never_answers_still_gets_a_real_null_response_back_to_the_primary(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::lsp::fixtures::temp_repo();
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         let spec = vue_companion_spec();
         let primary = spawn_fake_server(repo.path(), "vue-language-server", "normal");
         let companion = spawn_fake_server(repo.path(), spec.client_key, "silent");
@@ -4211,8 +4176,8 @@ process.stdin.on('data', (d) => {
     fn a_relay_arriving_before_the_companion_is_ready_still_answers_the_primary(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::lsp::fixtures::temp_repo();
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         let spec = vue_companion_spec();
         let primary = spawn_fake_server(repo.path(), "vue-language-server", "normal");
 
@@ -4243,7 +4208,7 @@ process.stdin.on('data', (d) => {
 
     #[test]
     fn only_a_companion_that_really_advertises_pull_support_becomes_a_pull_target() {
-        let root = tempfile::tempdir().expect("tempdir");
+        let root = crate::lsp::fixtures::temp_repo();
         let primary = spawn_fake_server(root.path(), "primary", "pull");
 
         assert!(
@@ -4281,8 +4246,8 @@ process.stdin.on('data', (d) => {
     fn a_relay_with_a_real_id_but_a_malformed_command_still_answers_the_primary(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::lsp::fixtures::temp_repo();
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         let spec = vue_companion_spec();
         let primary = spawn_fake_server(repo.path(), "vue-language-server", "normal");
         let companion = spawn_fake_server(repo.path(), spec.client_key, "normal");
@@ -4314,45 +4279,6 @@ process.stdin.on('data', (d) => {
             serde_json::from_str::<serde_json::Value>(&observed).expect("real JSON"),
             serde_json::json!([[13, null]]),
             "the real id must come back with an honest null body rather than nothing at all"
-        );
-    }
-
-    #[test]
-    fn single_delegation_stays_under_a_generous_1000ns_ceiling() {
-        let root = tempfile::tempdir().expect("tempdir");
-        let client = spawn_fake_server(root.path(), "bench", "normal");
-        let connection = LspConnection::Single(client.clone());
-        const ITERATIONS: u32 = 200_000;
-
-        for _ in 0..1_000 {
-            std::hint::black_box(client.supports_document_sync());
-            std::hint::black_box(connection.supports_document_sync());
-        }
-
-        let started = Instant::now();
-        for _ in 0..ITERATIONS {
-            std::hint::black_box(client.supports_document_sync());
-        }
-        let direct = started.elapsed();
-
-        let started = Instant::now();
-        for _ in 0..ITERATIONS {
-            std::hint::black_box(connection.supports_document_sync());
-        }
-        let through_facade = started.elapsed();
-
-        let direct_ns = direct.as_nanos() as f64 / f64::from(ITERATIONS);
-        let facade_ns = through_facade.as_nanos() as f64 / f64::from(ITERATIONS);
-        println!(
-            "supports_document_sync: direct {direct_ns:.1}ns/call, via LspConnection::Single \
-             {facade_ns:.1}ns/call, delta {:.1}ns",
-            facade_ns - direct_ns
-        );
-        assert!(
-            facade_ns - direct_ns < 1_000.0,
-            "the facade's enum match + delegate should stay well under this generous 1000ns \
-             ceiling; a real microsecond-or-more of added cost per call would mean it isn't the \
-             cheap branch it claims to be (direct {direct_ns:.1}ns, facade {facade_ns:.1}ns)"
         );
     }
 }
@@ -4401,8 +4327,8 @@ mod lsp_diagnostics_wiring_tests {
     /// Same minimal, dependency-free scratch cargo project shape as
     /// `lsp_core::client::tests::write_scratch_project` - kept as its own small copy here
     /// rather than exporting that one across the crate boundary.
-    fn write_scratch_project(main_rs: &str) -> tempfile::TempDir {
-        let dir = tempfile::TempDir::new().expect("tempdir");
+    fn write_scratch_project(main_rs: &str) -> crate::lsp::fixtures::TempRepo {
+        let dir = crate::lsp::fixtures::temp_repo();
         std::fs::write(
             dir.path().join("Cargo.toml"),
             "[package]\nname = \"app_lsp_wiring_fixture\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
@@ -4416,35 +4342,27 @@ mod lsp_diagnostics_wiring_tests {
     /// Repeatedly re-renders the centre pane and drains the deterministic test executor until
     /// `AdeApp::file_view_diagnostics` holds at least one diagnostic, or `deadline` passes. The
     /// real `publishDiagnostics` notification arrives on `lsp_core`'s own raw OS reader thread,
-    /// outside GPUI's scheduler entirely, so this must genuinely keep re-checking over real
-    /// time, like `lsp_core::client`'s own `wait_for_update` polling loop one layer down.
+    /// outside GPUI's scheduler entirely, so this must genuinely keep re-checking over real time.
     fn wait_for_real_diagnostics(
         app: &Entity<AdeApp>,
         cx: &mut VisualTestContext,
-        deadline: Instant,
+        deadline: Duration,
     ) {
-        loop {
-            app.update(cx, |app, cx| {
-                app.render_center_pane(cx);
-            });
-            cx.run_until_parked();
-
-            let has_diagnostics = app.read_with(cx, |app, _| !app.file_view_diagnostics.is_empty());
-            if has_diagnostics {
-                return;
-            }
-            assert!(
-                Instant::now() < deadline,
-                "no real diagnostic reached AdeApp::file_view_diagnostics within the caller's \
-                 real deadline (this helper is shared by callers with different real timeouts - \
-                 480s for rust-analyzer, 240s for typescript-language-server/pyright - so the \
-                 message deliberately doesn't hardcode either one)"
-            );
-            std::thread::sleep(Duration::from_millis(200));
-        }
+        assert!(
+            crate::lsp::fixtures::wait_until_parked(cx, deadline, |cx| {
+                app.update(cx, |app, cx| {
+                    app.render_center_pane(cx);
+                });
+                cx.run_until_parked();
+                app.read_with(cx, |app, _| !app.file_view_diagnostics.is_empty())
+            }),
+            "no real diagnostic reached AdeApp::file_view_diagnostics within the caller's own \
+             deadline"
+        );
     }
 
     #[gpui::test]
+    #[ignore = "external: rust-analyzer; see docs/testing.md"]
     fn a_real_diagnostic_reaches_file_view_diagnostics_through_the_real_app_code_path(
         cx: &mut TestAppContext,
     ) {
@@ -4454,7 +4372,7 @@ mod lsp_diagnostics_wiring_tests {
         );
         let main_rs = project.path().join("src").join("main.rs");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, project.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, project.path().to_path_buf());
 
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(main_rs.clone(), window, cx);
@@ -4464,8 +4382,7 @@ mod lsp_diagnostics_wiring_tests {
         // must happen before `ensure_lsp_client` ever gets a chance to run.
         cx.run_until_parked();
 
-        let deadline = Instant::now() + Duration::from_secs(480);
-        wait_for_real_diagnostics(&app, cx, deadline);
+        wait_for_real_diagnostics(&app, cx, Duration::from_secs(480));
 
         app.read_with(cx, |app, _| {
             let all_diagnostics: Vec<&diagnostics_view::LineDiagnostic> =
@@ -4545,12 +4462,12 @@ mod lsp_diagnostics_wiring_tests {
     }
 
     #[gpui::test]
-    #[ignore]
+    #[ignore = "external: typescript-language-server; see docs/testing.md"]
     fn a_real_typescript_diagnostic_reaches_file_view_diagnostics_through_the_real_app_code_path(
         cx: &mut TestAppContext,
     ) {
         let _serialize = serialize_real_lsp_subprocess_test();
-        let dir = tempfile::tempdir().expect("tempdir");
+        let dir = crate::lsp::fixtures::temp_repo();
         std::fs::write(
             dir.path().join("tsconfig.json"),
             "{\"compilerOptions\": {\"strict\": true, \"target\": \"ES2020\"}}\n",
@@ -4578,15 +4495,14 @@ mod lsp_diagnostics_wiring_tests {
             .expect("npm should be on PATH in this sandbox (real, live network install)");
         assert!(status.success(), "npm install typescript@5 failed");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, dir.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, dir.path().to_path_buf());
 
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(main_ts.clone(), window, cx);
         });
         cx.run_until_parked();
 
-        let deadline = Instant::now() + Duration::from_secs(240);
-        wait_for_real_diagnostics(&app, cx, deadline);
+        wait_for_real_diagnostics(&app, cx, Duration::from_secs(240));
 
         app.read_with(cx, |app, _| {
             let all_diagnostics: Vec<&diagnostics_view::LineDiagnostic> =
@@ -4625,21 +4541,20 @@ mod lsp_diagnostics_wiring_tests {
     fn wait_until(
         app: &Entity<AdeApp>,
         cx: &mut VisualTestContext,
-        deadline: Instant,
+        deadline: Duration,
         message: &str,
         predicate: impl Fn(&AdeApp) -> bool,
     ) {
-        loop {
-            app.update(cx, |app, cx| {
-                app.render_center_pane(cx);
-            });
-            cx.run_until_parked();
-            if app.read_with(cx, |app, _| predicate(app)) {
-                return;
-            }
-            assert!(Instant::now() < deadline, "{message}");
-            std::thread::sleep(Duration::from_millis(200));
-        }
+        assert!(
+            crate::lsp::fixtures::wait_until_parked(cx, deadline, |cx| {
+                app.update(cx, |app, cx| {
+                    app.render_center_pane(cx);
+                });
+                cx.run_until_parked();
+                app.read_with(cx, |app, _| predicate(app))
+            }),
+            "{message}"
+        );
     }
 
     /// Drives a real edit through the exact same code path a real keystroke does
@@ -4664,6 +4579,7 @@ mod lsp_diagnostics_wiring_tests {
     }
 
     #[gpui::test]
+    #[ignore = "external: rust-analyzer; see docs/testing.md"]
     fn rust_analyzer_tracks_a_real_live_unsaved_edit_for_both_diagnostics_and_completions(
         cx: &mut TestAppContext,
     ) {
@@ -4672,14 +4588,14 @@ mod lsp_diagnostics_wiring_tests {
             "fn main() {\n    let x: i32 = 1;\n    println!(\"{}\", x);\n}\n",
         );
         let main_rs = project.path().join("src").join("main.rs");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, project.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, project.path().to_path_buf());
 
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(main_rs.clone(), window, cx);
         });
         cx.run_until_parked();
 
-        let indexed_deadline = Instant::now() + Duration::from_secs(480);
+        let indexed_deadline = Duration::from_secs(480);
         wait_until(
             &app,
             cx,
@@ -4710,29 +4626,10 @@ mod lsp_diagnostics_wiring_tests {
             );
         });
 
-        // Widened twice from a real, observed 180s-deadline failure under genuine full-suite
-        // parallel load (`cargo test -p app --lib` with its default, num-cpus-wide test-
-        // threads): the whole suite repeatedly ran 3-5x its normal wall-clock length (up to
-        // ~330s vs. the usual ~70-100s) on this same sandbox, and this real rust-analyzer -
-        // already `Ready` and only asked to recompute diagnostics for a two-line edit, not
-        // re-index from scratch - still hadn't published the new diagnostic even at 300s on a
-        // later, still-more-contended run (this module's own `REAL_LSP_SUBPROCESS_TEST_LOCK`
-        // and the `None`-is-retried fix in `AdeApp::schedule_lsp_sync`'s own retry loop both
-        // already close the *other* real bugs this same investigation found - this deadline
-        // widening is a distinct, additional real-headroom fix, not a substitute for either).
-        // The wait itself already polls correctly (real `std::thread::sleep` between checks,
-        // bounded by a real deadline, not a fixed tick count - see `wait_until`'s own docs); the
-        // deadline itself was just too tight for how slow a real subprocess can genuinely get
-        // when dozens of sibling tests' own real subprocesses (other `rust-analyzer`/`pyright`/
-        // `typescript-language-server`/pty sessions, and - on this particular shared sandbox -
-        // other agents' own concurrent full test-suite runs) are contending for the same CPU
-        // cores. 480s keeps real headroom for that without losing the "assertion still fails if
-        // diagnostics genuinely never arrive" property that makes this a real regression gate,
-        // not a rubber stamp - and rust-analyzer gets the widest budget of the three real
-        // servers this module covers because it is, empirically, the one that has actually
-        // needed it (typescript-language-server/pyright's own 240s deadlines have not been
-        // observed failing across dozens of full-suite reproduction runs).
-        let diagnostic_deadline = Instant::now() + Duration::from_secs(480);
+        // Real rust-analyzer, recomputing after an edit under whatever load the machine is
+        // already under - the widest budget of the three servers this module covers, empirically
+        // the one that has needed it.
+        let diagnostic_deadline = Duration::from_secs(480);
         wait_until(
             &app,
             cx,
@@ -4784,7 +4681,7 @@ mod lsp_diagnostics_wiring_tests {
             "\nfn call() {\n    prin",
         );
 
-        let completion_deadline = Instant::now() + Duration::from_secs(60);
+        let completion_deadline = Duration::from_secs(60);
         wait_until(
             &app,
             cx,
@@ -4844,13 +4741,13 @@ mod lsp_diagnostics_wiring_tests {
     fn a_transient_pull_failure_is_retried_not_treated_as_a_permanent_stall(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::lsp::fixtures::temp_repo();
         let root = repo.path().to_path_buf();
         std::fs::create_dir_all(root.join("src")).expect("mkdir src");
         let absolute = root.join("src").join("main.rs");
         std::fs::write(&absolute, "fn main() {}\n").expect("write main.rs");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, root.clone());
+        let (app, cx) = open_test_app(cx, root.clone());
         let server = super::lsp_connection_facade_tests::spawn_fake_server(
             repo.path(),
             "rust-analyzer",
@@ -4898,27 +4795,19 @@ mod lsp_diagnostics_wiring_tests {
         // uses `type_text`'s own advance for the sync debounce - `run_until_parked()` alone does
         // not carry the virtual clock forward on its own, so without this the retry's own timer
         // would never fire and this loop would hang until the real deadline below.
-        let deadline = Instant::now() + Duration::from_secs(10);
-        let mut retried_past_the_first_failure = false;
-        while Instant::now() < deadline {
-            cx.background_executor
-                .advance_clock(PULL_DIAGNOSTICS_EMPTY_RETRY_DELAY);
-            cx.run_until_parked();
-            if server
-                .diagnostics_for_uri(&file_uri)
-                .is_some_and(|diagnostics| {
-                    diagnostics
-                        .iter()
-                        .any(|d| d.message == "real diagnostic from a retried pull")
-                })
-            {
-                retried_past_the_first_failure = true;
-                break;
-            }
-            std::thread::sleep(Duration::from_millis(20));
-        }
         assert!(
-            retried_past_the_first_failure,
+            crate::lsp::fixtures::wait_until_parked(cx, Duration::from_secs(10), |cx| {
+                cx.background_executor
+                    .advance_clock(PULL_DIAGNOSTICS_EMPTY_RETRY_DELAY);
+                cx.run_until_parked();
+                server
+                    .diagnostics_for_uri(&file_uri)
+                    .is_some_and(|diagnostics| {
+                        diagnostics
+                            .iter()
+                            .any(|d| d.message == "real diagnostic from a retried pull")
+                    })
+            }),
             "the retry loop must survive the fake server's first, deliberately-erroring pull \
              attempt and pick up the real, non-empty result its second attempt answers with - a \
              pre-fix build stops retrying after that first error and never reaches it"
@@ -4926,12 +4815,12 @@ mod lsp_diagnostics_wiring_tests {
     }
 
     #[gpui::test]
-    #[ignore]
+    #[ignore = "external: typescript-language-server, npm; see docs/testing.md"]
     fn typescript_language_server_tracks_a_real_live_unsaved_edit_for_both_diagnostics_and_completions(
         cx: &mut TestAppContext,
     ) {
         let _serialize = serialize_real_lsp_subprocess_test();
-        let dir = tempfile::tempdir().expect("tempdir");
+        let dir = crate::lsp::fixtures::temp_repo();
         std::fs::write(
             dir.path().join("tsconfig.json"),
             "{\"compilerOptions\": {\"strict\": true, \"target\": \"ES2020\"}}\n",
@@ -4953,13 +4842,13 @@ mod lsp_diagnostics_wiring_tests {
             .expect("npm should be on PATH in this sandbox (real, live network install)");
         assert!(status.success(), "npm install typescript@5 failed");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, dir.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, dir.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(main_ts.clone(), window, cx);
         });
         cx.run_until_parked();
 
-        let indexed_deadline = Instant::now() + Duration::from_secs(240);
+        let indexed_deadline = Duration::from_secs(240);
         wait_until(
             &app,
             cx,
@@ -4984,7 +4873,7 @@ mod lsp_diagnostics_wiring_tests {
                 .is_dirty());
         });
 
-        let diagnostic_deadline = Instant::now() + Duration::from_secs(240);
+        let diagnostic_deadline = Duration::from_secs(240);
         wait_until(
             &app,
             cx,
@@ -5008,7 +4897,7 @@ mod lsp_diagnostics_wiring_tests {
         });
         type_text(&app, cx, completion_trigger_offset, "\nconsol");
 
-        let completion_deadline = Instant::now() + Duration::from_secs(60);
+        let completion_deadline = Duration::from_secs(60);
         wait_until(
             &app,
             cx,
@@ -5049,23 +4938,23 @@ mod lsp_diagnostics_wiring_tests {
     }
 
     #[gpui::test]
-    #[ignore]
+    #[ignore = "external: pyright-langserver; see docs/testing.md"]
     fn pyright_tracks_a_real_live_unsaved_edit_for_both_diagnostics_and_completions(
         cx: &mut TestAppContext,
     ) {
         let _serialize = serialize_real_lsp_subprocess_test();
-        let dir = tempfile::tempdir().expect("tempdir");
+        let dir = crate::lsp::fixtures::temp_repo();
         let main_py = dir.path().join("main.py");
         let baseline = "ok: int = 1\nprint(ok)\n";
         std::fs::write(&main_py, baseline).expect("write main.py");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, dir.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, dir.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(main_py.clone(), window, cx);
         });
         cx.run_until_parked();
 
-        let indexed_deadline = Instant::now() + Duration::from_secs(240);
+        let indexed_deadline = Duration::from_secs(240);
         wait_until(
             &app,
             cx,
@@ -5085,7 +4974,7 @@ mod lsp_diagnostics_wiring_tests {
                 .is_dirty());
         });
 
-        let diagnostic_deadline = Instant::now() + Duration::from_secs(240);
+        let diagnostic_deadline = Duration::from_secs(240);
         wait_until(
             &app,
             cx,
@@ -5112,7 +5001,7 @@ mod lsp_diagnostics_wiring_tests {
         });
         type_text(&app, cx, completion_trigger_offset, "\npri");
 
-        let completion_deadline = Instant::now() + Duration::from_secs(60);
+        let completion_deadline = Duration::from_secs(60);
         wait_until(
             &app,
             cx,

--- a/crates/app/src/lsp/completion.rs
+++ b/crates/app/src/lsp/completion.rs
@@ -677,216 +677,181 @@ mod tests {
         chars.iter().map(|c| c.to_string()).collect()
     }
 
+    /// Every real shape of "the user typed something" the popup can be asked to open on: an
+    /// identifier byte invokes an ordinary completion, an advertised character opens a real
+    /// trigger-character one, and anything else opens nothing at all.
     #[test]
-    fn an_identifier_continuation_character_triggers_an_invoked_completion() {
-        let context = completion_trigger(Some('x'), &triggers(&["."])).expect("should trigger");
-        assert_eq!(
-            context.trigger_kind,
-            lsp_types::CompletionTriggerKind::INVOKED
-        );
-        assert_eq!(context.trigger_character, None);
+    fn every_typed_character_opens_exactly_the_completion_it_should() {
+        use lsp_types::CompletionTriggerKind as Kind;
+        let advertised = triggers(&[".", "::"]);
+        for (typed, advertised, expected) in [
+            (
+                Some('x'),
+                advertised.as_slice(),
+                Some((Kind::INVOKED, None)),
+            ),
+            (Some('9'), &[][..], Some((Kind::INVOKED, None))),
+            (Some('_'), &[][..], Some((Kind::INVOKED, None))),
+            (
+                Some('.'),
+                advertised.as_slice(),
+                Some((Kind::TRIGGER_CHARACTER, Some("."))),
+            ),
+            (Some(' '), advertised.as_slice(), None),
+            (Some(';'), advertised.as_slice(), None),
+            (Some(')'), &[][..], None),
+            // The very start of the buffer - no character behind the caret at all.
+            (None, advertised.as_slice(), None),
+        ] {
+            let context = completion_trigger(typed, advertised);
+            match expected {
+                None => assert_eq!(context, None, "{typed:?} must not open a completion"),
+                Some((kind, character)) => {
+                    let context =
+                        context.unwrap_or_else(|| panic!("{typed:?} must open a completion"));
+                    assert_eq!(context.trigger_kind, kind, "for {typed:?}");
+                    assert_eq!(
+                        context.trigger_character.as_deref(),
+                        character,
+                        "for {typed:?}"
+                    );
+                }
+            }
+        }
     }
 
-    #[test]
-    fn a_digit_or_underscore_also_triggers_an_invoked_completion() {
-        assert!(completion_trigger(Some('9'), &[]).is_some());
-        assert!(completion_trigger(Some('_'), &[]).is_some());
+    fn range(start_character: u32, end_character: u32) -> lsp_types::Range {
+        lsp_types::Range {
+            start: lsp_types::Position {
+                line: 0,
+                character: start_character,
+            },
+            end: lsp_types::Position {
+                line: 0,
+                character: end_character,
+            },
+        }
     }
 
+    /// The three real shapes a server can answer an edit in. The `InsertAndReplace` row is the
+    /// load-bearing one: taking the wider `replace` half would swallow text past the caret that
+    /// the user never asked to lose.
     #[test]
-    fn a_server_advertised_trigger_character_triggers_a_real_trigger_character_completion() {
-        let context = completion_trigger(Some('.'), &triggers(&[".", "::"])).expect("trigger");
-        assert_eq!(
-            context.trigger_kind,
-            lsp_types::CompletionTriggerKind::TRIGGER_CHARACTER
-        );
-        assert_eq!(context.trigger_character.as_deref(), Some("."));
-    }
-
-    #[test]
-    fn whitespace_and_punctuation_do_not_trigger_when_not_a_real_advertised_trigger_character() {
-        assert_eq!(completion_trigger(Some(' '), &triggers(&["."])), None);
-        assert_eq!(completion_trigger(Some(';'), &triggers(&["."])), None);
-        assert_eq!(completion_trigger(Some(')'), &[]), None);
-    }
-
-    #[test]
-    fn the_start_of_the_buffer_never_triggers() {
-        assert_eq!(completion_trigger(None, &triggers(&["."])), None);
-    }
-
-    #[test]
-    fn completion_text_edit_prefers_a_real_plain_edit() {
-        let item = lsp_types::CompletionItem {
-            label: "println!".to_string(),
-            text_edit: Some(lsp_types::CompletionTextEdit::Edit(lsp_types::TextEdit {
-                range: lsp_types::Range {
-                    start: lsp_types::Position {
-                        line: 0,
-                        character: 0,
-                    },
-                    end: lsp_types::Position {
-                        line: 0,
-                        character: 3,
-                    },
-                },
-                new_text: "println!".to_string(),
-            })),
-            ..Default::default()
-        };
-        let (range, text) = completion_text_edit(&item).expect("a real edit");
-        assert_eq!(range.start.character, 0);
-        assert_eq!(range.end.character, 3);
-        assert_eq!(text, "println!");
-    }
-
-    #[test]
-    fn completion_text_edit_reads_the_insert_half_of_a_real_insert_and_replace_edit() {
-        let item = lsp_types::CompletionItem {
-            label: "println!".to_string(),
-            text_edit: Some(lsp_types::CompletionTextEdit::InsertAndReplace(
-                lsp_types::InsertReplaceEdit {
+    fn completion_text_edit_reads_the_insert_half_of_every_real_edit_shape() {
+        for (name, text_edit, expected) in [
+            (
+                "a plain edit",
+                Some(lsp_types::CompletionTextEdit::Edit(lsp_types::TextEdit {
+                    range: range(0, 3),
                     new_text: "println!".to_string(),
-                    insert: lsp_types::Range {
-                        start: lsp_types::Position {
-                            line: 0,
-                            character: 0,
-                        },
-                        end: lsp_types::Position {
-                            line: 0,
-                            character: 3,
-                        },
+                })),
+                Some((0, 3)),
+            ),
+            (
+                "an insert-and-replace edit",
+                Some(lsp_types::CompletionTextEdit::InsertAndReplace(
+                    lsp_types::InsertReplaceEdit {
+                        new_text: "println!".to_string(),
+                        insert: range(0, 3),
+                        replace: range(0, 10),
                     },
-                    replace: lsp_types::Range {
-                        start: lsp_types::Position {
-                            line: 0,
-                            character: 0,
-                        },
-                        end: lsp_types::Position {
-                            line: 0,
-                            character: 10,
-                        },
-                    },
-                },
-            )),
-            ..Default::default()
-        };
-        let (range, _) = completion_text_edit(&item).expect("a real edit");
-        assert_eq!(
-            range.end.character, 3,
-            "the insert half (3), not the wider replace half (10), must be used"
-        );
+                )),
+                Some((0, 3)),
+            ),
+            ("no edit at all", None, None),
+        ] {
+            let item = lsp_types::CompletionItem {
+                label: "println!".to_string(),
+                text_edit,
+                ..Default::default()
+            };
+            match expected {
+                None => assert_eq!(completion_text_edit(&item), None, "{name}"),
+                Some((start, end)) => {
+                    let (edit_range, text) =
+                        completion_text_edit(&item).unwrap_or_else(|| panic!("{name}"));
+                    assert_eq!(edit_range.start.character, start, "{name}");
+                    assert_eq!(edit_range.end.character, end, "{name}");
+                    assert_eq!(text, "println!", "{name}");
+                }
+            }
+        }
     }
 
     #[test]
-    fn completion_text_edit_is_none_without_a_real_text_edit() {
-        let item = lsp_types::CompletionItem {
-            label: "foo".to_string(),
-            ..Default::default()
-        };
-        assert_eq!(completion_text_edit(&item), None);
-    }
-
-    #[test]
-    fn completion_plain_insert_text_prefers_a_real_insert_text_over_the_label() {
-        let item = lsp_types::CompletionItem {
-            label: "foo (function)".to_string(),
-            insert_text: Some("foo".to_string()),
-            ..Default::default()
-        };
-        assert_eq!(completion_plain_insert_text(&item), "foo");
-    }
-
-    #[test]
-    fn completion_plain_insert_text_falls_back_to_the_real_label_when_insert_text_is_absent() {
-        let item = lsp_types::CompletionItem {
-            label: "foo".to_string(),
-            insert_text: None,
-            ..Default::default()
-        };
-        assert_eq!(completion_plain_insert_text(&item), "foo");
+    fn completion_plain_insert_text_prefers_insert_text_and_falls_back_to_the_label() {
+        for (insert_text, expected) in [(Some("foo".to_string()), "foo"), (None, "foo (function)")]
+        {
+            let item = lsp_types::CompletionItem {
+                label: "foo (function)".to_string(),
+                insert_text: insert_text.clone(),
+                ..Default::default()
+            };
+            assert_eq!(completion_plain_insert_text(&item), expected);
+        }
     }
 
     #[test]
     fn identifier_prefix_start_walks_back_to_the_real_start_of_the_typed_word() {
-        assert_eq!(identifier_prefix_start("let x = pri", 11), 8);
-        assert_eq!(identifier_prefix_start("    foo_bar2", 12), 4);
+        for (line, cursor, expected) in [
+            ("let x = pri", 11, 8),
+            ("    foo_bar2", 12, 4),
+            // Stops at a real non-identifier byte rather than running through it.
+            ("foo.bar", 7, 4),
+            ("a.b", 3, 2),
+            // No prefix at all: the cursor is its own start.
+            ("foo.", 4, 4),
+            ("", 0, 0),
+        ] {
+            assert_eq!(
+                identifier_prefix_start(line, cursor),
+                expected,
+                "{line:?} at {cursor}"
+            );
+        }
     }
 
+    /// Every kind the popup gives a badge to, and the letter each badge paints - the glyphs the
+    /// design mockups specify. A kind with no badge slot, and an item with no kind at all, both
+    /// have to come back bare rather than pick an arbitrary bucket.
     #[test]
-    fn identifier_prefix_start_stops_at_a_real_non_identifier_byte() {
-        assert_eq!(identifier_prefix_start("foo.bar", 7), 4);
-        assert_eq!(identifier_prefix_start("a.b", 3), 2);
-    }
+    fn every_completion_kind_lands_in_its_documented_badge_bucket() {
+        use lsp_types::CompletionItemKind as ItemKind;
+        for (kind, expected) in [
+            (
+                Some(ItemKind::FUNCTION),
+                Some(CompletionKindBadge::Function),
+            ),
+            (Some(ItemKind::METHOD), Some(CompletionKindBadge::Function)),
+            (
+                Some(ItemKind::CONSTRUCTOR),
+                Some(CompletionKindBadge::Function),
+            ),
+            (
+                Some(ItemKind::VARIABLE),
+                Some(CompletionKindBadge::Variable),
+            ),
+            (Some(ItemKind::FIELD), Some(CompletionKindBadge::Variable)),
+            (
+                Some(ItemKind::CONSTANT),
+                Some(CompletionKindBadge::Variable),
+            ),
+            (Some(ItemKind::STRUCT), Some(CompletionKindBadge::Type)),
+            (Some(ItemKind::CLASS), Some(CompletionKindBadge::Type)),
+            (Some(ItemKind::ENUM), Some(CompletionKindBadge::Type)),
+            (Some(ItemKind::KEYWORD), None),
+            (None, None),
+        ] {
+            assert_eq!(completion_kind_badge(kind), expected, "for {kind:?}");
+        }
 
-    #[test]
-    fn identifier_prefix_start_is_the_cursor_itself_with_no_real_prefix() {
-        assert_eq!(identifier_prefix_start("foo.", 4), 4);
-        assert_eq!(identifier_prefix_start("", 0), 0);
-    }
-
-    #[test]
-    fn completion_kind_badge_groups_function_like_kinds() {
-        assert_eq!(
-            completion_kind_badge(Some(lsp_types::CompletionItemKind::FUNCTION)),
-            Some(CompletionKindBadge::Function)
-        );
-        assert_eq!(
-            completion_kind_badge(Some(lsp_types::CompletionItemKind::METHOD)),
-            Some(CompletionKindBadge::Function)
-        );
-        assert_eq!(
-            completion_kind_badge(Some(lsp_types::CompletionItemKind::CONSTRUCTOR)),
-            Some(CompletionKindBadge::Function)
-        );
-    }
-
-    #[test]
-    fn completion_kind_badge_groups_variable_like_kinds() {
-        assert_eq!(
-            completion_kind_badge(Some(lsp_types::CompletionItemKind::VARIABLE)),
-            Some(CompletionKindBadge::Variable)
-        );
-        assert_eq!(
-            completion_kind_badge(Some(lsp_types::CompletionItemKind::FIELD)),
-            Some(CompletionKindBadge::Variable)
-        );
-        assert_eq!(
-            completion_kind_badge(Some(lsp_types::CompletionItemKind::CONSTANT)),
-            Some(CompletionKindBadge::Variable)
-        );
-    }
-
-    #[test]
-    fn completion_kind_badge_groups_type_like_kinds() {
-        assert_eq!(
-            completion_kind_badge(Some(lsp_types::CompletionItemKind::STRUCT)),
-            Some(CompletionKindBadge::Type)
-        );
-        assert_eq!(
-            completion_kind_badge(Some(lsp_types::CompletionItemKind::CLASS)),
-            Some(CompletionKindBadge::Type)
-        );
-        assert_eq!(
-            completion_kind_badge(Some(lsp_types::CompletionItemKind::ENUM)),
-            Some(CompletionKindBadge::Type)
-        );
-    }
-
-    #[test]
-    fn completion_kind_badge_is_none_for_a_kind_with_no_real_badge_slot_or_no_kind_at_all() {
-        assert_eq!(
-            completion_kind_badge(Some(lsp_types::CompletionItemKind::KEYWORD)),
-            None
-        );
-        assert_eq!(completion_kind_badge(None), None);
-    }
-
-    #[test]
-    fn completion_kind_badge_letters_match_the_design_mockups_own_glyphs() {
-        assert_eq!(CompletionKindBadge::Function.letter(), "f");
-        assert_eq!(CompletionKindBadge::Variable.letter(), "v");
-        assert_eq!(CompletionKindBadge::Type.letter(), "t");
+        for (badge, letter) in [
+            (CompletionKindBadge::Function, "f"),
+            (CompletionKindBadge::Variable, "v"),
+            (CompletionKindBadge::Type, "t"),
+        ] {
+            assert_eq!(badge.letter(), letter, "for {badge:?}");
+        }
     }
 
     fn item(label: &str) -> lsp_types::CompletionItem {
@@ -964,24 +929,23 @@ mod tests {
         assert_eq!(rank_completion_items(&items, "new"), vec![0, 1]);
     }
 
+    /// The spec's own "when falsy the label is used" fallback - and falsy has to cover an empty
+    /// string, not just a missing field, or a server that sends `""` filters everything out.
     #[test]
-    fn completion_filter_text_prefers_a_real_server_supplied_filter_text() {
-        let mut with_filter = item("new(…)");
-        with_filter.filter_text = Some("new".to_string());
-        assert_eq!(completion_filter_text(&with_filter), "new");
-    }
-
-    #[test]
-    fn completion_filter_text_falls_back_to_the_label_when_absent_or_empty() {
-        assert_eq!(completion_filter_text(&item("version")), "version");
-        let mut blank = item("version");
-        blank.filter_text = Some(String::new());
-        assert_eq!(
-            completion_filter_text(&blank),
-            "version",
-            "the spec's own \"when falsy the label is used\" fallback must cover an empty string, \
-             not just a missing field"
-        );
+    fn completion_filter_text_prefers_the_servers_own_and_falls_back_to_the_label() {
+        for (filter_text, label, expected) in [
+            (Some("new"), "new(…)", "new"),
+            (None, "version", "version"),
+            (Some(""), "version", "version"),
+        ] {
+            let mut candidate = item(label);
+            candidate.filter_text = filter_text.map(str::to_string);
+            assert_eq!(
+                completion_filter_text(&candidate),
+                expected,
+                "for {label:?}"
+            );
+        }
     }
 
     #[test]
@@ -1077,28 +1041,15 @@ mod tests {
         assert_eq!(completion_match("ab", "abc"), None);
     }
 
+    /// The row's right-hand hint and the detail pane's signature line, over every real shape a
+    /// server sends. The `label_details` rows are the regression: `rust-analyzer`'s own
+    /// `label_details.detail` for a trait-provided method (`.into()`, `.try_into()`, …) is a
+    /// trait-source annotation (`"(as Into)"`), not a type - preferring it over the legacy
+    /// `detail` field broke the hint for some of the most common completions there are, so both
+    /// functions must ignore `label_details` entirely.
     #[test]
-    fn completion_item_display_trims_and_drops_a_real_blank_detail() {
-        let item = lsp_types::CompletionItem {
-            label: "foo".to_string(),
-            detail: Some("  fn() -> i32  ".to_string()),
-            ..Default::default()
-        };
-        let (label, detail) = completion_item_display(&item);
-        assert_eq!(label, "foo");
-        assert_eq!(detail.as_deref(), Some("fn() -> i32"));
-
-        let no_detail_item = lsp_types::CompletionItem {
-            label: "bar".to_string(),
-            detail: Some("   ".to_string()),
-            ..Default::default()
-        };
-        assert_eq!(completion_item_display(&no_detail_item).1, None);
-    }
-
-    #[test]
-    fn completion_item_display_ignores_a_real_rust_analyzer_trait_source_label_details_detail() {
-        let item = lsp_types::CompletionItem {
+    fn the_row_hint_and_signature_line_read_the_legacy_detail_and_never_label_details() {
+        let trait_provided = lsp_types::CompletionItem {
             label: "into".to_string(),
             detail: Some("fn(self) -> T".to_string()),
             label_details: Some(lsp_types::CompletionItemLabelDetails {
@@ -1107,26 +1058,7 @@ mod tests {
             }),
             ..Default::default()
         };
-        assert_eq!(
-            completion_item_display(&item).1.as_deref(),
-            Some("fn(self) -> T"),
-            "the row's own right-side hint must read the real legacy detail string, never the \
-             trait-source annotation rust-analyzer puts in label_details.detail"
-        );
-    }
-
-    #[test]
-    fn completion_item_display_falls_back_to_the_bare_label_with_no_real_detail_at_all() {
-        let item = lsp_types::CompletionItem {
-            label: "push_str".to_string(),
-            ..Default::default()
-        };
-        assert_eq!(completion_item_display(&item).1, None);
-    }
-
-    #[test]
-    fn completion_signature_text_ignores_label_details_and_cleans_the_legacy_detail() {
-        let item = lsp_types::CompletionItem {
+        let typescript_method = lsp_types::CompletionItem {
             label: "pushStr".to_string(),
             detail: Some("(method) QueryBuilder.pushStr(s: string): void".to_string()),
             label_details: Some(lsp_types::CompletionItemLabelDetails {
@@ -1135,36 +1067,61 @@ mod tests {
             }),
             ..Default::default()
         };
-        assert_eq!(
-            completion_signature_text(&item),
-            "pushStr(s: string): void",
-            "the pane's own signature line must clean the real legacy detail string, never read \
-             label_details at all"
-        );
-    }
-
-    #[test]
-    fn completion_signature_text_falls_back_to_the_legacy_detail_string() {
-        let item = lsp_types::CompletionItem {
+        let padded = lsp_types::CompletionItem {
+            label: "foo".to_string(),
+            detail: Some("  fn() -> i32  ".to_string()),
+            ..Default::default()
+        };
+        let blank = lsp_types::CompletionItem {
+            label: "bar".to_string(),
+            detail: Some("   ".to_string()),
+            ..Default::default()
+        };
+        let bare = lsp_types::CompletionItem {
+            label: "push_str".to_string(),
+            ..Default::default()
+        };
+        let rust_signature = lsp_types::CompletionItem {
             label: "push_str".to_string(),
             detail: Some("fn push_str(&mut self, string: &str)".to_string()),
             ..Default::default()
         };
-        assert_eq!(
-            completion_signature_text(&item),
-            "fn push_str(&mut self, string: &str)",
-            "rust-analyzer's own convention - a real, complete, standalone signature string \
-             with no kind/qualifier prefix to clean - must pass through unchanged"
-        );
-    }
 
-    #[test]
-    fn completion_signature_text_falls_back_to_the_bare_label_with_nothing_else_real() {
-        let item = lsp_types::CompletionItem {
-            label: "push_str".to_string(),
-            ..Default::default()
-        };
-        assert_eq!(completion_signature_text(&item), "push_str");
+        for (name, candidate, hint, signature) in [
+            (
+                "a padded detail",
+                &padded,
+                Some("fn() -> i32"),
+                "fn() -> i32",
+            ),
+            ("a blank detail", &blank, None, "bar"),
+            ("no detail at all", &bare, None, "push_str"),
+            (
+                "a trait-provided method",
+                &trait_provided,
+                Some("fn(self) -> T"),
+                "fn(self) -> T",
+            ),
+            (
+                "a TypeScript method",
+                &typescript_method,
+                Some("pushStr(s: string): void"),
+                "pushStr(s: string): void",
+            ),
+            (
+                "a standalone rust-analyzer signature",
+                &rust_signature,
+                Some("fn push_str(&mut self, string: &str)"),
+                "fn push_str(&mut self, string: &str)",
+            ),
+        ] {
+            assert_eq!(
+                completion_item_display(candidate).1.as_deref(),
+                hint,
+                "{name}"
+            );
+            assert_eq!(completion_signature_text(candidate), signature, "{name}");
+        }
     }
 
     #[test]
@@ -1813,155 +1770,118 @@ mod tests {
         }
     }
 
+    /// Real, live-observed shapes from both servers this app supports - a real dump against a
+    /// genuinely spawned rust-analyzer/typescript-language-server, not synthetic guesses (see
+    /// `clean_completion_detail`'s own docs). The three "untouched" rows are the false-positive
+    /// guards: a genuine parenthesized parameter list or tuple type at the start of `detail` is
+    /// distinguished from a kind descriptor by the `:`/`,` inside its parens, and a label
+    /// reappearing deep in a return type is not a `Qualifier.` prefix.
     #[test]
-    fn clean_completion_detail_strips_a_real_typescript_method_kind_and_qualifier_prefix() {
-        assert_eq!(
-            clean_completion_detail("(method) QueryBuilder.pushStr(s: string): void", "pushStr"),
-            "pushStr(s: string): void"
-        );
+    fn clean_completion_detail_strips_only_a_real_kind_or_qualifier_prefix() {
+        for (detail, label, expected) in [
+            (
+                "(method) QueryBuilder.pushStr(s: string): void",
+                "pushStr",
+                "pushStr(s: string): void",
+            ),
+            ("(property) Foo.bar: string", "bar", "bar: string"),
+            ("fn(&mut self, &str)", "push_str", "fn(&mut self, &str)"),
+            ("fn(self) -> T", "into", "fn(self) -> T"),
+            ("(x: number) => void", "onClick", "(x: number) => void"),
+            ("(number, string)", "pair", "(number, string)"),
+            ("fn() -> Option<Table>", "Table", "fn() -> Option<Table>"),
+        ] {
+            assert_eq!(
+                clean_completion_detail(detail, label),
+                expected,
+                "for {detail:?}"
+            );
+        }
+    }
+
+    /// Every real shape a server can answer `documentation` in. Markdown is degraded to plain
+    /// text; plain text passes through untouched; nothing real means nothing shown.
+    #[test]
+    fn completion_documentation_text_reads_every_real_documentation_shape() {
+        for (name, documentation, expected) in [
+            (
+                "a plain string",
+                Some(lsp_types::Documentation::String(
+                    "Appends a given string slice.".to_string(),
+                )),
+                Some("Appends a given string slice."),
+            ),
+            (
+                "markdown markup",
+                Some(lsp_types::Documentation::MarkupContent(
+                    lsp_types::MarkupContent {
+                        kind: lsp_types::MarkupKind::Markdown,
+                        value: "Appends a **given** string slice.".to_string(),
+                    },
+                )),
+                Some("Appends a given string slice."),
+            ),
+            (
+                "plain-text markup",
+                Some(lsp_types::Documentation::MarkupContent(
+                    lsp_types::MarkupContent {
+                        kind: lsp_types::MarkupKind::PlainText,
+                        value: "`not markdown` stays as-is".to_string(),
+                    },
+                )),
+                Some("`not markdown` stays as-is"),
+            ),
+            ("nothing at all", None, None),
+            (
+                "a blank string",
+                Some(lsp_types::Documentation::String("   ".to_string())),
+                None,
+            ),
+        ] {
+            let candidate = lsp_types::CompletionItem {
+                label: "push_str".to_string(),
+                documentation,
+                ..Default::default()
+            };
+            assert_eq!(
+                completion_documentation_text(&candidate).as_deref(),
+                expected,
+                "{name}"
+            );
+        }
     }
 
     #[test]
-    fn clean_completion_detail_strips_a_real_typescript_property_kind_and_qualifier_prefix() {
-        assert_eq!(
-            clean_completion_detail("(property) Foo.bar: string", "bar"),
-            "bar: string"
-        );
-    }
-
-    #[test]
-    fn clean_completion_detail_leaves_a_real_rust_analyzer_signature_untouched() {
-        assert_eq!(
-            clean_completion_detail("fn(&mut self, &str)", "push_str"),
-            "fn(&mut self, &str)"
-        );
-        assert_eq!(
-            clean_completion_detail("fn(self) -> T", "into"),
-            "fn(self) -> T"
-        );
-    }
-
-    #[test]
-    fn clean_completion_detail_never_strips_a_real_parenthesized_type() {
-        assert_eq!(
-            clean_completion_detail("(x: number) => void", "onClick"),
-            "(x: number) => void"
-        );
-        assert_eq!(
-            clean_completion_detail("(number, string)", "pair"),
-            "(number, string)"
-        );
-    }
-
-    #[test]
-    fn clean_completion_detail_only_strips_a_real_bare_dotted_qualifier() {
-        // The label reappearing deep inside a return type, with no real `Qualifier.` immediately
-        // before it, must not be mistaken for one.
-        assert_eq!(
-            clean_completion_detail("fn() -> Option<Table>", "Table"),
-            "fn() -> Option<Table>"
-        );
-    }
-
-    #[test]
-    fn completion_documentation_text_reads_a_real_plain_string_shape() {
-        let item = lsp_types::CompletionItem {
-            label: "push_str".to_string(),
-            documentation: Some(lsp_types::Documentation::String(
-                "Appends a given string slice.".to_string(),
-            )),
-            ..Default::default()
-        };
-        assert_eq!(
-            completion_documentation_text(&item).as_deref(),
-            Some("Appends a given string slice.")
-        );
-    }
-
-    #[test]
-    fn completion_documentation_text_degrades_a_real_markdown_markup_content() {
-        let item = lsp_types::CompletionItem {
-            label: "push_str".to_string(),
-            documentation: Some(lsp_types::Documentation::MarkupContent(
-                lsp_types::MarkupContent {
-                    kind: lsp_types::MarkupKind::Markdown,
-                    value: "Appends a **given** string slice.".to_string(),
-                },
-            )),
-            ..Default::default()
-        };
-        assert_eq!(
-            completion_documentation_text(&item).as_deref(),
-            Some("Appends a given string slice.")
-        );
-    }
-
-    #[test]
-    fn completion_documentation_text_passes_a_real_plain_text_markup_content_through_unmodified() {
-        let item = lsp_types::CompletionItem {
-            label: "push_str".to_string(),
-            documentation: Some(lsp_types::Documentation::MarkupContent(
-                lsp_types::MarkupContent {
-                    kind: lsp_types::MarkupKind::PlainText,
-                    value: "`not markdown` stays as-is".to_string(),
-                },
-            )),
-            ..Default::default()
-        };
-        assert_eq!(
-            completion_documentation_text(&item).as_deref(),
-            Some("`not markdown` stays as-is")
-        );
-    }
-
-    #[test]
-    fn completion_documentation_text_is_none_for_a_real_absent_or_blank_documentation() {
-        let no_doc = lsp_types::CompletionItem {
-            label: "foo".to_string(),
-            ..Default::default()
-        };
-        assert_eq!(completion_documentation_text(&no_doc), None);
-
-        let blank_doc = lsp_types::CompletionItem {
-            label: "foo".to_string(),
-            documentation: Some(lsp_types::Documentation::String("   ".to_string())),
-            ..Default::default()
-        };
-        assert_eq!(completion_documentation_text(&blank_doc), None);
-    }
-
-    #[test]
-    fn completion_module_path_reads_a_real_label_details_description() {
-        let item = lsp_types::CompletionItem {
-            label: "push_str".to_string(),
-            label_details: Some(lsp_types::CompletionItemLabelDetails {
-                detail: Some("(&mut self, &str)".to_string()),
-                description: Some("alloc::string::String".to_string()),
-            }),
-            ..Default::default()
-        };
-        assert_eq!(
-            completion_module_path(&item).as_deref(),
-            Some("alloc::string::String")
-        );
-    }
-
-    #[test]
-    fn completion_module_path_is_none_without_real_label_details_or_a_real_description() {
-        let no_label_details = lsp_types::CompletionItem {
-            label: "foo".to_string(),
-            ..Default::default()
-        };
-        assert_eq!(completion_module_path(&no_label_details), None);
-
-        let no_description = lsp_types::CompletionItem {
-            label: "foo".to_string(),
-            label_details: Some(lsp_types::CompletionItemLabelDetails {
-                detail: Some("()".to_string()),
-                description: None,
-            }),
-            ..Default::default()
-        };
-        assert_eq!(completion_module_path(&no_description), None);
+    fn completion_module_path_reads_only_a_real_label_details_description() {
+        for (name, label_details, expected) in [
+            (
+                "a real description",
+                Some(lsp_types::CompletionItemLabelDetails {
+                    detail: Some("(&mut self, &str)".to_string()),
+                    description: Some("alloc::string::String".to_string()),
+                }),
+                Some("alloc::string::String"),
+            ),
+            ("no label details at all", None, None),
+            (
+                "label details with no description",
+                Some(lsp_types::CompletionItemLabelDetails {
+                    detail: Some("()".to_string()),
+                    description: None,
+                }),
+                None,
+            ),
+        ] {
+            let candidate = lsp_types::CompletionItem {
+                label: "push_str".to_string(),
+                label_details,
+                ..Default::default()
+            };
+            assert_eq!(
+                completion_module_path(&candidate).as_deref(),
+                expected,
+                "{name}"
+            );
+        }
     }
 }

--- a/crates/app/src/lsp/completion_popup.rs
+++ b/crates/app/src/lsp/completion_popup.rs
@@ -1186,8 +1186,8 @@ fn resolve_completion_edit(
 #[cfg(test)]
 mod completions_scroll_tests {
     use super::*;
-    use crate::root::focus::palette_focus_tests;
     use crate::root::scrollbar::ScrollableHandle;
+    use crate::test_support::open_test_app;
     use gpui::{Entity, TestAppContext, VisualTestContext};
 
     /// Comfortably more than both the old 12-item render cap and the
@@ -1217,13 +1217,13 @@ mod completions_scroll_tests {
     ) -> (
         Entity<AdeApp>,
         &mut VisualTestContext,
-        tempfile::TempDir,
+        crate::lsp::fixtures::TempRepo,
         PathBuf,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::lsp::fixtures::temp_repo();
         let file = repo.path().join("sample.rs");
         std::fs::write(&file, "fn main() {}\n").expect("write sample.rs");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(file, window, cx);
         });
@@ -1510,17 +1510,17 @@ mod completions_scroll_tests {
 #[cfg(test)]
 mod completion_detail_pane_tests {
     use super::*;
-    use crate::root::focus::palette_focus_tests;
+    use crate::test_support::open_test_app;
     use gpui::TestAppContext;
 
     fn seed_ready_popup(
         cx: &mut TestAppContext,
         items: Vec<lsp_core::lsp_types::CompletionItem>,
     ) -> (gpui::Entity<AdeApp>, &mut gpui::VisualTestContext, PathBuf) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::lsp::fixtures::temp_repo();
         let file = repo.path().join("sample.rs");
         std::fs::write(&file, "fn main() {}\n").expect("write sample.rs");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(file, window, cx);
         });
@@ -1651,11 +1651,11 @@ mod completion_detail_pane_tests {
     fn a_short_lists_flipped_above_position_is_close_to_the_caret_not_the_worst_case_height(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::lsp::fixtures::temp_repo();
         let file = repo.path().join("sample.rs");
         let lines: Vec<String> = (0..30).map(|i| format!("fn f{i}() {{}}")).collect();
         std::fs::write(&file, lines.join("\n") + "\n").expect("write sample.rs");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(file, window, cx);
         });
@@ -1771,10 +1771,10 @@ mod completion_detail_pane_tests {
     fn accepting_a_real_auto_import_writes_its_import_line_and_keeps_the_caret(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::lsp::fixtures::temp_repo();
         let file = repo.path().join("main.ts");
         std::fs::write(&file, "const a = 1;\n\nconst other = app\n").expect("write main.ts");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(file, window, cx);
         });
@@ -1840,10 +1840,10 @@ mod completion_detail_pane_tests {
 
     #[gpui::test]
     fn the_auto_import_setting_off_inserts_the_name_without_the_import(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::lsp::fixtures::temp_repo();
         let file = repo.path().join("main.ts");
         std::fs::write(&file, "const a = 1;\n\nconst other = app\n").expect("write main.ts");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(file, window, cx);
         });
@@ -2203,10 +2203,10 @@ mod completion_detail_pane_tests {
     fn a_loading_popup_paints_only_the_list_column_with_no_detail_pane_or_footer_hints(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::lsp::fixtures::temp_repo();
         let file = repo.path().join("sample.rs");
         std::fs::write(&file, "fn main() {}\n").expect("write sample.rs");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(file, window, cx);
         });

--- a/crates/app/src/lsp/diagnostics.rs
+++ b/crates/app/src/lsp/diagnostics.rs
@@ -337,25 +337,20 @@ mod tests {
         );
     }
 
+    /// UTF-16 is what the protocol counts in and UTF-8 is what the buffer stores, so a
+    /// multi-byte character is the whole point: in `"café x"` the `'x'` is UTF-16 unit 5 but
+    /// byte 6. Anything past the line end clamps rather than panicking.
     #[test]
-    fn utf16_offset_to_byte_offset_is_identity_for_pure_ascii() {
-        assert_eq!(utf16_offset_to_byte_offset("let x = 1;", 4), 4);
-    }
-
-    #[test]
-    fn utf16_offset_to_byte_offset_accounts_for_a_real_multi_byte_char() {
-        // "café x" - 'é' is 2 UTF-8 bytes but only 1 UTF-16 code unit, so the real byte offset
-        // of the 'x' that follows it must be 6 (c=1,a=1,f=1,é=2 bytes,space=1 => byte 6), even
-        // though its UTF-16 offset is only 5 (c=1,a=1,f=1,é=1 unit,space=1 => unit 5).
-        let text = "caf\u{e9} x"; // '\u{e9}' is 'é'
-        let x_byte_offset = text.find('x').expect("'x' present");
-        assert_eq!(x_byte_offset, 6);
-        assert_eq!(utf16_offset_to_byte_offset(text, 5), x_byte_offset);
-    }
-
-    #[test]
-    fn utf16_offset_to_byte_offset_clamps_past_the_real_line_end() {
-        assert_eq!(utf16_offset_to_byte_offset("abc", 999), 3);
+    fn utf16_offset_to_byte_offset_converts_and_clamps() {
+        for (line, utf16_offset, expected) in
+            [("let x = 1;", 4, 4), ("caf\u{e9} x", 5, 6), ("abc", 999, 3)]
+        {
+            assert_eq!(
+                utf16_offset_to_byte_offset(line, utf16_offset),
+                expected,
+                "{line:?} at UTF-16 offset {utf16_offset}"
+            );
+        }
     }
 
     #[test]
@@ -424,36 +419,39 @@ mod tests {
         assert_eq!(Severity::from_lsp(None), Severity::Error);
     }
 
+    /// The worst severity in a line's list, and the ranking behind "worst" - never "whichever
+    /// the `Vec` happens to hold first", which is what a header count would silently get wrong.
     #[test]
-    fn worst_severity_is_none_for_an_empty_slice() {
+    fn worst_severity_ranks_by_severity_not_by_vec_order() {
+        fn at(severity: Severity) -> LineDiagnostic {
+            let mut diagnostic = line_diag(0..1);
+            diagnostic.severity = severity;
+            diagnostic
+        }
         assert_eq!(Severity::worst(&[]), None);
-    }
-
-    #[test]
-    fn worst_severity_picks_error_over_hint_regardless_of_vec_order() {
-        let mut a = line_diag(0..1);
-        a.severity = Severity::Hint;
-        let mut b = line_diag(0..1);
-        b.severity = Severity::Error;
-        assert_eq!(
-            Severity::worst(&[a.clone(), b.clone()]),
-            Some(Severity::Error)
-        );
-        assert_eq!(Severity::worst(&[b, a]), Some(Severity::Error));
-    }
-
-    #[test]
-    fn worst_severity_ranks_warning_above_information_and_hint() {
-        let mut hint = line_diag(0..1);
-        hint.severity = Severity::Hint;
-        let mut info = line_diag(0..1);
-        info.severity = Severity::Information;
-        let mut warning = line_diag(0..1);
-        warning.severity = Severity::Warning;
-        assert_eq!(
-            Severity::worst(&[hint, info, warning]),
-            Some(Severity::Warning)
-        );
+        for (name, diagnostics, expected) in [
+            (
+                "error listed last",
+                vec![at(Severity::Hint), at(Severity::Error)],
+                Severity::Error,
+            ),
+            (
+                "error listed first",
+                vec![at(Severity::Error), at(Severity::Hint)],
+                Severity::Error,
+            ),
+            (
+                "warning outranks information and hint",
+                vec![
+                    at(Severity::Hint),
+                    at(Severity::Information),
+                    at(Severity::Warning),
+                ],
+                Severity::Warning,
+            ),
+        ] {
+            assert_eq!(Severity::worst(&diagnostics), Some(expected), "{name}");
+        }
     }
 
     #[test]

--- a/crates/app/src/lsp/fixtures.rs
+++ b/crates/app/src/lsp/fixtures.rs
@@ -1,0 +1,50 @@
+//! Test-only fixtures shared by this folder's own test modules.
+//!
+//! Owns exactly one thing: handing a test a worktree root the app will agree with. Anything
+//! git-, wait- or process-shaped belongs in `crates/test-support`, and anything that opens a
+//! window in `crate::test_support`.
+
+use gpui::VisualTestContext;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+/// A real temporary directory whose [`Self::path`] is the root to hand
+/// [`crate::test_support::open_test_app`].
+///
+/// The path is canonicalized because `AdeApp` canonicalizes the repo root it is given
+/// ([`crate::rail::repo::canonical_repo_path`]) and then keys `lsp_clients` by an exact
+/// `(PathBuf, &str)` pair and `edit_buffers`/`open_files` by `path.strip_prefix(file_tree_root)`.
+/// On macOS `std::env::temp_dir()` is itself behind a symlink (`/var` -> `/private/var`), so a
+/// fixture that builds paths from `tempfile::TempDir::path()` verbatim produces keys that never
+/// match the ones the app resolved.
+pub(in crate::lsp) struct TempRepo {
+    /// Held for its `Drop`; the directory is removed when this value is.
+    _dir: tempfile::TempDir,
+    root: PathBuf,
+}
+
+impl TempRepo {
+    pub(in crate::lsp) fn path(&self) -> &Path {
+        &self.root
+    }
+}
+
+pub(in crate::lsp) fn temp_repo() -> TempRepo {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path().canonicalize().expect("canonicalize tempdir");
+    TempRepo { _dir: dir, root }
+}
+
+/// `test_support::wait_until`'s GPUI-driven sibling, for the state that only advances after a
+/// real render plus a `run_until_parked` between polls — a real server's `publishDiagnostics`
+/// arrives on `lsp_core`'s own OS reader thread, outside GPUI's scheduler entirely.
+///
+/// The shared helper cannot serve these callers: its condition closure takes no arguments, and
+/// theirs needs the `VisualTestContext` this hands back each time.
+pub(in crate::lsp) fn wait_until_parked(
+    cx: &mut VisualTestContext,
+    deadline: Duration,
+    mut attempt: impl FnMut(&mut VisualTestContext) -> bool,
+) -> bool {
+    test_support::wait_until(deadline, || attempt(cx))
+}

--- a/crates/app/src/lsp/hover.rs
+++ b/crates/app/src/lsp/hover.rs
@@ -603,25 +603,20 @@ mod tests {
         assert_eq!(sections.description, None);
     }
 
+    /// UTF-16 is what the protocol counts in and UTF-8 is what the buffer stores, so a
+    /// multi-byte character is the whole point: in `"café x"` the `'x'` is byte 6 but UTF-16 unit
+    /// 5. Anything past the line end clamps rather than panicking.
     #[test]
-    fn byte_offset_to_utf16_offset_is_identity_for_pure_ascii() {
-        assert_eq!(byte_offset_to_utf16_offset("let x = 1;", 4), 4);
-    }
-
-    #[test]
-    fn byte_offset_to_utf16_offset_accounts_for_a_real_multi_byte_char() {
-        // "café x" - 'é' is 2 UTF-8 bytes but only 1 UTF-16 code unit, so the real UTF-16 offset
-        // of the 'x' that follows it must be 5 (c=1,a=1,f=1,é=1 unit,space=1 => unit 5), even
-        // though its real byte offset is 6.
-        let text = "caf\u{e9} x";
-        let x_byte_offset = text.find('x').expect("'x' present");
-        assert_eq!(x_byte_offset, 6);
-        assert_eq!(byte_offset_to_utf16_offset(text, x_byte_offset), 5);
-    }
-
-    #[test]
-    fn byte_offset_to_utf16_offset_clamps_past_the_real_line_end() {
-        assert_eq!(byte_offset_to_utf16_offset("abc", 999), 3);
+    fn byte_offset_to_utf16_offset_converts_and_clamps() {
+        for (line, byte_offset, expected) in
+            [("let x = 1;", 4, 4), ("caf\u{e9} x", 6, 5), ("abc", 999, 3)]
+        {
+            assert_eq!(
+                byte_offset_to_utf16_offset(line, byte_offset),
+                expected,
+                "{line:?} at byte {byte_offset}"
+            );
+        }
     }
 
     #[test]
@@ -732,16 +727,6 @@ mod tests {
             vec!["const name = formatName(\"Ada\", \"Lovelace\");\nconsole.log(name);".to_string()],
             "a real fenced @example body must survive as real, multi-line example code"
         );
-    }
-
-    #[test]
-    fn degrade_markdown_to_plain_text_strips_a_real_fenced_code_block_and_starts_a_new_paragraph() {
-        let plain = degrade_markdown_to_plain_text(REAL_TYPESCRIPT_MARKDOWN_HOVER);
-        assert_eq!(
-            plain,
-            "\nfunction addOne(x: number): number\n\nAdds one to the given number."
-        );
-        assert!(!plain.contains('`'), "no backtick should survive degrading");
     }
 
     #[test]
@@ -948,33 +933,11 @@ mod tests {
         }
     }
 
+    /// Every real shape a server can answer go-to-definition in. The `Link` row is the one that
+    /// matters most: it must read the target's own *selection* range (the name span), not the
+    /// whole target range, which can start well before the item at its doc comment.
     #[test]
-    fn first_definition_location_reads_a_real_scalar_response() {
-        let response = lsp_types::GotoDefinitionResponse::Scalar(location("file:///a.rs", 4));
-        let (uri, range) = first_definition_location(&response).expect("a real location");
-        assert_eq!(uri.as_str(), "file:///a.rs");
-        assert_eq!(range.start.line, 4);
-    }
-
-    #[test]
-    fn first_definition_location_reads_the_real_first_array_entry() {
-        let response = lsp_types::GotoDefinitionResponse::Array(vec![
-            location("file:///first.rs", 1),
-            location("file:///second.rs", 2),
-        ]);
-        let (uri, range) = first_definition_location(&response).expect("a real location");
-        assert_eq!(uri.as_str(), "file:///first.rs");
-        assert_eq!(range.start.line, 1);
-    }
-
-    #[test]
-    fn first_definition_location_is_none_for_a_real_empty_array() {
-        let response = lsp_types::GotoDefinitionResponse::Array(vec![]);
-        assert_eq!(first_definition_location(&response), None);
-    }
-
-    #[test]
-    fn first_definition_location_reads_a_real_link_response_using_target_selection_range() {
+    fn first_definition_location_reads_the_first_target_of_every_real_response_shape() {
         let link = lsp_types::LocationLink {
             origin_selection_range: None,
             target_uri: "file:///target.rs".parse().expect("real test URI"),
@@ -999,12 +962,40 @@ mod tests {
                 },
             },
         };
-        let response = lsp_types::GotoDefinitionResponse::Link(vec![link]);
-        let (uri, range) = first_definition_location(&response).expect("a real location");
-        assert_eq!(uri.as_str(), "file:///target.rs");
-        // The real *selection* range (the target's own name span), not the whole real target
-        // range (which could start well before the item, e.g. at its own doc comment).
-        assert_eq!(range.start.line, 2);
-        assert_eq!(range.start.character, 3);
+        for (name, response, expected) in [
+            (
+                "a scalar location",
+                lsp_types::GotoDefinitionResponse::Scalar(location("file:///a.rs", 4)),
+                Some(("file:///a.rs", 4)),
+            ),
+            (
+                "an array - the first entry wins",
+                lsp_types::GotoDefinitionResponse::Array(vec![
+                    location("file:///first.rs", 1),
+                    location("file:///second.rs", 2),
+                ]),
+                Some(("file:///first.rs", 1)),
+            ),
+            (
+                "an empty array",
+                lsp_types::GotoDefinitionResponse::Array(vec![]),
+                None,
+            ),
+            (
+                "a link, read through its selection range",
+                lsp_types::GotoDefinitionResponse::Link(vec![link]),
+                Some(("file:///target.rs", 2)),
+            ),
+        ] {
+            match expected {
+                None => assert_eq!(first_definition_location(&response), None, "{name}"),
+                Some((expected_uri, expected_line)) => {
+                    let (uri, range) =
+                        first_definition_location(&response).unwrap_or_else(|| panic!("{name}"));
+                    assert_eq!(uri.as_str(), expected_uri, "{name}");
+                    assert_eq!(range.start.line, expected_line, "{name}");
+                }
+            }
+        }
     }
 }

--- a/crates/app/src/lsp/mod.rs
+++ b/crates/app/src/lsp/mod.rs
@@ -16,3 +16,5 @@ pub mod hover;
 
 pub(crate) mod client;
 pub(crate) mod completion_popup;
+#[cfg(test)]
+pub(crate) mod fixtures;

--- a/crates/app/src/merge/flow.rs
+++ b/crates/app/src/merge/flow.rs
@@ -983,63 +983,43 @@ fn fold_merge_result(
 #[cfg(test)]
 mod merge_regression_tests {
     use super::*;
+    use crate::test_support::{temp_repo_with, TempRoot};
     use gpui::{EntityInputHandler, TestAppContext};
     use std::fs;
     use std::process::Command;
     use tempfile::TempDir;
+    use test_support::{git, git_output};
 
-    fn git(dir: &std::path::Path, args: &[&str]) {
-        let output = Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {:?} failed in {:?}:\nstdout: {}\nstderr: {}",
-            args,
-            dir,
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
+    fn init_repo() -> TempRoot {
+        temp_repo_with(|root| {
+            test_support::seed_empty_repo_at(root);
+            test_support::commit(root, "base.txt", "base\n", "initial");
+        })
     }
 
-    fn init_repo() -> TempDir {
-        let dir = TempDir::new().expect("tempdir");
-        git(dir.path(), &["init", "-b", "main"]);
-        git(dir.path(), &["config", "user.email", "test@example.com"]);
-        git(dir.path(), &["config", "user.name", "Test User"]);
-        fs::write(dir.path().join("base.txt"), "base\n").expect("write");
-        git(dir.path(), &["add", "base.txt"]);
-        git(dir.path(), &["commit", "-m", "initial"]);
-        dir
-    }
-
-    /// Same real-linked-worktree idiom as `wt_core::merge`'s own test module.
+    /// Same real-linked-worktree idiom as `wt_core::merge`'s own test module. The path is
+    /// canonicalized for the same reason [`temp_repo`] canonicalizes a repo root: the app keys
+    /// worktrees by exact `PathBuf`, and on macOS the temp directory is behind a symlink.
     fn add_worktree(repo_path: &std::path::Path, branch: &str, name: &str) -> PathBuf {
         let container = TempDir::new().expect("tempdir");
-        let path = container.path().join(name);
-        drop(container);
-        git(
-            repo_path,
-            &[
-                "worktree",
-                "add",
-                "-b",
-                branch,
-                path.to_str().expect("utf8 path"),
-            ],
-        );
+        let root = container
+            .path()
+            .canonicalize()
+            .expect("canonicalize tempdir");
+        // `keep()`, not `drop()`: dropping the container deleted the directory and freed its
+        // random name for reuse, so under the parallel suite another fixture could be handed the
+        // same name and create `<name>` inside it first - `git worktree add` then failed with
+        // "already exists". Reproduced directly: 1 run in ~7 of the merge module under load.
+        // Keeping the (empty) directory costs nothing the old code did not already leak, since
+        // git recreated the path afterwards and nothing ever removed it.
+        let _ = container.keep();
+        let path = root.join(name);
+        test_support::add_worktree(repo_path, branch, &path);
         path
     }
 
     fn status(dir: &std::path::Path) -> String {
-        let output = Command::new("git")
-            .current_dir(dir)
-            .args(["status", "--porcelain"])
-            .output()
-            .expect("git status");
-        String::from_utf8_lossy(&output.stdout).into_owned()
+        git_output(dir, &["status", "--porcelain"])
     }
 
     /// Real parent-commit count for `rev` - the same real check `wt_core::merge`'s own test

--- a/crates/app/src/palette/render.rs
+++ b/crates/app/src/palette/render.rs
@@ -1442,8 +1442,11 @@ mod palette_language_server_step_tests {
     #[gpui::test]
     fn picking_a_row_restarts_exactly_that_server_and_closes_the_palette(cx: &mut TestAppContext) {
         let repo = tempfile::tempdir().expect("tempdir");
-        let root = repo.path().to_path_buf();
         let (app, _server, cx) = app_with_two_servers(cx, repo.path());
+        // The key `app_with_two_servers` really inserted under - `AdeApp` canonicalizes the root it
+        // is opened with, which on macOS resolves the `/var -> /private/var` symlink `TempDir`
+        // hands out, so `repo.path()` would key an entry that does not exist.
+        let root = app.read_with(cx, |app, _| app.file_tree_root.clone());
 
         cx.dispatch_action(TogglePalette);
         cx.run_until_parked();

--- a/crates/app/src/provenance/change_set.rs
+++ b/crates/app/src/provenance/change_set.rs
@@ -288,7 +288,7 @@ fn take_removal(ledger: &mut BTreeMap<usize, Vec<(Author, u32)>>, anchor: usize)
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::process::Command;
+    use test_support::git;
 
     use wt_core::diff::{diff_against_base, DiffHunk, DiffLine};
 
@@ -796,21 +796,5 @@ impl UserApi {
         store.begin_agent_edit(worktree, &file);
         std::fs::write(&file, content).expect("write");
         store.record_agent_edit(worktree, &file, agent);
-    }
-
-    fn git(dir: &Path, args: &[&str]) {
-        let output = Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {:?} failed in {:?}:\nstdout: {}\nstderr: {}",
-            args,
-            dir,
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
     }
 }

--- a/crates/app/src/provenance/integration_tests.rs
+++ b/crates/app/src/provenance/integration_tests.rs
@@ -11,13 +11,12 @@
 use std::io::{Read, Write};
 use std::net::TcpStream;
 use std::path::Path;
-use std::process::Command;
 
 use gpui::EntityInputHandler as _;
 
 use crate::hooks::settings_file::{PORT_ENV, TOKEN_ENV};
 use crate::provenance::{AgentKey, Author};
-use crate::root::focus::palette_focus_tests::open_test_app;
+use crate::test_support::{open_test_app, temp_repo_with};
 use crate::work_surface::agents::ProcessKind;
 
 const USERS_RS_BASE: &str = "\
@@ -40,14 +39,10 @@ impl UserApi {
 fn a_real_hook_edit_event_becomes_a_real_per_agent_attribution_on_a_real_change_set_row(
     cx: &mut gpui::TestAppContext,
 ) {
-    let repo = tempfile::tempdir().expect("tempdir");
-    git(repo.path(), &["init", "-b", "main"]);
-    git(repo.path(), &["config", "user.email", "test@example.com"]);
-    git(repo.path(), &["config", "user.name", "Test User"]);
-    std::fs::create_dir_all(repo.path().join("src/api")).expect("mkdir");
-    std::fs::write(repo.path().join("src/api/users.rs"), USERS_RS_BASE).expect("seed");
-    git(repo.path(), &["add", "-A"]);
-    git(repo.path(), &["commit", "-m", "initial"]);
+    let repo = temp_repo_with(|root| {
+        test_support::seed_empty_repo_at(root);
+        test_support::commit(root, "src/api/users.rs", USERS_RS_BASE, "initial");
+    });
 
     let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
 
@@ -154,13 +149,10 @@ fn a_real_hook_edit_event_becomes_a_real_per_agent_attribution_on_a_real_change_
 fn a_real_save_through_jerrys_own_editor_flips_exactly_its_own_lines_to_you(
     cx: &mut gpui::TestAppContext,
 ) {
-    let repo = tempfile::tempdir().expect("tempdir");
-    git(repo.path(), &["init", "-b", "main"]);
-    git(repo.path(), &["config", "user.email", "test@example.com"]);
-    git(repo.path(), &["config", "user.name", "Test User"]);
-    std::fs::write(repo.path().join("sample.txt"), "one\ntwo\nthree\n").expect("seed");
-    git(repo.path(), &["add", "-A"]);
-    git(repo.path(), &["commit", "-m", "initial"]);
+    let repo = temp_repo_with(|root| {
+        test_support::seed_empty_repo_at(root);
+        test_support::commit(root, "sample.txt", "one\ntwo\nthree\n", "initial");
+    });
 
     let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
     cx.run_until_parked();
@@ -231,21 +223,5 @@ fn post(port: u16, token: &str, query: &str, body: &str) {
     assert!(
         response.starts_with("HTTP/1.1 204"),
         "the listener must accept a real hook request, got: {response}"
-    );
-}
-
-fn git(dir: &Path, args: &[&str]) {
-    let output = Command::new("git")
-        .current_dir(dir)
-        .args(args)
-        .output()
-        .expect("failed to spawn git");
-    assert!(
-        output.status.success(),
-        "git {:?} failed in {:?}:\nstdout: {}\nstderr: {}",
-        args,
-        dir,
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
     );
 }

--- a/crates/app/src/provenance/render.rs
+++ b/crates/app/src/provenance/render.rs
@@ -580,8 +580,8 @@ mod attribution_render_tests {
     use crate::sidebar::render::RightSidebarView;
     use crate::work_surface::agents::AgentKind;
     use gpui::TestAppContext;
-    use std::process::Command;
     use tempfile::TempDir;
+    use test_support::git;
 
     /// The mock's own `src/api/users.rs`, as committed.
     const BASE: &str = "\
@@ -650,24 +650,16 @@ impl UserApi {
     const CHIP_CODEX: &str = "change-row-author-src/api/users.rs-codex";
     const CHIP_YOU: &str = "change-row-author-src/api/users.rs-you";
 
-    fn git(dir: &Path, args: &[&str]) {
-        let output = Command::new("git")
-            .args(args)
-            .current_dir(dir)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {args:?} failed: {}",
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
     /// A real repo whose one shared file carries lines from two different agents *and* one hand
     /// edit, with the provenance really recorded for all three.
     fn shared_file_repo() -> (TempDir, super::super::store::ProvenanceStore) {
         let dir = TempDir::new().expect("tempdir");
-        let repo = dir.path();
+        // Canonicalized because `AdeApp` canonicalizes the root it is given
+        // (`crate::rail::repo::canonical_repo_path`) and then keys provenance by exact `PathBuf`.
+        // On macOS `std::env::temp_dir()` is itself behind a `/var` -> `/private/var` symlink, so
+        // recording against `TempDir::path()` verbatim writes keys the app can never look up.
+        let root = dir.path().canonicalize().expect("canonicalize tempdir");
+        let repo = root.as_path();
         git(repo, &["init", "-b", "main"]);
         git(repo, &["config", "user.email", "test@example.com"]);
         git(repo, &["config", "user.name", "Test User"]);
@@ -762,7 +754,12 @@ impl UserApi {
     #[gpui::test]
     fn a_file_only_one_agent_wrote_gets_chips_but_no_ring(cx: &mut TestAppContext) {
         let dir = TempDir::new().expect("tempdir");
-        let repo = dir.path();
+        // Canonicalized because `AdeApp` canonicalizes the root it is given
+        // (`crate::rail::repo::canonical_repo_path`) and then keys provenance by exact `PathBuf`.
+        // On macOS `std::env::temp_dir()` is itself behind a `/var` -> `/private/var` symlink, so
+        // recording against `TempDir::path()` verbatim writes keys the app can never look up.
+        let root = dir.path().canonicalize().expect("canonicalize tempdir");
+        let repo = root.as_path();
         git(repo, &["init", "-b", "main"]);
         git(repo, &["config", "user.email", "test@example.com"]);
         git(repo, &["config", "user.name", "Test User"]);

--- a/crates/app/src/provenance/store.rs
+++ b/crates/app/src/provenance/store.rs
@@ -522,7 +522,7 @@ pub fn relative_within(worktree: &Path, file: &Path) -> Option<PathBuf> {
 mod tests {
     use super::*;
     use std::path::Path;
-    use std::process::Command;
+    use test_support::{git, git_output};
 
     /// The real shape of one agent tool call, end to end: the `PreToolUse` snapshot, the agent's
     /// actual write to the actual file, then the `PostToolUse` record. No step is simulated - the
@@ -996,7 +996,7 @@ mod tests {
             vec!["log", "--format=full", "--all"],
             vec!["cat-file", "-p", "HEAD"],
         ] {
-            let output = git_stdout(repo, &args);
+            let output = git_output(repo, &args);
             assert!(
                 !output.contains(marker) && !output.to_lowercase().contains("provenance"),
                 "`git {}` leaked attribution:\n{output}",
@@ -1004,44 +1004,19 @@ mod tests {
             );
         }
         assert_eq!(
-            git_stdout(repo, &["notes", "list"]).trim(),
+            git_output(repo, &["notes", "list"]),
             "",
             "attribution must not be smuggled out as a git note either"
         );
         assert_eq!(
-            git_stdout(repo, &["for-each-ref", "--format=%(refname)"]).trim(),
+            git_output(repo, &["for-each-ref", "--format=%(refname)"]),
             "refs/heads/main",
             "the store must not anchor anything with a ref of its own"
         );
         assert_eq!(
-            git_stdout(repo, &["status", "--porcelain"]).trim(),
+            git_output(repo, &["status", "--porcelain"]),
             "",
             "the store must not leave a single file behind in the worktree"
         );
-    }
-
-    fn git(dir: &Path, args: &[&str]) {
-        let output = Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {:?} failed in {:?}:\nstdout: {}\nstderr: {}",
-            args,
-            dir,
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
-    fn git_stdout(dir: &Path, args: &[&str]) -> String {
-        let output = Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        String::from_utf8_lossy(&output.stdout).into_owned()
     }
 }

--- a/crates/app/src/rail/menu_render.rs
+++ b/crates/app/src/rail/menu_render.rs
@@ -406,53 +406,15 @@ impl AdeApp {
 #[cfg(test)]
 mod rail_menu_tests {
     use super::*;
-    use crate::root::focus::palette_focus_tests;
     use gpui::TestAppContext;
     use std::fs;
     use std::path::Path;
-    use std::process::Command;
-    use tempfile::TempDir;
-
-    fn git(dir: &Path, args: &[&str]) {
-        let output = Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {:?} failed in {:?}: {}",
-            args,
-            dir,
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
-    fn init_repo() -> TempDir {
-        let dir = TempDir::new().expect("tempdir");
-        git(dir.path(), &["init", "-b", "main"]);
-        git(dir.path(), &["config", "user.email", "test@example.com"]);
-        git(dir.path(), &["config", "user.name", "Test User"]);
-        fs::write(dir.path().join("base.txt"), "base\n").expect("write");
-        git(dir.path(), &["add", "base.txt"]);
-        git(dir.path(), &["commit", "-m", "initial"]);
-        dir
-    }
 
     fn add_worktree(repo_path: &Path, branch: &str, name: &str) -> PathBuf {
-        let container = TempDir::new().expect("tempdir");
+        let container = crate::test_support::temp_root();
         let path = container.path().join(name);
         drop(container);
-        git(
-            repo_path,
-            &[
-                "worktree",
-                "add",
-                "-b",
-                branch,
-                path.to_str().expect("utf8 path"),
-            ],
-        );
+        test_support::add_worktree(repo_path, branch, &path);
         path
     }
 
@@ -583,9 +545,9 @@ mod rail_menu_tests {
     fn right_clicking_a_worktree_row_paints_the_row_set_the_revision_lists(
         cx: &mut TestAppContext,
     ) {
-        let repo = init_repo();
+        let repo = crate::test_support::temp_repo();
         let feature = add_worktree(repo.path(), "feature", "feature");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
         // A real agent session in the main worktree, so the Archive row has a real count to
         // report (a plain shell gets no rail row, and so is not something this row promises).
@@ -626,9 +588,9 @@ mod rail_menu_tests {
 
     #[gpui::test]
     fn new_agent_here_really_spawns_an_agent_into_that_worktree(cx: &mut TestAppContext) {
-        let repo = init_repo();
+        let repo = crate::test_support::temp_repo();
         let feature = add_worktree(repo.path(), "feature", "feature");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
         app.read_with(cx, |app, _| {
             assert_eq!(
@@ -662,8 +624,8 @@ mod rail_menu_tests {
     fn right_clicking_an_agent_row_paints_open_one_pause_or_resume_and_one_archive_run(
         cx: &mut TestAppContext,
     ) {
-        let repo = init_repo();
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_repo();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         let agent_id = spawn_agent(&app, cx);
@@ -693,7 +655,7 @@ mod rail_menu_tests {
 
     #[gpui::test]
     fn scrolling_the_rail_does_not_move_or_clip_an_open_menu(cx: &mut TestAppContext) {
-        let repo = init_repo();
+        let repo = crate::test_support::temp_repo();
         for index in 0..8 {
             add_worktree(
                 repo.path(),
@@ -701,7 +663,7 @@ mod rail_menu_tests {
                 &format!("wt{index}"),
             );
         }
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
         // Small enough that nine worktree rows genuinely overflow the rail's own viewport -
         // without a list that really scrolls, this test would pass against a menu nailed to a
@@ -765,8 +727,8 @@ mod rail_menu_tests {
     fn the_overflow_button_opens_history_and_settings_under_its_own_right_edge(
         cx: &mut TestAppContext,
     ) {
-        let repo = init_repo();
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_repo();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         let button = cx
@@ -805,8 +767,8 @@ mod rail_menu_tests {
 
     #[gpui::test]
     fn picking_settings_from_the_overflow_really_opens_settings(cx: &mut TestAppContext) {
-        let repo = init_repo();
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_repo();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         let button = cx.debug_bounds("rail-overflow").expect("button");
@@ -830,8 +792,8 @@ mod rail_menu_tests {
     fn archive_run_ends_the_run_and_leaves_the_worktree_and_its_files_alone(
         cx: &mut TestAppContext,
     ) {
-        let repo = init_repo();
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_repo();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
         let written = repo.path().join("agent-wrote-this.txt");
         fs::write(&written, "work\n").expect("write");
@@ -855,9 +817,9 @@ mod rail_menu_tests {
     fn remove_worktree_takes_two_clicks_and_then_really_removes_the_checkout(
         cx: &mut TestAppContext,
     ) {
-        let repo = init_repo();
+        let repo = crate::test_support::temp_repo();
         let feature = add_worktree(repo.path(), "feature", "feature");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         right_click_worktree_row(&app, cx, &feature);
@@ -894,9 +856,9 @@ mod rail_menu_tests {
 
     #[gpui::test]
     fn dismissing_the_menu_disarms_a_half_confirmed_removal(cx: &mut TestAppContext) {
-        let repo = init_repo();
+        let repo = crate::test_support::temp_repo();
         let feature = add_worktree(repo.path(), "feature", "feature");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         right_click_worktree_row(&app, cx, &feature);
@@ -929,8 +891,8 @@ mod rail_menu_tests {
 
     #[gpui::test]
     fn open_in_opens_its_second_level_in_the_same_menu(cx: &mut TestAppContext) {
-        let repo = init_repo();
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_repo();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         right_click_worktree_row(&app, cx, repo.path());
@@ -951,8 +913,8 @@ mod rail_menu_tests {
 
     #[gpui::test]
     fn a_menu_opened_at_the_windows_foot_flips_above_the_pointer(cx: &mut TestAppContext) {
-        let repo = init_repo();
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_repo();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         let viewport = cx.update(|window, _cx| window.bounds().size);

--- a/crates/app/src/rail/render.rs
+++ b/crates/app/src/rail/render.rs
@@ -2019,16 +2019,15 @@ mod agent_trailing_text_count_tests {
         }
     }
 
+    /// The row's trailing text conjugates with its own count - and no count at all is an empty
+    /// string, not `"0 files"`: the absence of a measurement and a measured zero are different
+    /// facts, and only the latter is a conjugation case.
     #[test]
-    fn review_file_count_conjugates_at_zero_one_and_two() {
+    fn the_review_file_count_conjugates_and_an_unmeasured_row_says_nothing() {
         assert_eq!(agent_trailing_text(&review_row(Some(0))), "0 files");
         assert_eq!(agent_trailing_text(&review_row(Some(1))), "1 file");
         assert_eq!(agent_trailing_text(&review_row(Some(2))), "2 files");
         assert_eq!(agent_trailing_text(&review_row(Some(12))), "12 files");
-    }
-
-    #[test]
-    fn an_unmeasured_review_row_has_no_trailing_text() {
         assert_eq!(agent_trailing_text(&review_row(None)), "");
     }
 }
@@ -2036,57 +2035,17 @@ mod agent_trailing_text_count_tests {
 #[cfg(test)]
 mod prune_regression_tests {
     use super::*;
-    use crate::root::focus::palette_focus_tests;
     use gpui::TestAppContext;
-    use std::fs;
     use std::path::Path;
-    use std::process::Command;
-    use tempfile::TempDir;
-
-    fn git(dir: &Path, args: &[&str]) {
-        let output = Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {:?} failed in {:?}:\nstdout: {}\nstderr: {}",
-            args,
-            dir,
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
-    fn init_repo() -> TempDir {
-        let dir = TempDir::new().expect("tempdir");
-        git(dir.path(), &["init", "-b", "main"]);
-        git(dir.path(), &["config", "user.email", "test@example.com"]);
-        git(dir.path(), &["config", "user.name", "Test User"]);
-        fs::write(dir.path().join("base.txt"), "base\n").expect("write");
-        git(dir.path(), &["add", "base.txt"]);
-        git(dir.path(), &["commit", "-m", "initial"]);
-        dir
-    }
 
     /// Same linked-worktree idiom `merge::flow`'s test module uses. Created with no new
     /// commits, so its branch tip trivially equals `main`'s - a genuinely-merged, clean
     /// worktree without needing a second real merge to produce one.
     fn add_worktree(repo_path: &Path, branch: &str, name: &str) -> PathBuf {
-        let container = TempDir::new().expect("tempdir");
+        let container = crate::test_support::temp_root();
         let path = container.path().join(name);
         drop(container);
-        git(
-            repo_path,
-            &[
-                "worktree",
-                "add",
-                "-b",
-                branch,
-                path.to_str().expect("utf8 path"),
-            ],
-        );
+        test_support::add_worktree(repo_path, branch, &path);
         path
     }
 
@@ -2128,10 +2087,10 @@ mod prune_regression_tests {
     fn a_second_confirm_while_first_batch_is_in_flight_does_not_prune_a_worktree_seeded_after_it(
         cx: &mut TestAppContext,
     ) {
-        let repo = init_repo();
+        let repo = crate::test_support::temp_repo();
         let first = add_worktree(repo.path(), "first-feature", "first-feature-wt");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         app.update(cx, |app, _cx| {
             seed_one_prunable_worktree(app, first.clone(), "first-feature");
         });
@@ -2201,7 +2160,6 @@ mod rail_row_tests {
     use super::*;
     use crate::hooks::store::LiveRun;
     use crate::rail::worktrees::WorktreeItem;
-    use crate::root::focus::palette_focus_tests;
     use gpui::TestAppContext;
 
     fn worktree_item(path: PathBuf, label: &str) -> WorktreeItem {
@@ -2223,10 +2181,10 @@ mod rail_row_tests {
 
     #[gpui::test]
     fn worktree_is_expanded_defaults_to_the_real_idle_rooted_rule(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let wt = tempfile::tempdir().expect("tempdir wt");
-        let other_wt = tempfile::tempdir().expect("tempdir other wt");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let wt = crate::test_support::temp_root();
+        let other_wt = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         app.update(cx, |app, _cx| {
             app.worktrees = vec![
@@ -2292,8 +2250,8 @@ mod rail_row_tests {
 
     #[gpui::test]
     fn a_worktree_with_only_a_shell_open_produces_no_agent_row(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         app.update(cx, |app, _cx| {
             app.worktrees = vec![worktree_item(repo.path().to_path_buf(), "repo")];
         });
@@ -2353,9 +2311,9 @@ mod rail_row_tests {
 
     #[gpui::test]
     fn the_selected_worktree_never_idle_collapses_by_default(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let wt = tempfile::tempdir().expect("tempdir wt");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let wt = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         app.update(cx, |app, _cx| {
             app.worktrees = vec![worktree_item(wt.path().to_path_buf(), "wt")];
@@ -2409,9 +2367,9 @@ mod rail_row_tests {
 
     #[gpui::test]
     fn toggle_worktree_collapsed_flips_and_remembers_the_override(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let wt = tempfile::tempdir().expect("tempdir wt");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let wt = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         app.update(cx, |app, _cx| {
             app.worktrees = vec![worktree_item(wt.path().to_path_buf(), "wt")];
@@ -2464,10 +2422,10 @@ mod rail_row_tests {
 
     #[gpui::test]
     fn selecting_an_agent_selects_its_worktree_and_raises_its_tab(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let wt_a = tempfile::tempdir().expect("tempdir a");
-        let wt_b = tempfile::tempdir().expect("tempdir b");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let wt_a = crate::test_support::temp_root();
+        let wt_b = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         app.update(cx, |app, _cx| {
             app.worktrees = vec![
@@ -2525,10 +2483,10 @@ mod rail_row_tests {
     fn render_rail_list_does_not_panic_across_bare_and_multi_agent_worktrees(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let bare_wt = tempfile::tempdir().expect("tempdir bare");
-        let busy_wt = tempfile::tempdir().expect("tempdir busy");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let bare_wt = crate::test_support::temp_root();
+        let busy_wt = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         app.update(cx, |app, _cx| {
             app.worktrees = vec![
@@ -2568,10 +2526,10 @@ mod rail_row_tests {
     fn build_repo_groups_header_wt_count_is_unaffected_by_the_filter_query(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let wt_alpha = tempfile::tempdir().expect("tempdir alpha");
-        let wt_beta = tempfile::tempdir().expect("tempdir beta");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let wt_alpha = crate::test_support::temp_root();
+        let wt_beta = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         app.update(cx, |app, _cx| {
             app.worktrees = vec![
@@ -2618,9 +2576,9 @@ mod rail_row_tests {
     ) {
         use crate::work_surface::agents::AgentKind;
 
-        let repo = tempfile::tempdir().expect("tempdir");
-        let wt = tempfile::tempdir().expect("tempdir wt");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let wt = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         app.update(cx, |app, _cx| {
             app.worktrees = vec![worktree_item(wt.path().to_path_buf(), "wt")];
@@ -2704,9 +2662,9 @@ mod rail_row_tests {
     ) {
         use crate::work_surface::agents::AgentKind;
 
-        let repo = tempfile::tempdir().expect("tempdir");
-        let wt = tempfile::tempdir().expect("tempdir wt");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let wt = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         app.update(cx, |app, _cx| {
             app.worktrees = vec![worktree_item(wt.path().to_path_buf(), "wt")];
         });
@@ -2761,9 +2719,9 @@ mod rail_row_tests {
     ) {
         use crate::work_surface::agents::AgentKind;
 
-        let repo = tempfile::tempdir().expect("tempdir");
-        let wt = tempfile::tempdir().expect("tempdir wt");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let wt = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         app.update(cx, |app, _cx| {
             app.worktrees = vec![worktree_item(wt.path().to_path_buf(), "wt")];
         });
@@ -2798,14 +2756,10 @@ mod rail_row_tests {
              {:?}",
             spec.args
         );
-    }
 
-    #[gpui::test]
-    fn resume_past_agent_is_a_no_op_for_an_unknown_key(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        // A stale/unknown key (the record was pruned, or never existed) is a genuine no-op -
+        // nothing is spawned, and nothing else about the app's state changes.
         let count_before = app.read_with(cx, |app, _| app.agents.iter().count());
-
         let resumed = app.update_in(cx, |app, window, cx| {
             app.resume_past_agent("no-such-key", window, cx)
         });
@@ -2829,51 +2783,33 @@ mod rail_row_tests {
 /// (`crate::root::AdeApp::select_worktree_by_path`'s cross-repo fallback).
 #[cfg(test)]
 mod repo_checkout_tests {
-    use crate::root::focus::palette_focus_tests;
     use crate::work_surface::agents::ProcessKind;
     use crate::work_surface::state::TabRef;
     use gpui::TestAppContext;
     use std::path::Path;
-    use std::process::Command;
-    use tempfile::TempDir;
 
     /// A minimal, real `git init`-ed repo - mirrors `crate::root::state::
     /// load_worktrees_integration_tests`'s identical own helper, duplicated locally per this
     /// crate's own established per-test-module convention rather than shared.
-    fn git(dir: &Path, args: &[&str]) {
-        let output = Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {:?} failed in {:?}:\nstdout: {}\nstderr: {}",
-            args,
-            dir,
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
-    fn init_repo() -> TempDir {
-        let dir = TempDir::new().expect("tempdir");
-        git(dir.path(), &["init", "-b", "main"]);
-        git(dir.path(), &["config", "user.email", "test@example.com"]);
-        git(dir.path(), &["config", "user.name", "Test User"]);
-        std::fs::write(dir.path().join("base.txt"), "base\n").expect("write");
-        git(dir.path(), &["add", "base.txt"]);
-        git(dir.path(), &["commit", "-m", "initial"]);
-        dir
-    }
-
+    /// The repo header is **not a click target** - per explicit user direction, after two
+    /// subtler header-click behaviors were both rejected in review (auto-selecting the repo's
+    /// main worktree; then a "pure navigation" focus switch that still re-rooted the sidebar):
+    /// clicking a repo header must do *nothing at all*. Only worktree rows and agent rows are
+    /// clickable in the rail, and repo switching happens exclusively through a worktree row
+    /// (see `clicking_a_non_focused_repos_worktree_row_switches_repo_and_selects_it` below).
+    ///
+    /// Driven through a real click on the header's own painted bounds - which must still paint
+    /// at all (GitHub issue #113's "the whole group vanished from the rail" half is unchanged) -
+    /// asserting the focused repo, file tree root, worktree selection, and the live agent set
+    /// are all exactly what they were before the click. That proves the header genuinely has no
+    /// `on_click`, not merely that it does something subtler than before.
     #[gpui::test]
     fn clicking_a_non_focused_repos_header_does_nothing_at_all(cx: &mut TestAppContext) {
-        let repo_a = tempfile::tempdir().expect("tempdir a");
-        let repo_b = tempfile::tempdir().expect("tempdir b");
+        let repo_a = crate::test_support::temp_root();
+        let repo_b = crate::test_support::temp_root();
         std::fs::write(repo_b.path().join("b.txt"), "b\n").expect("write");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo_a.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo_a.path().to_path_buf());
         cx.run_until_parked();
 
         let repo_b_id = app.update(cx, |app, cx| app.add_repo(repo_b.path().to_path_buf(), cx));
@@ -2945,10 +2881,10 @@ mod repo_checkout_tests {
     fn build_repo_groups_marks_a_non_focused_repos_data_as_loaded_once_its_real_fetch_resolves(
         cx: &mut TestAppContext,
     ) {
-        let repo_a = tempfile::tempdir().expect("tempdir a");
-        let repo_b = init_repo();
+        let repo_a = crate::test_support::temp_root();
+        let repo_b = crate::test_support::temp_repo();
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo_a.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo_a.path().to_path_buf());
         cx.run_until_parked();
 
         let repo_a_id = app.read_with(cx, |app, _| {
@@ -3011,14 +2947,26 @@ mod repo_checkout_tests {
         );
     }
 
+    /// Real cross-repo agent persistence (`crate::root::AdeApp::open_repo_in_current_window`'s
+    /// own "cross-repo agent persistence" docs): a real Claude agent spawned into repo B must
+    /// still show up in `Self::build_repo_groups`' output for repo B, with genuinely live status,
+    /// even after focus has moved away to repo A - the rail's own "see at a glance if a
+    /// background repo's agent needs me" promise. Also proves the inverse half of that same
+    /// promise: repo A's own tab strip (`crate::work_surface::render::AdeApp::
+    /// combined_tab_order`) must *not* show repo B's agent while B isn't the active worktree -
+    /// cross-repo visibility lives in the rail alone, never a new tab-strip affordance.
+    // Asserts the folded-in row carries `Status::Run`, which requires the spawned `claude` CLI to
+    // still be a live process. On a machine without that binary the PTY child exits immediately
+    // and the status is `Fail`, so this needs the real agent CLI - the `external` tier.
+    #[ignore = "external: claude; see docs/testing.md"]
     #[gpui::test]
     fn build_repo_groups_folds_a_non_focused_repos_real_agent_into_its_own_row(
         cx: &mut TestAppContext,
     ) {
-        let repo_a = tempfile::tempdir().expect("tempdir a");
-        let repo_b = init_repo();
+        let repo_a = crate::test_support::temp_root();
+        let repo_b = crate::test_support::temp_repo();
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo_a.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo_a.path().to_path_buf());
         cx.run_until_parked();
 
         // Focus repo B long enough to spawn a real Claude agent into it, mirroring how a user
@@ -3099,8 +3047,8 @@ mod repo_checkout_tests {
 
     #[gpui::test]
     fn clicking_the_already_focused_repos_header_does_not_reset_it(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         let repo_id = app.read_with(cx, |app, _| {
@@ -3132,19 +3080,10 @@ mod repo_checkout_tests {
     /// Same linked-worktree idiom the sibling test modules use: created with no new commits of its
     /// own, which is all these tests need from it (a second, real, selectable worktree row).
     fn add_worktree(repo_path: &Path, branch: &str, name: &str) -> std::path::PathBuf {
-        let container = TempDir::new().expect("tempdir");
+        let container = crate::test_support::temp_root();
         let path = container.path().join(name);
         drop(container);
-        git(
-            repo_path,
-            &[
-                "worktree",
-                "add",
-                "-b",
-                branch,
-                path.to_str().expect("utf8 path"),
-            ],
-        );
+        test_support::add_worktree(repo_path, branch, &path);
         path
     }
 
@@ -3152,11 +3091,11 @@ mod repo_checkout_tests {
     fn clicking_a_non_focused_repos_worktree_row_switches_repo_and_selects_it(
         cx: &mut TestAppContext,
     ) {
-        let repo_a = init_repo();
-        let repo_b = init_repo();
+        let repo_a = crate::test_support::temp_repo();
+        let repo_b = crate::test_support::temp_repo();
         let repo_b_feature = add_worktree(repo_b.path(), "feature", "b-feature");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo_a.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo_a.path().to_path_buf());
         cx.run_until_parked();
 
         app.update(cx, |app, cx| {
@@ -3234,14 +3173,14 @@ mod repo_checkout_tests {
     fn a_cross_repo_worktree_selection_survives_the_repos_own_background_fetch(
         cx: &mut TestAppContext,
     ) {
-        let repo_a = init_repo();
-        let repo_b = init_repo();
+        let repo_a = crate::test_support::temp_repo();
+        let repo_b = crate::test_support::temp_repo();
         // Two linked worktrees, so the target is not at index 0 and a stale index would be
         // visible as a wrong selection rather than accidentally landing on the right row.
         let _first = add_worktree(repo_b.path(), "first", "b-first");
         let target = add_worktree(repo_b.path(), "second", "b-second");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo_a.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo_a.path().to_path_buf());
         cx.run_until_parked();
         app.update(cx, |app, cx| {
             app.add_repo(repo_b.path().to_path_buf(), cx);
@@ -3287,10 +3226,10 @@ mod repo_checkout_tests {
 
     #[gpui::test]
     fn selecting_a_worktree_path_no_repo_knows_about_still_does_nothing(cx: &mut TestAppContext) {
-        let repo_a = init_repo();
-        let repo_b = init_repo();
+        let repo_a = crate::test_support::temp_repo();
+        let repo_b = crate::test_support::temp_repo();
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo_a.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo_a.path().to_path_buf());
         cx.run_until_parked();
         app.update(cx, |app, cx| {
             app.add_repo(repo_b.path().to_path_buf(), cx);
@@ -3318,8 +3257,8 @@ mod repo_checkout_tests {
     fn an_agent_spawned_in_a_repo_opened_through_a_symlink_still_appears_in_the_rail(
         cx: &mut TestAppContext,
     ) {
-        let repo = init_repo();
-        let link_holder = TempDir::new().expect("tempdir");
+        let repo = crate::test_support::temp_repo();
+        let link_holder = crate::test_support::temp_root();
         let link = link_holder.path().join("repo-link");
         std::os::unix::fs::symlink(repo.path(), &link).expect("symlink");
         assert_ne!(
@@ -3328,7 +3267,7 @@ mod repo_checkout_tests {
             "sanity check: the symlink really is a different path from the real repo"
         );
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, link.clone());
+        let (app, cx) = crate::test_support::open_test_app(cx, link.clone());
         cx.run_until_parked();
 
         let agent_id = app.update_in(cx, |app, window, cx| {
@@ -3370,13 +3309,13 @@ mod repo_checkout_tests {
     #[cfg(unix)]
     #[gpui::test]
     fn opening_a_symlinked_folder_stores_the_resolved_repo_path(cx: &mut TestAppContext) {
-        let repo_a = init_repo();
-        let repo_b = init_repo();
-        let link_holder = TempDir::new().expect("tempdir");
+        let repo_a = crate::test_support::temp_repo();
+        let repo_b = crate::test_support::temp_repo();
+        let link_holder = crate::test_support::temp_root();
         let link = link_holder.path().join("repo-b-link");
         std::os::unix::fs::symlink(repo_b.path(), &link).expect("symlink");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo_a.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo_a.path().to_path_buf());
         cx.run_until_parked();
 
         app.update_in(cx, |app, window, cx| {
@@ -3419,56 +3358,17 @@ mod repo_checkout_tests {
 /// family of bugs behind it:
 #[cfg(test)]
 mod worktree_tab_attribution_tests {
-    use crate::root::focus::palette_focus_tests;
     use crate::work_surface::state::TabRef;
     use gpui::TestAppContext;
     use std::path::{Path, PathBuf};
-    use std::process::Command;
-    use tempfile::TempDir;
-
-    fn git(dir: &Path, args: &[&str]) {
-        let output = Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {:?} failed in {:?}:\nstdout: {}\nstderr: {}",
-            args,
-            dir,
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
 
     /// A real repository with a real commit - `wt_core::list_worktrees_porcelain` reports nothing
     /// at all for a bare `tempfile::tempdir()`, so these tests need a genuine main worktree row.
-    fn init_repo() -> TempDir {
-        let dir = TempDir::new().expect("tempdir");
-        git(dir.path(), &["init", "-b", "main"]);
-        git(dir.path(), &["config", "user.email", "test@example.com"]);
-        git(dir.path(), &["config", "user.name", "Test User"]);
-        std::fs::write(dir.path().join("base.txt"), "base\n").expect("write");
-        git(dir.path(), &["add", "base.txt"]);
-        git(dir.path(), &["commit", "-m", "initial"]);
-        dir
-    }
-
     fn add_worktree(repo_path: &Path, branch: &str, name: &str) -> PathBuf {
-        let container = TempDir::new().expect("tempdir");
+        let container = crate::test_support::temp_root();
         let path = container.path().join(name);
         drop(container);
-        git(
-            repo_path,
-            &[
-                "worktree",
-                "add",
-                "-b",
-                branch,
-                path.to_str().expect("utf8 path"),
-            ],
-        );
+        test_support::add_worktree(repo_path, branch, &path);
         path
     }
 
@@ -3497,8 +3397,8 @@ mod worktree_tab_attribution_tests {
 
     #[gpui::test]
     fn a_fresh_launch_genuinely_selects_the_repos_own_main_worktree(cx: &mut TestAppContext) {
-        let repo = init_repo();
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_repo();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         app.read_with(cx, |app, _| {
@@ -3538,9 +3438,9 @@ mod worktree_tab_attribution_tests {
     fn the_startup_terminal_is_a_real_worktrees_tab_and_survives_switching_away_and_back(
         cx: &mut TestAppContext,
     ) {
-        let repo = init_repo();
+        let repo = crate::test_support::temp_repo();
         let feature = add_worktree(repo.path(), "feature", "feature");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         let startup_agent = app.read_with(cx, |app, _| {
@@ -3608,9 +3508,9 @@ mod worktree_tab_attribution_tests {
     fn launching_against_a_subdirectory_still_attributes_its_shell_to_a_real_worktree(
         cx: &mut TestAppContext,
     ) {
-        let repo = init_repo();
+        let repo = crate::test_support::temp_repo();
         std::fs::create_dir_all(repo.path().join("crates")).expect("mkdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().join("crates"));
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().join("crates"));
         cx.run_until_parked();
 
         let startup_agent = app.read_with(cx, |app, _| {
@@ -3655,9 +3555,9 @@ mod worktree_tab_attribution_tests {
 
     #[gpui::test]
     fn launching_inside_a_linked_worktree_selects_that_worktree_not_main(cx: &mut TestAppContext) {
-        let repo = init_repo();
+        let repo = crate::test_support::temp_repo();
         let feature = add_worktree(repo.path(), "feature", "feature");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, feature.clone());
+        let (app, cx) = crate::test_support::open_test_app(cx, feature.clone());
         cx.run_until_parked();
 
         app.read_with(cx, |app, _| {
@@ -3678,9 +3578,9 @@ mod worktree_tab_attribution_tests {
     fn opening_a_folder_lands_on_a_real_worktree_and_spawns_its_shell_there(
         cx: &mut TestAppContext,
     ) {
-        let repo_a = init_repo();
-        let repo_b = init_repo();
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo_a.path().to_path_buf());
+        let repo_a = crate::test_support::temp_repo();
+        let repo_b = crate::test_support::temp_repo();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo_a.path().to_path_buf());
         cx.run_until_parked();
 
         app.update_in(cx, |app, window, cx| {
@@ -3717,11 +3617,11 @@ mod worktree_tab_attribution_tests {
     fn a_worktree_click_racing_the_open_fetch_still_gets_its_guaranteed_shell(
         cx: &mut TestAppContext,
     ) {
-        let repo_a = init_repo();
-        let repo_b = init_repo();
+        let repo_a = crate::test_support::temp_repo();
+        let repo_b = crate::test_support::temp_repo();
         let feature = add_worktree(repo_b.path(), "feature", "feature");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo_a.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo_a.path().to_path_buf());
         cx.run_until_parked();
         // Repo B is already a known repo with a real, already-fetched worktree list - which is
         // what makes the racing click below able to resolve a row at all.
@@ -3761,9 +3661,9 @@ mod worktree_tab_attribution_tests {
 
     #[gpui::test]
     fn nothing_selected_means_nothing_shown_anywhere(cx: &mut TestAppContext) {
-        let repo_a = init_repo();
-        let repo_b = init_repo();
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo_a.path().to_path_buf());
+        let repo_a = crate::test_support::temp_repo();
+        let repo_b = crate::test_support::temp_repo();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo_a.path().to_path_buf());
         cx.run_until_parked();
 
         // Repo B enters through the real "Open Folder…" gesture, so it genuinely has a live shell
@@ -3843,7 +3743,6 @@ mod worktree_tab_attribution_tests {
 /// measured-bounds technique rather than only reading the render code.
 #[cfg(test)]
 mod rail_filter_caret_tests {
-    use crate::root::focus::palette_focus_tests;
     use gpui::TestAppContext;
     use std::time::Duration;
 
@@ -3851,8 +3750,8 @@ mod rail_filter_caret_tests {
     fn caret_sits_before_the_placeholder_when_empty_and_after_the_text_once_typed(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         app.update_in(cx, |app, window, cx| {
             window.focus(&app.filter_focus_handle, cx);
@@ -3906,8 +3805,8 @@ mod rail_filter_caret_tests {
 
     #[gpui::test]
     fn focusing_the_rail_filter_starts_the_real_shared_blink_loop(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         // `on_focus`/`on_blur` (`AdeApp::wire_caret_blink`'s own mechanism) only fire while GPUI
         // considers the window itself "active" - a real, freshly opened test window starts out
         // not active at all.
@@ -3944,7 +3843,6 @@ mod rail_filter_caret_tests {
 #[cfg(test)]
 mod agent_chip_icon_pack_tests {
     use crate::rail::worktrees::WorktreeItem;
-    use crate::root::focus::palette_focus_tests;
     use crate::work_surface::agents::ProcessKind;
     use gpui::{px, TestAppContext};
 
@@ -3972,14 +3870,14 @@ mod agent_chip_icon_pack_tests {
     fn open_with_a_running_agent(
         cx: &mut TestAppContext,
     ) -> (
-        tempfile::TempDir,
-        tempfile::TempDir,
+        crate::test_support::TempRoot,
+        crate::test_support::TempRoot,
         gpui::Entity<crate::root::AdeApp>,
         &mut gpui::VisualTestContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let wt = tempfile::tempdir().expect("tempdir wt");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let wt = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         app.update(cx, |app, _cx| {
             app.worktrees = vec![worktree_item(wt.path().to_path_buf(), "wt")];
@@ -4018,7 +3916,7 @@ mod agent_chip_icon_pack_tests {
     fn the_rail_agent_row_switches_to_a_real_pack_icon_once_one_is_configured(
         cx: &mut TestAppContext,
     ) {
-        let pack_dir = tempfile::tempdir().expect("tempdir");
+        let pack_dir = crate::test_support::temp_root();
         // The seeded agent is a real `AgentKind::Claude` (`work_surface::agent_icon_name`'s own
         // mapping), so `claude.svg` is the real file this specific row's chip looks for.
         std::fs::write(pack_dir.path().join("claude.svg"), "<svg></svg>").expect("write");
@@ -4044,7 +3942,7 @@ mod agent_chip_icon_pack_tests {
 
     #[gpui::test]
     fn the_pack_icon_element_is_a_real_image_not_a_colour_dependent_svg(cx: &mut TestAppContext) {
-        let pack_dir = tempfile::tempdir().expect("tempdir");
+        let pack_dir = crate::test_support::temp_root();
         std::fs::write(pack_dir.path().join("claude.svg"), "<svg></svg>").expect("write");
 
         let (_repo, _wt, app, cx) = open_with_a_running_agent(cx);
@@ -4264,7 +4162,6 @@ mod rail_correction_tests {
 mod rail_rev6_render_tests {
     use super::*;
     use crate::rail::worktrees::WorktreeItem;
-    use crate::root::focus::palette_focus_tests;
     use gpui::TestAppContext;
 
     fn worktree_item(path: PathBuf, label: &str) -> WorktreeItem {
@@ -4301,14 +4198,14 @@ mod rail_rev6_render_tests {
     fn open_with_a_failed_agent(
         cx: &mut TestAppContext,
     ) -> (
-        tempfile::TempDir,
-        tempfile::TempDir,
+        crate::test_support::TempRoot,
+        crate::test_support::TempRoot,
         gpui::Entity<crate::root::AdeApp>,
         &mut gpui::VisualTestContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let wt = tempfile::tempdir().expect("tempdir wt");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let wt = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         app.update(cx, |app, _cx| {
             app.worktrees = vec![worktree_item(wt.path().to_path_buf(), "wt")];
@@ -4359,8 +4256,8 @@ mod rail_rev6_render_tests {
 
     #[gpui::test]
     fn each_urgency_pair_is_an_element_only_when_its_own_count_is_nonzero(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         app.update(cx, |app, _cx| {
             let repo_id = app.repos[0].id;
             for kind in [UrgencyCount::NeedsInput, UrgencyCount::Failed] {
@@ -4478,8 +4375,8 @@ mod rail_rev6_render_tests {
 
     #[gpui::test]
     fn the_prune_control_is_a_bin_icon_in_a_seventeen_pixel_box(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (_app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (_app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         let button = cx
@@ -4526,10 +4423,10 @@ mod rail_rev6_render_tests {
     fn the_repo_header_sits_closer_to_its_rows_than_the_rows_sit_to_each_other(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let alpha = tempfile::tempdir().expect("tempdir alpha");
-        let beta = tempfile::tempdir().expect("tempdir beta");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let alpha = crate::test_support::temp_root();
+        let beta = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         app.update(cx, |app, cx| {
             app.worktrees = vec![
                 worktree_item(alpha.path().to_path_buf(), "alpha"),
@@ -4608,10 +4505,8 @@ mod rail_rev6_render_tests {
 mod rail_virtualization_tests {
     use super::*;
     use crate::rail::worktrees::WorktreeItem;
-    use crate::root::focus::palette_focus_tests;
     use gpui::TestAppContext;
     use std::path::Path;
-    use tempfile::TempDir;
 
     /// Deliberately more rows than any plausible test viewport can show at 27px each, mirroring
     /// `crate::sidebar::render::virtualization_tests`' own 300-file tree fixture - "dozens to
@@ -4643,12 +4538,15 @@ mod rail_virtualization_tests {
     /// directly" - both paths converge on the exact same `WorktreeItem`/`WorktreeRow`/`RepoGroup`
     /// types this file's own `rail_row_tests`/`prune_regression_tests` already seed the same way
     /// for their own synthetic fixtures. Returns every seeded path in seed order; the caller owns
-    /// `keepalive` so the real `TempDir`s (and the directories they hold open) outlive the test.
-    fn seed_many_worktrees(app: &mut AdeApp, keepalive: &mut Vec<TempDir>) -> Vec<PathBuf> {
+    /// `keepalive` so the real temporary directories outlive the test.
+    fn seed_many_worktrees(
+        app: &mut AdeApp,
+        keepalive: &mut Vec<crate::test_support::TempRoot>,
+    ) -> Vec<PathBuf> {
         let mut paths = Vec::with_capacity(ROW_COUNT);
         let mut items = Vec::with_capacity(ROW_COUNT);
         for index in 0..ROW_COUNT {
-            let dir = TempDir::new().expect("tempdir");
+            let dir = crate::test_support::temp_root();
             let path = dir.path().to_path_buf();
             keepalive.push(dir);
             items.push(worktree_item(path.clone(), &format!("wt-{index:03}")));
@@ -4678,8 +4576,8 @@ mod rail_virtualization_tests {
 
     #[gpui::test]
     fn a_worktree_row_far_below_the_viewport_is_never_painted(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         let mut keepalive = Vec::new();
         let paths = app.update(cx, |app, _cx| seed_many_worktrees(app, &mut keepalive));
         app.update(cx, |_app, cx| cx.notify());
@@ -4708,8 +4606,8 @@ mod rail_virtualization_tests {
     fn scrolling_the_virtualized_rail_materializes_a_row_that_was_not_painted(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         let mut keepalive = Vec::new();
         let paths = app.update(cx, |app, _cx| seed_many_worktrees(app, &mut keepalive));
         app.update(cx, |_app, cx| cx.notify());
@@ -4776,8 +4674,8 @@ mod rail_virtualization_tests {
     fn hovering_a_visible_row_does_not_materialize_a_row_far_below_the_viewport(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         let mut keepalive = Vec::new();
         let paths = app.update(cx, |app, _cx| seed_many_worktrees(app, &mut keepalive));
         app.update(cx, |_app, cx| cx.notify());
@@ -4819,7 +4717,6 @@ mod rail_virtualization_tests {
 #[cfg(test)]
 mod rail_filter_selection_tests {
     use super::*;
-    use crate::root::focus::palette_focus_tests;
     use gpui::TestAppContext;
 
     fn secondary(key: &str) -> String {
@@ -4837,7 +4734,7 @@ mod rail_filter_selection_tests {
         repo: &std::path::Path,
         text: &str,
     ) -> (gpui::Entity<AdeApp>, &'a mut gpui::VisualTestContext) {
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.to_path_buf());
         cx.update(|_window, cx| cx.bind_keys(crate::default_key_bindings()));
         app.update_in(cx, |app, window, cx| {
             window.focus(&app.filter_focus_handle, cx);
@@ -4886,7 +4783,7 @@ mod rail_filter_selection_tests {
     fn shift_arrow_extends_a_real_selection_and_a_plain_arrow_collapses_it(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
         let (app, cx) = open_filter_with(cx, repo.path(), "origin");
 
         cx.simulate_keystrokes("home shift-right shift-right shift-right");
@@ -4910,7 +4807,7 @@ mod rail_filter_selection_tests {
 
     #[gpui::test]
     fn a_real_click_places_the_caret_and_a_drag_selects_the_range_between(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
         let (app, cx) = open_filter_with(cx, repo.path(), "origin/main");
 
         let start = point_at_offset(&app, cx, 0);
@@ -4956,7 +4853,7 @@ mod rail_filter_selection_tests {
 
     #[gpui::test]
     fn a_real_double_click_selects_the_word_under_the_pointer(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
         let (app, cx) = open_filter_with(cx, repo.path(), "origin/main");
         let inside_second_word = point_inside_glyph(&app, cx, 8);
         cx.simulate_event(gpui::MouseDownEvent {
@@ -4977,7 +4874,7 @@ mod rail_filter_selection_tests {
 
     #[gpui::test]
     fn a_shift_click_extends_from_the_existing_anchor(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
         let (app, cx) = open_filter_with(cx, repo.path(), "origin/main");
         let left_edge = point_at_offset(&app, cx, 0);
         cx.simulate_mouse_down(
@@ -5009,7 +4906,7 @@ mod rail_filter_selection_tests {
 
     #[gpui::test]
     fn select_all_then_copy_puts_the_real_text_on_the_real_clipboard(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
         let (app, cx) = open_filter_with(cx, repo.path(), "origin/main");
         // Seeded with something else first, so a green result cannot come from a clipboard that
         // simply already said the right thing.
@@ -5040,7 +4937,7 @@ mod rail_filter_selection_tests {
 
     #[gpui::test]
     fn cut_removes_the_selection_and_paste_puts_it_back_somewhere_else(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
         let (app, cx) = open_filter_with(cx, repo.path(), "origin/main");
 
         cx.simulate_keystrokes("home shift-right shift-right shift-right");
@@ -5086,9 +4983,12 @@ mod rail_filter_selection_tests {
         );
     }
 
+    /// Any edit made while a selection is live replaces that whole range rather than acting at
+    /// the caret: a paste substitutes its clipboard content for it, and one Backspace empties it
+    /// rather than removing a single character from its end.
     #[gpui::test]
-    fn paste_over_a_selection_replaces_it(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+    fn an_edit_over_a_live_selection_replaces_the_whole_range(cx: &mut TestAppContext) {
+        let repo = crate::test_support::temp_root();
         let (app, cx) = open_filter_with(cx, repo.path(), "origin/main");
         cx.update(|_window, cx| {
             cx.write_to_clipboard(gpui::ClipboardItem::new_string("upstream".into()))
@@ -5104,12 +5004,7 @@ mod rail_filter_selection_tests {
             "upstream/main",
             "a paste with a live selection replaces that whole range"
         );
-    }
 
-    #[gpui::test]
-    fn backspace_over_a_selection_deletes_the_whole_range(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = open_filter_with(cx, repo.path(), "origin/main");
         cx.simulate_keystrokes(&secondary("a"));
         cx.simulate_keystrokes("backspace");
         cx.run_until_parked();
@@ -5122,7 +5017,7 @@ mod rail_filter_selection_tests {
 
     #[gpui::test]
     fn the_selection_is_really_measured_from_the_row_that_painted_it(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
         let (app, cx) = open_filter_with(cx, repo.path(), "origin/main");
         cx.simulate_keystrokes(&secondary("a"));
         cx.run_until_parked();

--- a/crates/app/src/rail/repo.rs
+++ b/crates/app/src/rail/repo.rs
@@ -363,29 +363,30 @@ mod tests {
         );
     }
 
+    /// A repo's display name is its path's own basename, falling back to the whole path when
+    /// there is no basename to take - and a freshly constructed repo starts with nothing loaded,
+    /// so nothing renders a worktree list it has not actually fetched yet.
     #[test]
-    fn repo_new_derives_a_display_name_from_the_path_basename() {
+    fn repo_new_names_itself_from_its_path_and_starts_with_nothing_loaded() {
         let repo = Repo::new(RepoId(0), PathBuf::from("/home/user/code/jerry-core"));
         assert_eq!(repo.name, "jerry-core");
         assert!(repo.worktrees.is_empty());
+        assert!(!repo.worktrees_loaded);
+
+        assert_eq!(Repo::new(RepoId(0), PathBuf::from("/")).name, "/");
     }
 
+    /// Neither a file that is not there nor one that is not valid TOML may fail the load - a
+    /// hand-edited or half-written `repos.toml` degrades to the empty state, never an error the
+    /// caller has to handle at startup.
     #[test]
-    fn repo_new_falls_back_to_the_whole_path_when_there_is_no_basename() {
-        let repo = Repo::new(RepoId(0), PathBuf::from("/"));
-        assert_eq!(repo.name, "/");
-    }
+    fn a_missing_or_corrupted_file_loads_as_empty_state_rather_than_failing() {
+        let dir = crate::test_support::temp_root();
+        assert_eq!(
+            RepoState::load_at(&dir.path().join("does-not-exist.toml")),
+            RepoState::default()
+        );
 
-    #[test]
-    fn a_missing_file_loads_as_empty_state_rather_than_failing() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let state = RepoState::load_at(&dir.path().join("does-not-exist.toml"));
-        assert_eq!(state, RepoState::default());
-    }
-
-    #[test]
-    fn a_corrupted_file_loads_as_empty_state_rather_than_failing() {
-        let dir = tempfile::tempdir().expect("tempdir");
         let path = dir.path().join("repos.toml");
         std::fs::write(&path, "this is not valid toml {{{").expect("write");
         assert_eq!(RepoState::load_at(&path), RepoState::default());
@@ -393,7 +394,7 @@ mod tests {
 
     #[test]
     fn a_remembered_worktree_is_returned_only_while_it_still_exists() {
-        let worktree = tempfile::tempdir().expect("tempdir");
+        let worktree = crate::test_support::temp_root();
         let mut state = RepoState::default();
         state.repos.insert(
             "/repo/a".to_string(),
@@ -428,7 +429,7 @@ mod tests {
 
     #[test]
     fn saving_and_loading_round_trips_a_real_file() {
-        let dir = tempfile::tempdir().expect("tempdir");
+        let dir = crate::test_support::temp_root();
         let path = dir.path().join("repos.toml");
         let mut state = RepoState::default();
         state.repos.insert(
@@ -453,7 +454,7 @@ mod tests {
 
     #[test]
     fn saving_leaves_no_temp_file_behind() {
-        let dir = tempfile::tempdir().expect("tempdir");
+        let dir = crate::test_support::temp_root();
         let path = dir.path().join("nested").join("repos.toml");
         let mut state = RepoState::default();
         state.repos.insert(
@@ -481,7 +482,7 @@ mod tests {
 
     #[test]
     fn saving_merges_with_another_instances_repo_instead_of_erasing_it() {
-        let dir = tempfile::tempdir().expect("tempdir");
+        let dir = crate::test_support::temp_root();
         let path = dir.path().join("repos.toml");
 
         let mut instance_a = RepoState::default();
@@ -518,7 +519,7 @@ mod tests {
 
     #[test]
     fn a_merged_save_really_deletes_an_owned_repos_entry() {
-        let dir = tempfile::tempdir().expect("tempdir");
+        let dir = crate::test_support::temp_root();
         let path = dir.path().join("repos.toml");
         let owned: std::collections::BTreeSet<String> =
             ["/repo/a".to_string()].into_iter().collect();
@@ -544,76 +545,55 @@ mod tests {
     }
 
     #[test]
-    fn last_focused_existing_path_is_none_when_nothing_was_ever_remembered() {
-        let state = RepoState::default();
-        assert_eq!(state.last_focused_existing_path(), None);
-    }
+    fn last_focused_existing_path_resolves_only_a_known_repo_that_is_still_a_real_directory() {
+        assert_eq!(RepoState::default().last_focused_existing_path(), None);
 
-    #[test]
-    fn last_focused_existing_path_is_none_when_the_key_is_not_a_known_repo() {
-        // `last_focused` names a key that was never actually added to `repos` (e.g. a hand-
-        // edited file, or a repo since removed) - must not resolve to a path anyway.
-        let state = RepoState {
+        // `last_focused` naming a key that was never added to `repos` (a hand-edited file, or a
+        // repo since removed) must not resolve to a path anyway.
+        let unknown = RepoState {
             last_focused: Some("/repo/never-added".to_string()),
             ..RepoState::default()
         };
-        assert_eq!(state.last_focused_existing_path(), None);
-    }
+        assert_eq!(unknown.last_focused_existing_path(), None);
 
-    #[test]
-    fn last_focused_existing_path_is_none_when_the_remembered_directory_no_longer_exists() {
-        let dir = tempfile::tempdir().expect("tempdir");
+        let dir = crate::test_support::temp_root();
+        let remembered = |path: &std::path::Path| {
+            let key = path.to_str().expect("utf8 path").to_string();
+            let mut state = RepoState::default();
+            state.repos.insert(
+                key.clone(),
+                RepoRecord {
+                    name: "repo".to_string(),
+                    selected_worktree: None,
+                },
+            );
+            state.last_focused = Some(key);
+            state
+        };
+
+        let live = dir.path().join("live-repo");
+        std::fs::create_dir(&live).expect("mkdir");
+        assert_eq!(
+            remembered(&live).last_focused_existing_path(),
+            Some(live.clone())
+        );
+
         let gone = dir.path().join("deleted-repo");
         std::fs::create_dir(&gone).expect("mkdir");
-        let key = gone.to_str().expect("utf8 path").to_string();
-
-        let mut state = RepoState::default();
-        state.repos.insert(
-            key.clone(),
-            RepoRecord {
-                name: "deleted-repo".to_string(),
-                selected_worktree: None,
-            },
-        );
-        state.last_focused = Some(key);
-        // The directory is removed *after* being recorded - simulating a repo that was open,
-        // remembered, and has since been deleted or moved.
+        let state = remembered(&gone);
         std::fs::remove_dir(&gone).expect("rmdir");
-
         assert_eq!(
             state.last_focused_existing_path(),
             None,
             "a deleted/moved remembered folder must fall back to empty, not a broken path"
         );
-    }
 
-    #[test]
-    fn last_focused_existing_path_is_none_when_the_remembered_path_was_replaced_by_a_file() {
-        let dir = tempfile::tempdir().expect("tempdir");
         let replaced = dir.path().join("was-a-repo");
         std::fs::create_dir(&replaced).expect("mkdir");
-        let key = replaced.to_str().expect("utf8 path").to_string();
-
-        let mut state = RepoState::default();
-        state.repos.insert(
-            key.clone(),
-            RepoRecord {
-                name: "was-a-repo".to_string(),
-                selected_worktree: None,
-            },
-        );
-        state.last_focused = Some(key);
-
-        // The directory is removed and replaced with a plain file of the same name - the path
-        // still `exists()`, but is no longer a real, usable repo checkout.
+        let state = remembered(&replaced);
         std::fs::remove_dir(&replaced).expect("rmdir");
         std::fs::write(&replaced, "not a repo").expect("write");
-        assert!(replaced.exists(), "sanity check: the path still exists");
-        assert!(
-            !replaced.is_dir(),
-            "sanity check: it is a file now, not a directory"
-        );
-
+        assert!(replaced.exists() && !replaced.is_dir());
         assert_eq!(
             state.last_focused_existing_path(),
             None,
@@ -622,52 +602,13 @@ mod tests {
         );
     }
 
+    /// [`RepoState::save_merged_at`] must persist `last_focused` too, not just `repos` - the
+    /// real mechanism GitHub issue #90's "remembers the last-opened folder" needs - and it is a
+    /// single global value, so a later save with a genuine new focus overwrites whatever the
+    /// previous save left, across two separate calls simulating two real `AdeApp::focus_repo`s.
     #[test]
-    fn last_focused_existing_path_resolves_a_real_known_and_still_existing_repo() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let key = dir.path().to_str().expect("utf8 path").to_string();
-
-        let mut state = RepoState::default();
-        state.repos.insert(
-            key.clone(),
-            RepoRecord {
-                name: "repo".to_string(),
-                selected_worktree: None,
-            },
-        );
-        state.last_focused = Some(key);
-
-        assert_eq!(
-            state.last_focused_existing_path(),
-            Some(dir.path().to_path_buf())
-        );
-    }
-
-    #[test]
-    fn save_merged_at_persists_last_focused() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let path = dir.path().join("repos.toml");
-        let owned: std::collections::BTreeSet<String> =
-            ["/repo/a".to_string()].into_iter().collect();
-
-        let mut state = RepoState::default();
-        state.repos.insert(
-            "/repo/a".to_string(),
-            RepoRecord {
-                name: "a".to_string(),
-                selected_worktree: None,
-            },
-        );
-        state.last_focused = Some("/repo/a".to_string());
-        state.save_merged_at(&path, &owned).expect("save");
-
-        let reloaded = RepoState::load_at(&path);
-        assert_eq!(reloaded.last_focused, Some("/repo/a".to_string()));
-    }
-
-    #[test]
-    fn save_merged_at_overwrites_a_previous_last_focused_with_a_newer_one() {
-        let dir = tempfile::tempdir().expect("tempdir");
+    fn save_merged_at_persists_last_focused_and_a_later_save_overwrites_it() {
+        let dir = crate::test_support::temp_root();
         let path = dir.path().join("repos.toml");
         let owned: std::collections::BTreeSet<String> =
             ["/repo/a".to_string(), "/repo/b".to_string()]
@@ -675,20 +616,16 @@ mod tests {
                 .collect();
 
         let mut state = RepoState::default();
-        state.repos.insert(
-            "/repo/a".to_string(),
-            RepoRecord {
-                name: "a".to_string(),
-                selected_worktree: None,
-            },
-        );
-        state.repos.insert(
-            "/repo/b".to_string(),
-            RepoRecord {
-                name: "b".to_string(),
-                selected_worktree: None,
-            },
-        );
+        for name in ["a", "b"] {
+            state.repos.insert(
+                format!("/repo/{name}"),
+                RepoRecord {
+                    name: name.to_string(),
+                    selected_worktree: None,
+                },
+            );
+        }
+
         state.last_focused = Some("/repo/a".to_string());
         state.save_merged_at(&path, &owned).expect("save a focused");
         assert_eq!(
@@ -705,48 +642,32 @@ mod tests {
         );
     }
 
+    /// The concurrency cap's real shape: ten due repos with a cap of four must split into
+    /// `[4, 4, 2]`, never a single batch of ten (which would let all ten real `git worktree list`
+    /// subprocesses fire at once) and never one repo per batch either (which would serialize the
+    /// whole sweep needlessly). A cap of zero is a defensive floor rather than a real call site -
+    /// every real caller passes a positive constant - and must neither panic (`[T]::chunks`
+    /// itself panics on a zero chunk size) nor silently drop every id.
     #[test]
-    fn repo_new_starts_with_worktrees_unloaded() {
-        let repo = Repo::new(RepoId(0), PathBuf::from("/home/user/code/jerry-core"));
-        assert!(!repo.worktrees_loaded);
-    }
-
-    #[test]
-    fn batch_repos_for_refresh_splits_into_capped_chunks() {
-        let ids: Vec<RepoId> = (0..10).map(RepoId).collect();
-        let batches = batch_repos_for_refresh(&ids, 4);
-        assert_eq!(
-            batches.iter().map(Vec::len).collect::<Vec<_>>(),
-            vec![4, 4, 2],
-            "ten ids with a cap of four must split 4/4/2, bounding every single batch's real \
-             concurrent subprocess count to the cap"
-        );
-        // Order is preserved and nothing is dropped or duplicated - every id from the input
-        // appears exactly once, in its original relative order.
-        let flattened: Vec<RepoId> = batches.into_iter().flatten().collect();
-        assert_eq!(flattened, ids);
-    }
-
-    #[test]
-    fn batch_repos_for_refresh_fewer_ids_than_the_cap_is_a_single_batch() {
-        let ids: Vec<RepoId> = (0..3).map(RepoId).collect();
-        let batches = batch_repos_for_refresh(&ids, 4);
-        assert_eq!(batches.len(), 1);
-        assert_eq!(batches[0].len(), 3);
-    }
-
-    #[test]
-    fn batch_repos_for_refresh_of_no_ids_is_no_batches() {
-        assert!(batch_repos_for_refresh(&[], 4).is_empty());
-    }
-
-    #[test]
-    fn batch_repos_for_refresh_treats_a_zero_concurrency_as_one() {
-        let ids: Vec<RepoId> = (0..3).map(RepoId).collect();
-        let batches = batch_repos_for_refresh(&ids, 0);
-        assert_eq!(
-            batches.iter().map(Vec::len).collect::<Vec<_>>(),
-            vec![1, 1, 1]
-        );
+    fn batch_repos_for_refresh_caps_every_batch_and_never_loses_an_id() {
+        for (count, concurrency, expected) in [
+            (10, 4, vec![4, 4, 2]),
+            (3, 4, vec![3]),
+            (0, 4, vec![]),
+            (3, 0, vec![1, 1, 1]),
+        ] {
+            let ids: Vec<RepoId> = (0..count).map(RepoId).collect();
+            let batches = batch_repos_for_refresh(&ids, concurrency);
+            assert_eq!(
+                batches.iter().map(Vec::len).collect::<Vec<_>>(),
+                expected,
+                "{count} ids at a concurrency of {concurrency}"
+            );
+            let flattened: Vec<RepoId> = batches.into_iter().flatten().collect();
+            assert_eq!(
+                flattened, ids,
+                "every id must appear exactly once, in its original relative order"
+            );
+        }
     }
 }

--- a/crates/app/src/rail/state.rs
+++ b/crates/app/src/rail/state.rs
@@ -969,6 +969,8 @@ mod tests {
         assert!(!running_row.matches_filter("writing auth.rs"));
     }
 
+    /// Unlike `group_by_urgency`, every status must appear in the tally even when its count is
+    /// zero - including the all-zero case, which must still be five rows rather than none.
     #[test]
     fn urgency_counts_covers_every_status_in_order_including_zero_counts() {
         let rows = vec![
@@ -984,16 +986,12 @@ mod tests {
                 (Status::Review, 1),
                 (Status::Run, 0),
                 (Status::Idle, 0),
-            ],
-            "unlike group_by_urgency, every status must appear even when its count is zero"
+            ]
         );
-    }
 
-    #[test]
-    fn urgency_counts_with_no_agents_is_all_zero_not_omitted() {
-        let counts = urgency_counts(&[]);
-        assert_eq!(counts.len(), 5);
-        assert!(counts.iter().all(|(_, count)| *count == 0));
+        let empty = urgency_counts(&[]);
+        assert_eq!(empty.len(), 5);
+        assert!(empty.iter().all(|(_, count)| *count == 0));
     }
 
     #[test]
@@ -1024,120 +1022,62 @@ mod tests {
         assert_eq!(filter_agents(&rows, "").len(), 2);
     }
 
-    #[test]
-    fn worktree_note_main_checkout_is_never_prunable_even_if_merged() {
-        let note = WorktreeNote {
-            is_main: true,
-            clean: Some(true),
-            merge: Some(WorktreeMergeStatus {
+    fn note(
+        is_main: bool,
+        clean: Option<bool>,
+        merged: Option<bool>,
+        is_locked: bool,
+    ) -> WorktreeNote {
+        WorktreeNote {
+            is_main,
+            clean,
+            merge: merged.map(|merged| WorktreeMergeStatus {
                 base_branch: "main".to_string(),
-                merged: true,
-                head_committer_unix_seconds: Some(0),
+                merged,
+                // 11:04 UTC == 11 * 3600 + 4 * 60 seconds into the day.
+                head_committer_unix_seconds: Some(if merged { 11 * 3600 + 4 * 60 } else { 0 }),
             }),
-            is_locked: false,
-        };
-        assert!(!note.is_prunable());
-        assert_eq!(note.label(), "checkout · clean");
+            is_locked,
+        }
     }
 
+    /// Every real combination of the four inputs a worktree note is built from, and the two
+    /// answers it owes for each: what the row says, and whether the worktree may be offered for
+    /// pruning at all. Only one combination is prunable - a linked worktree that is merged,
+    /// clean and unlocked. A dirty one would be refused by `wt_core::remove_worktree` anyway; a
+    /// locked one must never be offered regardless of merge state, though the merged fact still
+    /// shows; and the main checkout is never prunable however merged and clean it is.
     #[test]
-    fn worktree_note_dirty_main_checkout_label() {
-        let note = WorktreeNote {
-            is_main: true,
-            clean: Some(false),
-            merge: None,
-            is_locked: false,
-        };
-        assert_eq!(note.label(), "checkout · dirty");
-    }
-
-    #[test]
-    fn worktree_note_merged_and_clean_linked_worktree_is_prunable() {
-        let seconds_since_midnight = 11 * 3600 + 4 * 60;
-        let note = WorktreeNote {
-            is_main: false,
-            clean: Some(true),
-            merge: Some(WorktreeMergeStatus {
-                base_branch: "main".to_string(),
-                merged: true,
-                head_committer_unix_seconds: Some(seconds_since_midnight),
-            }),
-            is_locked: false,
-        };
-        assert!(note.is_prunable());
-        assert_eq!(note.label(), "merged 11:04 · prunable");
-    }
-
-    #[test]
-    fn worktree_note_merged_but_dirty_linked_worktree_is_not_prunable() {
-        let note = WorktreeNote {
-            is_main: false,
-            clean: Some(false),
-            merge: Some(WorktreeMergeStatus {
-                base_branch: "main".to_string(),
-                merged: true,
-                head_committer_unix_seconds: Some(0),
-            }),
-            is_locked: false,
-        };
-        assert!(
-            !note.is_prunable(),
-            "a dirty worktree must never be offered as prunable, even if its branch is merged \
-             - wt_core::remove_worktree would refuse it anyway"
-        );
-        assert_eq!(note.label(), "dirty");
-    }
-
-    #[test]
-    fn worktree_note_unmerged_linked_worktree_is_not_prunable() {
-        let note = WorktreeNote {
-            is_main: false,
-            clean: Some(true),
-            merge: Some(WorktreeMergeStatus {
-                base_branch: "main".to_string(),
-                merged: false,
-                head_committer_unix_seconds: Some(0),
-            }),
-            is_locked: false,
-        };
-        assert!(!note.is_prunable());
-        assert_eq!(note.label(), "clean");
-    }
-
-    #[test]
-    fn worktree_note_with_no_detectable_base_is_never_prunable() {
-        let note = WorktreeNote {
-            is_main: false,
-            clean: Some(true),
-            merge: None,
-            is_locked: false,
-        };
-        assert!(!note.is_prunable());
-    }
-
-    #[test]
-    fn worktree_note_locked_merged_clean_worktree_is_never_prunable_but_label_says_locked() {
-        // A locked worktree can be genuinely merged and clean - lock state is independent of
-        // merge/dirty state.
-        let note = WorktreeNote {
-            is_main: false,
-            clean: Some(true),
-            merge: Some(WorktreeMergeStatus {
-                base_branch: "main".to_string(),
-                merged: true,
-                head_committer_unix_seconds: Some(0),
-            }),
-            is_locked: true,
-        };
-        assert!(
-            !note.is_prunable(),
-            "a locked worktree must never be offered as prunable regardless of merge/clean state"
-        );
-        assert_eq!(
-            note.label(),
-            "merged 00:00 · locked",
-            "the merged fact should still be visible, just not offered as prunable"
-        );
+    fn only_a_merged_clean_unlocked_linked_worktree_is_prunable() {
+        let cases: &[(WorktreeNote, bool, &str)] = &[
+            (
+                note(true, Some(true), Some(true), false),
+                false,
+                "checkout \u{b7} clean",
+            ),
+            (
+                note(true, Some(false), None, false),
+                false,
+                "checkout \u{b7} dirty",
+            ),
+            (
+                note(false, Some(true), Some(true), false),
+                true,
+                "merged 11:04 \u{b7} prunable",
+            ),
+            (note(false, Some(false), Some(true), false), false, "dirty"),
+            (note(false, Some(true), Some(false), false), false, "clean"),
+            (note(false, Some(true), None, false), false, "clean"),
+            (
+                note(false, Some(true), Some(true), true),
+                false,
+                "merged 11:04 \u{b7} locked",
+            ),
+        ];
+        for (note, prunable, label) in cases {
+            assert_eq!(note.is_prunable(), *prunable, "{note:?}");
+            assert_eq!(note.label(), *label, "{note:?}");
+        }
     }
 
     fn worktree_entry(path: &str, note: WorktreeNote) -> WorktreeEntry {
@@ -1688,11 +1628,63 @@ mod tests {
     }
 
     #[test]
-    fn the_two_urgency_tooltips_agree_with_their_own_counts_in_noun_and_verb() {
+    fn every_count_bearing_rail_label_conjugates_rather_than_dodging() {
         assert_eq!(needs_input_tooltip(1), "1 worktree here needs input");
         assert_eq!(needs_input_tooltip(2), "2 worktrees here need input");
         assert_eq!(failed_tooltip(1), "1 worktree here has a failed agent");
         assert_eq!(failed_tooltip(3), "3 worktrees here have failed agents");
+
+        assert_eq!(prune_armed_tooltip(1), "Click again to remove 1 worktree");
+        assert_eq!(prune_armed_tooltip(2), "Click again to remove 2 worktrees");
+
+        assert_eq!(worktree_disk_label(0, "0 B"), "0 worktrees \u{b7} 0 B");
+        assert_eq!(worktree_disk_label(1, "4.2 GB"), "1 worktree \u{b7} 4.2 GB");
+        assert_eq!(
+            worktree_disk_label(2, "4.2 GB"),
+            "2 worktrees \u{b7} 4.2 GB"
+        );
+
+        for (n, confirm, pruning, pruned) in [
+            (0, "0 worktrees", "0 worktrees", "0 worktrees"),
+            (1, "1 worktree", "1 worktree", "1 worktree"),
+            (2, "2 worktrees", "2 worktrees", "2 worktrees"),
+        ] {
+            assert_eq!(
+                prune_confirm_label(n),
+                format!("click prune again to remove {confirm}")
+            );
+            assert_eq!(pruning_label(n), format!("pruning {pruning}\u{2026}"));
+            assert_eq!(pruned_label(n), format!("pruned {pruned}"));
+        }
+
+        for n in 0..4 {
+            for label in [prune_confirm_label(n), pruning_label(n), pruned_label(n)] {
+                assert!(
+                    !label.contains("(s)"),
+                    "prune label must conjugate, not dodge: {label}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn the_prune_tooltip_states_the_count_and_only_a_measured_size() {
+        assert_eq!(
+            prune_tooltip(1, Some((214 * 1024 * 1024, false))),
+            "Prune merged worktrees \u{2014} 1 prunable, frees 214.0 MB"
+        );
+        assert_eq!(
+            prune_tooltip(3, Some((2 * 1024 * 1024 * 1024, true))),
+            "Prune merged worktrees \u{2014} 3 prunable, frees 2.0 GB+"
+        );
+        assert_eq!(
+            prune_tooltip(1, None),
+            "Prune merged worktrees \u{2014} 1 prunable"
+        );
+        assert_eq!(
+            prune_tooltip(0, Some((0, false))),
+            "Prune merged worktrees \u{2014} nothing prunable"
+        );
     }
 
     #[test]
@@ -1717,83 +1709,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn the_prune_tooltip_states_the_count_and_only_a_measured_size() {
-        assert_eq!(
-            prune_tooltip(1, Some((214 * 1024 * 1024, false))),
-            "Prune merged worktrees \u{2014} 1 prunable, frees 214.0 MB"
-        );
-        assert_eq!(
-            prune_tooltip(3, Some((2 * 1024 * 1024 * 1024, true))),
-            "Prune merged worktrees \u{2014} 3 prunable, frees 2.0 GB+",
-            "a truncated scan keeps the `+` suffix `disk_usage_label` already uses - the number \
-             is a floor, and the tooltip must not round it into a claim"
-        );
-        assert_eq!(
-            prune_tooltip(1, None),
-            "Prune merged worktrees \u{2014} 1 prunable",
-            "an unmeasured candidate drops the whole clause rather than reporting a size that \
-             leaves it out"
-        );
-        assert_eq!(
-            prune_tooltip(0, Some((0, false))),
-            "Prune merged worktrees \u{2014} nothing prunable",
-            "zero candidates changes the sentence's shape rather than reading `0 prunable`"
-        );
-    }
-
-    #[test]
-    fn the_armed_prune_tooltip_conjugates_its_own_count() {
-        assert_eq!(prune_armed_tooltip(1), "Click again to remove 1 worktree");
-        assert_eq!(prune_armed_tooltip(2), "Click again to remove 2 worktrees");
-    }
-
-    #[test]
-    fn worktree_disk_label_conjugates_at_zero_one_and_two() {
-        assert_eq!(worktree_disk_label(0, "0 B"), "0 worktrees \u{b7} 0 B");
-        assert_eq!(worktree_disk_label(1, "4.2 GB"), "1 worktree \u{b7} 4.2 GB");
-        assert_eq!(
-            worktree_disk_label(2, "4.2 GB"),
-            "2 worktrees \u{b7} 4.2 GB"
-        );
-    }
-
-    #[test]
-    fn prune_labels_conjugate_at_zero_one_and_two() {
-        assert_eq!(
-            prune_confirm_label(0),
-            "click prune again to remove 0 worktrees"
-        );
-        assert_eq!(
-            prune_confirm_label(1),
-            "click prune again to remove 1 worktree"
-        );
-        assert_eq!(
-            prune_confirm_label(2),
-            "click prune again to remove 2 worktrees"
-        );
-
-        assert_eq!(pruning_label(0), "pruning 0 worktrees\u{2026}");
-        assert_eq!(pruning_label(1), "pruning 1 worktree\u{2026}");
-        assert_eq!(pruning_label(2), "pruning 2 worktrees\u{2026}");
-
-        assert_eq!(pruned_label(0), "pruned 0 worktrees");
-        assert_eq!(pruned_label(1), "pruned 1 worktree");
-        assert_eq!(pruned_label(2), "pruned 2 worktrees");
-    }
-
-    #[test]
-    fn no_prune_label_uses_the_parenthesised_plural_escape_hatch() {
-        for n in 0..4 {
-            for label in [prune_confirm_label(n), pruning_label(n), pruned_label(n)] {
-                assert!(
-                    !label.contains("(s)"),
-                    "prune label must conjugate, not dodge: {label}"
-                );
-            }
-        }
-    }
-
+    /// §4's prune tooltip: "Prune merged worktrees \u{2014} 1 prunable, frees 214 MB" - the words
+    /// the icon itself cannot carry, including the size only when it is really known.
     #[test]
     fn format_elapsed_picks_the_largest_whole_unit() {
         assert_eq!(format_elapsed(Duration::from_secs(0)), "0s");
@@ -1841,26 +1758,6 @@ mod tests {
             "matches only the agent-less row, via its real path - the label alone never \
              contains a directory component like this"
         );
-    }
-
-    #[test]
-    fn is_prunable_helper_looks_up_by_path() {
-        let mut notes = HashMap::new();
-        notes.insert(
-            PathBuf::from("/repo-wt/merged"),
-            WorktreeNote {
-                is_main: false,
-                clean: Some(true),
-                merge: Some(WorktreeMergeStatus {
-                    base_branch: "main".to_string(),
-                    merged: true,
-                    head_committer_unix_seconds: Some(0),
-                }),
-                is_locked: false,
-            },
-        );
-        assert!(is_prunable(&notes, Path::new("/repo-wt/merged")));
-        assert!(!is_prunable(&notes, Path::new("/repo-wt/unknown")));
     }
 
     #[test]
@@ -1976,43 +1873,19 @@ mod tests {
         assert_eq!(sum_diff_stat(&diff), (2, 1));
     }
 
-    fn git(dir: &Path, args: &[&str]) {
-        let output = std::process::Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {:?} failed in {:?}:\nstdout: {}\nstderr: {}",
-            args,
-            dir,
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
-    fn init_repo() -> tempfile::TempDir {
-        let dir = tempfile::TempDir::new().expect("tempdir");
-        git(dir.path(), &["init", "-b", "main"]);
-        git(dir.path(), &["config", "user.email", "test@example.com"]);
-        git(dir.path(), &["config", "user.name", "Test User"]);
-        std::fs::write(dir.path().join("file.txt"), "hello\n").expect("write file");
-        git(dir.path(), &["add", "file.txt"]);
-        git(dir.path(), &["commit", "-m", "initial commit"]);
-        dir
-    }
-
+    /// End-to-end, against a real tempdir git repo: [`compute_status_snapshot`] reports a
+    /// prunable, clean, merged worktree correctly, and a dirty one as not prunable, in one
+    /// snapshot covering both the diff side and the worktree-note side.
     #[test]
     fn compute_status_snapshot_reports_real_diff_and_merge_state() {
-        let repo = init_repo();
+        let repo = crate::test_support::temp_repo();
 
         // A linked worktree with an uncommitted change - should show up in `diffs` with a
         // real added-line count, and not be considered clean.
-        let dirty_wt_dir = tempfile::TempDir::new().expect("tempdir");
+        let dirty_wt_dir = crate::test_support::temp_root();
         let dirty_wt_path = dirty_wt_dir.path().join("dirty-wt");
         drop(dirty_wt_dir);
-        git(
+        test_support::git(
             repo.path(),
             &[
                 "worktree",
@@ -2026,10 +1899,10 @@ mod tests {
 
         // A linked worktree that's clean and fully merged (no unique commits) - a real prune
         // candidate.
-        let merged_wt_dir = tempfile::TempDir::new().expect("tempdir");
+        let merged_wt_dir = crate::test_support::temp_root();
         let merged_wt_path = merged_wt_dir.path().join("merged-wt");
         drop(merged_wt_dir);
-        git(
+        test_support::git(
             repo.path(),
             &[
                 "worktree",
@@ -2112,24 +1985,21 @@ mod tests {
         assert_eq!(merged_ahead_behind.behind, 0);
     }
 
+    /// A real directory tree's sizes are summed recursively; a path that isn't there at all is
+    /// zero rather than an error the caller has to handle.
     #[test]
-    fn disk_usage_bytes_sums_real_file_sizes_recursively() {
-        let dir = tempfile::TempDir::new().expect("tempdir");
+    fn disk_usage_bytes_sums_a_real_tree_and_reports_zero_for_a_missing_one() {
+        let dir = crate::test_support::temp_root();
         std::fs::write(dir.path().join("a.txt"), vec![b'x'; 100]).expect("write");
         let sub = dir.path().join("sub");
         std::fs::create_dir(&sub).expect("mkdir");
         std::fs::write(sub.join("b.txt"), vec![b'y'; 250]).expect("write");
 
-        let (total, truncated) = disk_usage_bytes(dir.path());
-        assert_eq!(total, 350);
-        assert!(!truncated);
-    }
-
-    #[test]
-    fn disk_usage_bytes_on_a_nonexistent_path_is_zero_not_an_error() {
-        let (total, truncated) = disk_usage_bytes(Path::new("/definitely/not/a/real/path/xyz"));
-        assert_eq!(total, 0);
-        assert!(!truncated);
+        assert_eq!(disk_usage_bytes(dir.path()), (350, false));
+        assert_eq!(
+            disk_usage_bytes(Path::new("/definitely/not/a/real/path/xyz")),
+            (0, false)
+        );
     }
 
     #[test]

--- a/crates/app/src/rail/status.rs
+++ b/crates/app/src/rail/status.rs
@@ -288,81 +288,155 @@ mod tests {
         }
     }
 
+    /// The exact facts first: an exit code and a missing process both settle the answer outright,
+    /// and only a real *agent session*'s clean exit can mean "review ready" - a plain shell
+    /// closing next to an unrelated worktree diff is a terminal that closed, not finished
+    /// reviewable work (see `ProcessKind::is_agent_session`'s docs).
     #[test]
-    fn no_process_is_idle_regardless_of_kind_or_diff() {
-        assert_eq!(
-            derive_status(ProcessKind::Shell, ProcessSignal::NoProcess, quiet(), true),
-            Status::Idle
-        );
-        assert_eq!(
-            derive_status(
+    fn an_exit_or_a_missing_process_settles_the_status_outright() {
+        let cases: &[(ProcessKind, ProcessSignal, bool, Status, &str)] = &[
+            (
+                ProcessKind::Shell,
+                ProcessSignal::NoProcess,
+                true,
+                Status::Idle,
+                "a process that never started is idle whatever the diff says",
+            ),
+            (
                 ProcessKind::claude(),
                 ProcessSignal::NoProcess,
-                quiet(),
-                true
+                true,
+                Status::Idle,
+                "and that holds for an agent too",
             ),
-            Status::Idle
-        );
+            (
+                ProcessKind::Shell,
+                ProcessSignal::Exited { success: false },
+                true,
+                Status::Fail,
+                "a non-zero exit is a failure whatever the diff says",
+            ),
+            (
+                ProcessKind::claude(),
+                ProcessSignal::Exited { success: false },
+                false,
+                Status::Fail,
+                "for an agent as much as a shell",
+            ),
+            (
+                ProcessKind::claude(),
+                ProcessSignal::Exited { success: true },
+                true,
+                Status::Review,
+                "an agent session's clean exit with real changes is review-ready",
+            ),
+            (
+                ProcessKind::claude(),
+                ProcessSignal::Exited { success: true },
+                false,
+                Status::Idle,
+                "with nothing to review it is idle, not an empty review row",
+            ),
+            (
+                ProcessKind::Shell,
+                ProcessSignal::Exited { success: true },
+                true,
+                Status::Idle,
+                "a shell isn't an agent session - its exit can't be \"review ready\"",
+            ),
+        ];
+        for (kind, signal, has_diff, expected, why) in cases {
+            assert_eq!(
+                derive_status(*kind, *signal, quiet(), *has_diff),
+                *expected,
+                "{why}"
+            );
+        }
     }
 
+    /// The quiescence ladder, with no other signal in play: recent output is `Run` for every
+    /// kind; past the recent window a shell is `Idle` (it is sitting at its prompt, not asking
+    /// anything) while an agent is still `Run` - the whole reason the second, longer threshold
+    /// exists is that normal tool-call latency must not flicker to "needs input" - and only past
+    /// that agent threshold does an agent reach `Ask`.
     #[test]
-    fn running_within_the_recent_window_is_run_for_every_kind() {
-        let signal = ProcessSignal::Running {
-            idle: Duration::from_millis(500),
-        };
-        assert_eq!(
-            derive_status(ProcessKind::Shell, signal, quiet(), false),
-            Status::Run
-        );
-        assert_eq!(
-            derive_status(ProcessKind::claude(), signal, quiet(), false),
-            Status::Run
-        );
-        assert_eq!(
-            derive_status(ProcessKind::codex(), signal, quiet(), false),
-            Status::Run
-        );
+    fn quiescence_alone_walks_the_two_thresholds_per_process_kind() {
+        let recent = Duration::from_millis(500);
+        let between = RUN_RECENT_OUTPUT_WINDOW + Duration::from_secs(1);
+        let long = AGENT_ASK_IDLE_THRESHOLD + Duration::from_secs(1);
+        let cases: &[(ProcessKind, Duration, Status, &str)] = &[
+            (
+                ProcessKind::Shell,
+                recent,
+                Status::Run,
+                "a shell just wrote something",
+            ),
+            (
+                ProcessKind::claude(),
+                recent,
+                Status::Run,
+                "and so did claude",
+            ),
+            (
+                ProcessKind::codex(),
+                recent,
+                Status::Run,
+                "and so did codex",
+            ),
+            (
+                ProcessKind::Shell,
+                between,
+                Status::Idle,
+                "a shell at its prompt is idle, not \"needs input\" - it isn't asking anything",
+            ),
+            (
+                ProcessKind::claude(),
+                between,
+                Status::Run,
+                "an agent between the two thresholds is still working",
+            ),
+            (ProcessKind::codex(), between, Status::Run, "codex likewise"),
+            (
+                ProcessKind::claude(),
+                long,
+                Status::Ask,
+                "past its own threshold a silent agent is asking",
+            ),
+            (ProcessKind::codex(), long, Status::Ask, "codex likewise"),
+        ];
+        for (kind, idle, expected, why) in cases {
+            assert_eq!(
+                derive_status(
+                    *kind,
+                    ProcessSignal::Running { idle: *idle },
+                    quiet(),
+                    false
+                ),
+                *expected,
+                "{why}"
+            );
+        }
     }
 
+    /// The real false-positive class the terminal signal exists to fix (GitHub issue #239), one
+    /// observed live: Claude Code kept its `\u{25d0}`/`\u{25d1}` spinner animating through a
+    /// 9-second run of `sleep 3` tool calls that wrote nothing at all. Purely by idle time that
+    /// agent is "needs input"; by its own title it is plainly still working. An advancing
+    /// progress report says the same thing - but a stalled or paused one is exactly when the
+    /// human may be wanted, so it buys no indefinite reprieve.
     #[test]
-    fn a_quiet_shell_past_the_recent_window_is_idle_not_ask() {
-        let signal = ProcessSignal::Running {
-            idle: RUN_RECENT_OUTPUT_WINDOW + Duration::from_secs(1),
-        };
-        assert_eq!(
-            derive_status(ProcessKind::Shell, signal, quiet(), false),
-            Status::Idle,
-            "a shell sitting at its prompt is idle, not \"needs input\" - it isn't asking anything"
-        );
-    }
-
-    #[test]
-    fn an_agent_paused_between_the_two_thresholds_is_still_run() {
-        // Past the "recent" window but not yet past the longer agent-specific ask threshold:
-        // this is the whole reason the second threshold exists (see the module docs) - normal
-        // tool-call/thinking latency must not flicker to "needs input".
-        let signal = ProcessSignal::Running {
-            idle: RUN_RECENT_OUTPUT_WINDOW + Duration::from_secs(1),
-        };
-        assert_eq!(
-            derive_status(ProcessKind::claude(), signal, quiet(), false),
-            Status::Run
-        );
-        assert_eq!(
-            derive_status(ProcessKind::codex(), signal, quiet(), false),
-            Status::Run
-        );
-    }
-
-    #[test]
-    fn a_busy_title_keeps_a_long_quiet_agent_on_run_instead_of_ask() {
-        // The real false-positive class this signal exists to fix (GitHub issue #239), and one
-        // observed live: Claude Code kept its `\u{25d0}`/`\u{25d1}` spinner animating through a
-        // 9-second run of `sleep 3` tool calls that wrote nothing at all to the terminal. Purely
-        // by idle time that agent is "needs input"; by its own title it is plainly still working.
+    fn a_live_work_signal_holds_a_long_quiet_agent_on_run_but_a_stalled_one_does_not() {
         let long_quiet = ProcessSignal::Running {
             idle: AGENT_ASK_IDLE_THRESHOLD * 20,
         };
+        let progress = |state| TerminalSignal {
+            progress: Some(Progress {
+                state,
+                percent: Some(40),
+            }),
+            ..TerminalSignal::default()
+        };
+
         assert_eq!(
             derive_status(ProcessKind::claude(), long_quiet, quiet(), false),
             Status::Ask,
@@ -378,50 +452,28 @@ mod tests {
             Status::Run,
             "an agent whose own title says it is working must not be reported as needing input"
         );
-    }
-
-    #[test]
-    fn an_active_progress_report_also_keeps_a_long_quiet_agent_on_run() {
-        let long_quiet = ProcessSignal::Running {
-            idle: AGENT_ASK_IDLE_THRESHOLD * 20,
-        };
         for state in [ProgressState::Normal, ProgressState::Indeterminate] {
-            let terminal = TerminalSignal {
-                progress: Some(Progress {
-                    state,
-                    percent: Some(40),
-                }),
-                ..TerminalSignal::default()
-            };
             assert_eq!(
-                derive_status(ProcessKind::claude(), long_quiet, terminal, false),
+                derive_status(ProcessKind::claude(), long_quiet, progress(state), false),
                 Status::Run,
                 "{state:?} is work actually advancing"
             );
         }
-        // A stalled or paused report is exactly when the human may be wanted, so it must not buy
-        // the process an indefinite "still running" - the idle clock takes over again.
         for state in [ProgressState::Error, ProgressState::Paused] {
-            let terminal = TerminalSignal {
-                progress: Some(Progress {
-                    state,
-                    percent: Some(40),
-                }),
-                ..TerminalSignal::default()
-            };
             assert_eq!(
-                derive_status(ProcessKind::claude(), long_quiet, terminal, false),
+                derive_status(ProcessKind::claude(), long_quiet, progress(state), false),
                 Status::Ask,
                 "{state:?} must not be able to claim the agent is still working"
             );
         }
     }
 
+    /// The threshold exists only because Jerry used to have no better signal. When the agent says
+    /// outright that it is blocked on the human - a `NeedsAttention` title, an unanswered OSC 9
+    /// notification, or both alongside a still-spinning busy glyph - waiting the timer out is
+    /// pure added latency, so attention outranks everything short of an exact fact.
     #[test]
-    fn a_needs_attention_title_reaches_ask_long_before_the_idle_threshold() {
-        // The 15s threshold exists only because Jerry used to have no better signal. When the
-        // agent says outright that it's blocked on the human, waiting the timer out is pure
-        // added latency.
+    fn a_real_attention_claim_reaches_ask_immediately_and_outranks_a_busy_one() {
         let barely_quiet = ProcessSignal::Running {
             idle: Duration::from_millis(100),
         };
@@ -439,41 +491,34 @@ mod tests {
             ),
             Status::Ask
         );
-    }
-
-    #[test]
-    fn an_unanswered_osc_notification_reaches_ask_long_before_the_idle_threshold() {
-        let barely_quiet = ProcessSignal::Running {
-            idle: Duration::from_millis(100),
-        };
-        let terminal = TerminalSignal {
-            attention_pinged: true,
-            ..TerminalSignal::default()
-        };
         assert_eq!(
-            derive_status(ProcessKind::claude(), barely_quiet, terminal, false),
+            derive_status(
+                ProcessKind::claude(),
+                barely_quiet,
+                TerminalSignal {
+                    attention_pinged: true,
+                    ..TerminalSignal::default()
+                },
+                false
+            ),
             Status::Ask
         );
-    }
-
-    #[test]
-    fn attention_outranks_busy_when_an_agent_claims_both() {
-        // An agent that is both spinning a busy glyph and has an unanswered notification out is
-        // one that needs the human now and happens to still be rendering - see the module docs.
-        let terminal = TerminalSignal {
-            title: Some(TitleSignal::Busy),
-            attention_pinged: true,
-            progress: Some(Progress {
-                state: ProgressState::Normal,
-                percent: Some(10),
-            }),
-        };
-        let signal = ProcessSignal::Running {
-            idle: Duration::from_millis(100),
-        };
         assert_eq!(
-            derive_status(ProcessKind::claude(), signal, terminal, false),
-            Status::Ask
+            derive_status(
+                ProcessKind::claude(),
+                barely_quiet,
+                TerminalSignal {
+                    title: Some(TitleSignal::Busy),
+                    attention_pinged: true,
+                    progress: Some(Progress {
+                        state: ProgressState::Normal,
+                        percent: Some(10),
+                    }),
+                },
+                false
+            ),
+            Status::Ask,
+            "an agent that is both spinning and has an unanswered ping out needs the human now"
         );
     }
 
@@ -496,13 +541,16 @@ mod tests {
         }
     }
 
+    /// Neither side channel may move a shell row. A shell prompt, a `vim` session, or a stray
+    /// `printf '\e]0;...\a'` in someone's `.bashrc` can put any glyph or word in a shell's title,
+    /// and none of that makes a shell an agent session that can need input. The hook half is
+    /// deliberately defensive: hooks are only ever installed for `AgentKind::Claude` spawns, so a
+    /// shell should structurally never carry one - but "structurally impossible" is exactly the
+    /// kind of claim that quietly stops being true, and a shell driven to `Ask`/`Review`/`Fail`
+    /// by an inbox entry would be a real bug.
     #[test]
-    fn a_shell_never_reaches_ask_no_matter_how_agent_like_its_title_looks() {
-        // A shell prompt, a `vim` session, or a stray `printf '\e]0;...\a'` in someone's
-        // `.bashrc` can put any glyph or word in a shell's title. None of that makes a shell an
-        // agent session that can need input - see the module docs. This also covers the reverse
-        // direction: a busy-looking title must not hold a shell on `Run` either.
-        let every_signal = [
+    fn neither_a_terminal_signal_nor_a_hook_fact_can_move_a_shell_row() {
+        let every_terminal_signal = [
             titled(TitleSignal::NeedsAttention),
             titled(TitleSignal::Busy),
             titled(TitleSignal::Idle),
@@ -520,38 +568,54 @@ mod tests {
                 }),
             },
         ];
-        for terminal in every_signal {
-            assert_eq!(
-                derive_status(
-                    ProcessKind::Shell,
-                    ProcessSignal::Running {
-                        idle: AGENT_ASK_IDLE_THRESHOLD * 2
-                    },
-                    terminal,
-                    false
-                ),
-                Status::Idle,
-                "a quiet shell stays Idle regardless of {terminal:?}"
-            );
-            assert_eq!(
-                derive_status(
-                    ProcessKind::Shell,
-                    ProcessSignal::Running {
-                        idle: Duration::from_millis(100)
-                    },
-                    terminal,
-                    false
-                ),
-                Status::Run,
-                "a freshly-active shell stays Run regardless of {terminal:?}"
-            );
+        for terminal in every_terminal_signal {
+            for (idle, expected) in [
+                (AGENT_ASK_IDLE_THRESHOLD * 2, Status::Idle),
+                (Duration::from_millis(100), Status::Run),
+            ] {
+                assert_eq!(
+                    derive_status(
+                        ProcessKind::Shell,
+                        ProcessSignal::Running { idle },
+                        terminal,
+                        false
+                    ),
+                    expected,
+                    "a shell at idle={idle:?} must stay {expected:?} regardless of {terminal:?}"
+                );
+            }
+        }
+
+        for fact in [
+            HookFact::Working,
+            HookFact::NeedsInput,
+            HookFact::TurnEnded,
+            HookFact::TurnFailed,
+        ] {
+            for (idle, expected) in [
+                (AGENT_ASK_IDLE_THRESHOLD * 2, Status::Idle),
+                (Duration::from_millis(50), Status::Run),
+            ] {
+                assert_eq!(
+                    super::derive_status(
+                        ProcessKind::Shell,
+                        ProcessSignal::Running { idle },
+                        quiet(),
+                        hooked(fact),
+                        true
+                    ),
+                    expected,
+                    "a shell at idle={idle:?} must stay {expected:?} regardless of a {fact:?} hook"
+                );
+            }
         }
     }
 
+    /// An exit is an exact fact: neither a stale title glyph from just before the process died
+    /// nor a `Working` hook from the same moment may argue with it, or resurrect a process that
+    /// was never started.
     #[test]
-    fn a_terminal_signal_never_overrides_an_exit_or_a_missing_process() {
-        // An exit is an exact fact - a stale title glyph from just before the process died must
-        // not be able to argue with it.
+    fn no_side_channel_overrides_an_exit_or_a_missing_process() {
         let shouting = TerminalSignal {
             title: Some(TitleSignal::Busy),
             attention_pinged: true,
@@ -560,91 +624,63 @@ mod tests {
                 percent: Some(50),
             }),
         };
-        assert_eq!(
-            derive_status(
-                ProcessKind::claude(),
+        for (signal, has_diff, expected) in [
+            (
                 ProcessSignal::Exited { success: false },
-                shouting,
-                false
+                false,
+                Status::Fail,
             ),
-            Status::Fail
-        );
+            (
+                ProcessSignal::Exited { success: true },
+                true,
+                Status::Review,
+            ),
+            (ProcessSignal::NoProcess, true, Status::Idle),
+        ] {
+            assert_eq!(
+                derive_status(ProcessKind::claude(), signal, shouting, has_diff),
+                expected
+            );
+        }
+
+        for fact in [
+            HookFact::Working,
+            HookFact::NeedsInput,
+            HookFact::TurnEnded,
+            HookFact::TurnFailed,
+        ] {
+            assert_eq!(
+                super::derive_status(
+                    ProcessKind::claude(),
+                    ProcessSignal::Exited { success: false },
+                    quiet(),
+                    hooked(fact),
+                    false
+                ),
+                Status::Fail,
+                "{fact:?} must not argue with a non-zero exit"
+            );
+            assert_eq!(
+                super::derive_status(
+                    ProcessKind::claude(),
+                    ProcessSignal::NoProcess,
+                    quiet(),
+                    hooked(fact),
+                    true
+                ),
+                Status::Idle,
+                "{fact:?} must not invent a process that was never started"
+            );
+        }
         assert_eq!(
-            derive_status(
+            super::derive_status(
                 ProcessKind::claude(),
                 ProcessSignal::Exited { success: true },
-                shouting,
+                quiet(),
+                hooked(HookFact::Working),
                 true
             ),
             Status::Review
-        );
-        assert_eq!(
-            derive_status(
-                ProcessKind::claude(),
-                ProcessSignal::NoProcess,
-                shouting,
-                true
-            ),
-            Status::Idle
-        );
-    }
-
-    #[test]
-    fn an_agent_quiet_past_the_ask_threshold_is_ask() {
-        let signal = ProcessSignal::Running {
-            idle: AGENT_ASK_IDLE_THRESHOLD + Duration::from_secs(1),
-        };
-        assert_eq!(
-            derive_status(ProcessKind::claude(), signal, quiet(), false),
-            Status::Ask
-        );
-        assert_eq!(
-            derive_status(ProcessKind::codex(), signal, quiet(), false),
-            Status::Ask
-        );
-    }
-
-    #[test]
-    fn nonzero_exit_is_fail_regardless_of_diff() {
-        let signal = ProcessSignal::Exited { success: false };
-        assert_eq!(
-            derive_status(ProcessKind::Shell, signal, quiet(), true),
-            Status::Fail
-        );
-        assert_eq!(
-            derive_status(ProcessKind::claude(), signal, quiet(), false),
-            Status::Fail
-        );
-    }
-
-    #[test]
-    fn zero_exit_with_a_real_diff_is_review() {
-        let signal = ProcessSignal::Exited { success: true };
-        assert_eq!(
-            derive_status(ProcessKind::claude(), signal, quiet(), true),
-            Status::Review
-        );
-    }
-
-    #[test]
-    fn a_shell_zero_exit_with_a_real_diff_is_idle_not_review() {
-        // A plain shell exiting next to an unrelated worktree diff isn't a session that
-        // finished reviewable work - it's a terminal that closed. Only a real agent session's
-        // clean exit means "review ready" (see `ProcessKind::is_agent_session`'s docs).
-        let signal = ProcessSignal::Exited { success: true };
-        assert_eq!(
-            derive_status(ProcessKind::Shell, signal, quiet(), true),
-            Status::Idle,
-            "a shell isn't an agent session - its exit can't be \"review ready\""
-        );
-    }
-
-    #[test]
-    fn zero_exit_with_no_diff_is_idle_not_review() {
-        let signal = ProcessSignal::Exited { success: true };
-        assert_eq!(
-            derive_status(ProcessKind::claude(), signal, quiet(), false),
-            Status::Idle
         );
     }
 
@@ -814,93 +850,6 @@ mod tests {
             ),
             Status::Run
         );
-    }
-
-    #[test]
-    fn a_hook_fact_never_overrides_an_exit_or_a_missing_process() {
-        // An exit is an exact fact. A `Working` hook from just before the process died must not
-        // resurrect it - the same rule `TerminalSignal` already obeys.
-        for fact in [
-            HookFact::Working,
-            HookFact::NeedsInput,
-            HookFact::TurnEnded,
-            HookFact::TurnFailed,
-        ] {
-            assert_eq!(
-                super::derive_status(
-                    ProcessKind::claude(),
-                    ProcessSignal::Exited { success: false },
-                    quiet(),
-                    hooked(fact),
-                    false
-                ),
-                Status::Fail,
-                "{fact:?} must not argue with a non-zero exit"
-            );
-            assert_eq!(
-                super::derive_status(
-                    ProcessKind::claude(),
-                    ProcessSignal::NoProcess,
-                    quiet(),
-                    hooked(fact),
-                    true
-                ),
-                Status::Idle,
-                "{fact:?} must not invent a process that was never started"
-            );
-        }
-        assert_eq!(
-            super::derive_status(
-                ProcessKind::claude(),
-                ProcessSignal::Exited { success: true },
-                quiet(),
-                hooked(HookFact::Working),
-                true
-            ),
-            Status::Review
-        );
-    }
-
-    #[test]
-    fn a_hook_fact_can_never_change_a_shell_row() {
-        // Defensive, and deliberately so. Hooks are only ever installed for `AgentKind::Claude`
-        // spawns, so a shell should structurally never carry one - but "structurally impossible"
-        // is exactly the kind of claim that quietly stops being true, and a shell that could be
-        // driven to `Ask`/`Review`/`Fail` by an inbox entry would be a real bug. This pins the
-        // gate rather than trusting the surrounding architecture to keep holding.
-        for fact in [
-            HookFact::Working,
-            HookFact::NeedsInput,
-            HookFact::TurnEnded,
-            HookFact::TurnFailed,
-        ] {
-            assert_eq!(
-                super::derive_status(
-                    ProcessKind::Shell,
-                    ProcessSignal::Running {
-                        idle: AGENT_ASK_IDLE_THRESHOLD * 2
-                    },
-                    quiet(),
-                    hooked(fact),
-                    true
-                ),
-                Status::Idle,
-                "a quiet shell stays Idle regardless of a {fact:?} hook"
-            );
-            assert_eq!(
-                super::derive_status(
-                    ProcessKind::Shell,
-                    ProcessSignal::Running {
-                        idle: Duration::from_millis(50)
-                    },
-                    quiet(),
-                    hooked(fact),
-                    true
-                ),
-                Status::Run,
-                "a freshly-active shell stays Run regardless of a {fact:?} hook"
-            );
-        }
     }
 
     #[test]

--- a/crates/app/src/rail/strip_render.rs
+++ b/crates/app/src/rail/strip_render.rs
@@ -519,38 +519,7 @@ fn severity_color(severity: diagnostics_view::Severity) -> theme::ColorToken {
 #[cfg(test)]
 mod sidebar_strip_tests {
     use super::*;
-    use crate::root::focus::palette_focus_tests;
     use gpui::TestAppContext;
-    use std::fs;
-    use std::path::Path;
-    use std::process::Command;
-    use tempfile::TempDir;
-
-    fn git(dir: &Path, args: &[&str]) {
-        let output = Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {:?} failed in {:?}: {}",
-            args,
-            dir,
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
-    fn init_repo() -> TempDir {
-        let dir = TempDir::new().expect("tempdir");
-        git(dir.path(), &["init", "-b", "main"]);
-        git(dir.path(), &["config", "user.email", "test@example.com"]);
-        git(dir.path(), &["config", "user.name", "Test User"]);
-        fs::write(dir.path().join("base.txt"), "base\n").expect("write");
-        git(dir.path(), &["add", "base.txt"]);
-        git(dir.path(), &["commit", "-m", "initial"]);
-        dir
-    }
 
     /// The four bounds every geometry assertion below reads: the two view cells, the `+` and the
     /// `⋯`, in the order the strip paints them.
@@ -584,8 +553,8 @@ mod sidebar_strip_tests {
 
     #[gpui::test]
     fn every_strip_cell_is_a_full_height_38px_slab_with_no_gap(cx: &mut TestAppContext) {
-        let repo = init_repo();
-        let (_app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_repo();
+        let (_app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         let band = cx
@@ -639,8 +608,8 @@ mod sidebar_strip_tests {
 
     #[gpui::test]
     fn all_three_column_headers_end_on_one_line(cx: &mut TestAppContext) {
-        let repo = init_repo();
-        let (_app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_repo();
+        let (_app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         let rail = cx
@@ -669,8 +638,8 @@ mod sidebar_strip_tests {
 
     #[gpui::test]
     fn the_centre_columns_bottom_edge_is_carried_all_the_way_across(cx: &mut TestAppContext) {
-        let repo = init_repo();
-        let (_app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_repo();
+        let (_app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         let centre = cx.debug_bounds("tab-strip").expect("the tab strip");
@@ -701,8 +670,8 @@ mod sidebar_strip_tests {
 
     #[gpui::test]
     fn clicking_a_cell_really_switches_the_panel_under_it(cx: &mut TestAppContext) {
-        let repo = init_repo();
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_repo();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         assert!(
@@ -744,8 +713,8 @@ mod sidebar_strip_tests {
 
     #[gpui::test]
     fn both_view_glyphs_are_phosphor_assets_in_one_shared_optical_box(cx: &mut TestAppContext) {
-        let repo = init_repo();
-        let (_app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_repo();
+        let (_app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         let box_size = f32::from(IconSize::Strip.box_size());
@@ -777,8 +746,8 @@ mod sidebar_strip_tests {
 
     #[gpui::test]
     fn a_window_with_nothing_waiting_paints_no_state_marker(cx: &mut TestAppContext) {
-        let repo = init_repo();
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_repo();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         assert!(
@@ -805,8 +774,8 @@ mod sidebar_strip_tests {
 
     #[gpui::test]
     fn an_empty_day_drops_the_view_cells_and_keeps_the_trailing_pair(cx: &mut TestAppContext) {
-        let repo = init_repo();
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_repo();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
         assert!(
             cx.debug_bounds("sidebar-strip-worktrees").is_some(),
@@ -841,8 +810,8 @@ mod sidebar_strip_tests {
 
     #[gpui::test]
     fn the_filter_rows_placeholder_follows_the_selected_view(cx: &mut TestAppContext) {
-        let repo = init_repo();
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_repo();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         assert!(
@@ -876,8 +845,8 @@ mod sidebar_strip_tests {
 
     #[gpui::test]
     fn the_plus_cell_still_spawns_a_real_agent(cx: &mut TestAppContext) {
-        let repo = init_repo();
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_repo();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         let before = app.read_with(cx, |app, _| app.agents.iter().count());
@@ -906,41 +875,14 @@ mod problems_view_tests {
         publish_full_and_wait, spawn_fake_server,
     };
     use crate::rail::worktrees::WorktreeItem;
-    use crate::root::focus::palette_focus_tests;
     use gpui::TestAppContext;
     use std::path::Path;
-    use std::process::Command;
     use std::sync::Arc;
-    use tempfile::TempDir;
 
     /// LSP severity numbers, as a real server sends them.
     const ERROR: u8 = 1;
     const WARNING: u8 = 2;
     const HINT: u8 = 4;
-
-    fn git(dir: &Path, args: &[&str]) {
-        let output = Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {args:?} failed in {dir:?}: {}",
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
-    fn init_repo() -> TempDir {
-        let dir = TempDir::new().expect("tempdir");
-        git(dir.path(), &["init", "-b", "main"]);
-        git(dir.path(), &["config", "user.email", "test@example.com"]);
-        git(dir.path(), &["config", "user.name", "Test User"]);
-        std::fs::write(dir.path().join("base.txt"), "base\n").expect("write");
-        git(dir.path(), &["add", "base.txt"]);
-        git(dir.path(), &["commit", "-m", "initial"]);
-        dir
-    }
 
     /// Writes a real file under `root` and hands back its absolute path and its `file://` uri -
     /// the two things a real publish and a real click each need.
@@ -992,15 +934,15 @@ mod problems_view_tests {
     fn a_diagnostic_from_another_checkout_never_renders_under_the_active_one(
         cx: &mut TestAppContext,
     ) {
-        let repo = init_repo();
-        let other = TempDir::new().expect("tempdir");
+        let repo = crate::test_support::temp_repo();
+        let other = crate::test_support::temp_root();
         let here = repo.path().to_path_buf();
         let there = other.path().to_path_buf();
 
         let (_, here_uri) = real_file(&here, "src/here.rs", "fn here() {}\n");
         let (_, there_uri) = real_file(&there, "src/there.rs", "fn there() {}\n");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, here.clone());
+        let (app, cx) = crate::test_support::open_test_app(cx, here.clone());
         cx.run_until_parked();
 
         let here_server = spawn_fake_server(&here, "rust-analyzer", "normal");
@@ -1089,12 +1031,12 @@ mod problems_view_tests {
     fn a_row_for_a_never_opened_file_really_opens_it_at_the_diagnostics_line(
         cx: &mut TestAppContext,
     ) {
-        let repo = init_repo();
+        let repo = crate::test_support::temp_repo();
         let root = repo.path().to_path_buf();
         let (buried, buried_uri) =
             real_file(&root, "src/db/orm/select.rs", &"// filler\n".repeat(60));
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, root.clone());
+        let (app, cx) = crate::test_support::open_test_app(cx, root.clone());
         cx.run_until_parked();
 
         let server = spawn_fake_server(&root, "rust-analyzer", "normal");
@@ -1163,13 +1105,13 @@ mod problems_view_tests {
 
     #[gpui::test]
     fn the_header_and_the_marker_are_tallied_over_the_real_published_list(cx: &mut TestAppContext) {
-        let repo = init_repo();
+        let repo = crate::test_support::temp_repo();
         let root = repo.path().to_path_buf();
         let (_, broken) = real_file(&root, "src/db/orm/select.rs", "fn a() {}\n");
         let (_, noisy) = real_file(&root, "src/db/query_builder.rs", "fn b() {}\n");
         let (_, chatty) = real_file(&root, "src/api/orders.rs", "fn c() {}\n");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, root.clone());
+        let (app, cx) = crate::test_support::open_test_app(cx, root.clone());
         cx.run_until_parked();
 
         let server = spawn_fake_server(&root, "rust-analyzer", "normal");
@@ -1257,8 +1199,8 @@ mod problems_view_tests {
     fn a_diagnostic_about_a_file_outside_the_checkout_is_the_only_one_dropped(
         cx: &mut TestAppContext,
     ) {
-        let repo = init_repo();
-        let registry = TempDir::new().expect("tempdir");
+        let repo = crate::test_support::temp_repo();
+        let registry = crate::test_support::temp_root();
         let root = repo.path().to_path_buf();
         let (_, dependency) = real_file(
             registry.path(),
@@ -1270,7 +1212,7 @@ mod problems_view_tests {
         // landed): the dependency row must be the only one dropped, not everything.
         let (_, mine) = real_file(&root, "src/lib.rs", "pub fn mine() {}\n");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, root.clone());
+        let (app, cx) = crate::test_support::open_test_app(cx, root.clone());
         cx.run_until_parked();
 
         let server = spawn_fake_server(&root, "rust-analyzer", "normal");
@@ -1317,11 +1259,11 @@ mod problems_view_tests {
 
     #[gpui::test]
     fn a_row_for_a_deleted_file_disappears_from_the_list_and_the_tally(cx: &mut TestAppContext) {
-        let repo = init_repo();
+        let repo = crate::test_support::temp_repo();
         let root = repo.path().to_path_buf();
         let (doomed, doomed_uri) = real_file(&root, "src/scratch.rs", "fn tmp() {}\n");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, root.clone());
+        let (app, cx) = crate::test_support::open_test_app(cx, root.clone());
         cx.run_until_parked();
 
         let server = spawn_fake_server(&root, "rust-analyzer", "normal");
@@ -1367,11 +1309,11 @@ mod problems_view_tests {
     fn restarting_the_language_server_empties_the_list_rather_than_stranding_it(
         cx: &mut TestAppContext,
     ) {
-        let repo = init_repo();
+        let repo = crate::test_support::temp_repo();
         let root = repo.path().to_path_buf();
         let (_, uri) = real_file(&root, "src/main.rs", "fn main() {}\n");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, root.clone());
+        let (app, cx) = crate::test_support::open_test_app(cx, root.clone());
         cx.run_until_parked();
 
         let server = spawn_fake_server(&root, "rust-analyzer", "normal");

--- a/crates/app/src/rail/title_signal.rs
+++ b/crates/app/src/rail/title_signal.rs
@@ -99,25 +99,17 @@ fn has_word(haystack: &str, word: &str) -> bool {
 mod tests {
     use super::*;
 
+    /// The real captures this module was written against, byte for byte: Gemini CLI's idle title
+    /// (OSC 0 payload, trailing padding included) and Claude Code 2.1.228's whole session
+    /// transcript - at rest, a spinner alternating across a 9-second stretch of silent `sleep 3`
+    /// tool calls, then back to rest. Nothing here is invented; see the module docs.
     #[test]
-    fn the_exact_gemini_idle_title_captured_from_a_real_session_reads_as_idle() {
-        // Byte-for-byte what Gemini CLI wrote to a real pty on this machine (OSC 0 payload,
-        // trailing padding included) - see the module docs.
-        assert_eq!(
-            classify_title(
-                "\u{25c7}  Ready (scratchpad)                                                    "
-            ),
-            TitleSignal::Idle
-        );
-    }
-
-    #[test]
-    fn the_real_claude_code_session_transcript_classifies_end_to_end() {
-        // The exact titles Claude Code 2.1.228 wrote to a real pty, in order, over one session:
-        // at rest, then a spinner alternating across a 9-second stretch of silent `sleep 3` tool
-        // calls, then back to rest. Nothing here is invented - see the module docs for the
-        // capture. This is the whole signal, pinned as one sequence.
+    fn the_real_captured_session_titles_classify_end_to_end() {
         let transcript = [
+            (
+                "\u{25c7}  Ready (scratchpad)                                                    ",
+                TitleSignal::Idle,
+            ),
             ("\u{2733} Claude Code", TitleSignal::Idle),
             ("\u{25d0} Claude Code", TitleSignal::Busy),
             (
@@ -138,80 +130,81 @@ mod tests {
         }
     }
 
+    /// Every glyph family this module knows, and the rule that a glyph outranks contradicting
+    /// prose - the glyph is the deliberate signal, the prose is incidental. `\u{25d0}`/`\u{25d1}`
+    /// and the Braille frames were observed live; the rest of each contiguous set is included
+    /// because it must not read as anything else (see the constants' own docs).
     #[test]
-    fn every_frame_of_claude_codes_half_circle_spinner_reads_as_busy() {
-        // `\u{25d0}`/`\u{25d1}` were observed live; the other two are the rest of the same
-        // contiguous set (see the constants' docs) and must not read as anything else.
-        for frame in ['\u{25d0}', '\u{25d1}', '\u{25d2}', '\u{25d3}'] {
-            assert_eq!(
-                classify_title(&format!("{frame} doing something")),
-                TitleSignal::Busy,
-                "{frame:?}"
-            );
+    fn a_status_glyph_decides_the_signal_whatever_the_prose_says() {
+        let cases: &[(&str, TitleSignal)] = &[
+            ("\u{25d0} doing something", TitleSignal::Busy),
+            ("\u{25d1} doing something", TitleSignal::Busy),
+            ("\u{25d2} doing something", TitleSignal::Busy),
+            ("\u{25d3} doing something", TitleSignal::Busy),
+            ("\u{2726} Working (jerry)", TitleSignal::Busy),
+            ("\u{23f2} (jerry)", TitleSignal::Busy),
+            ("\u{25c7} Ready", TitleSignal::Idle),
+            (
+                "\u{270b} Waiting for permission",
+                TitleSignal::NeedsAttention,
+            ),
+            ("\u{280b} some-cli", TitleSignal::Busy),
+            ("\u{2819} some-cli", TitleSignal::Busy),
+            ("\u{2839} some-cli", TitleSignal::Busy),
+            ("\u{2807} some-cli", TitleSignal::Busy),
+            ("\u{2800} some-cli", TitleSignal::Busy),
+            ("\u{28ff} some-cli", TitleSignal::Busy),
+            ("\u{2726} almost done", TitleSignal::Busy),
+            ("\u{270b} working on it", TitleSignal::NeedsAttention),
+        ];
+        for (title, expected) in cases {
+            assert_eq!(classify_title(title), *expected, "{title:?}");
         }
     }
 
+    /// Keywords match case-insensitively, and only on whole words - including at either end of
+    /// the title, which the boundary check has to treat as a boundary rather than a missing
+    /// character, and after an earlier non-matching occurrence, which `has_word`'s scan-onward
+    /// loop has to get past ("already ready").
     #[test]
-    fn geminis_documented_glyph_set_maps_to_its_four_states() {
-        assert_eq!(
-            classify_title("\u{2726} Working (jerry)"),
-            TitleSignal::Busy
-        );
-        assert_eq!(classify_title("\u{23f2} (jerry)"), TitleSignal::Busy);
-        assert_eq!(classify_title("\u{25c7} Ready"), TitleSignal::Idle);
-        assert_eq!(
-            classify_title("\u{270b} Waiting for permission"),
-            TitleSignal::NeedsAttention
-        );
-    }
-
-    #[test]
-    fn a_braille_spinner_frame_anywhere_means_busy() {
-        for frame in [
-            '\u{280b}', '\u{2819}', '\u{2839}', '\u{2807}', '\u{2800}', '\u{28ff}',
-        ] {
-            assert_eq!(
-                classify_title(&format!("{frame} some-cli")),
-                TitleSignal::Busy,
-                "{frame:?} is a Braille spinner frame"
-            );
+    fn a_keyword_matches_case_insensitively_on_whole_words_anywhere_in_the_title() {
+        let cases: &[(&str, TitleSignal)] = &[
+            ("agent: thinking", TitleSignal::Busy),
+            ("[Ready]", TitleSignal::Idle),
+            ("build done.", TitleSignal::Idle),
+            ("waiting for approval", TitleSignal::NeedsAttention),
+            ("WORKING", TitleSignal::Busy),
+            ("Idle", TitleSignal::Idle),
+            ("PERMISSION needed", TitleSignal::NeedsAttention),
+            ("ready", TitleSignal::Idle),
+            ("ready to go", TitleSignal::Idle),
+            ("all ready", TitleSignal::Idle),
+            ("already ready", TitleSignal::Idle),
+            ("\u{2026}\u{2026}ready\u{2026}\u{2026}", TitleSignal::Idle),
+        ];
+        for (title, expected) in cases {
+            assert_eq!(classify_title(title), *expected, "{title:?}");
         }
     }
 
+    /// The false-positive class the word-boundary guard exists for: terminal titles are mostly
+    /// paths, and plenty of ordinary ones embed these letters. An ordinary shell title - and a
+    /// multibyte one, whose bytes `has_word`'s offset arithmetic must never split - claims
+    /// nothing at all.
     #[test]
-    fn a_glyph_beats_a_contradicting_keyword() {
-        assert_eq!(
-            classify_title("\u{2726} almost done"),
-            TitleSignal::Busy,
-            "the glyph is the deliberate signal; the prose is incidental"
-        );
-        assert_eq!(
-            classify_title("\u{270b} working on it"),
-            TitleSignal::NeedsAttention
-        );
-    }
-
-    #[test]
-    fn keywords_match_only_on_whole_words() {
-        assert_eq!(classify_title("agent: thinking"), TitleSignal::Busy);
-        assert_eq!(classify_title("[Ready]"), TitleSignal::Idle);
-        assert_eq!(classify_title("build done."), TitleSignal::Idle);
-        assert_eq!(
-            classify_title("waiting for approval"),
-            TitleSignal::NeedsAttention
-        );
-    }
-
-    #[test]
-    fn a_path_that_merely_contains_a_keyword_as_a_substring_does_not_match() {
-        // The exact false-positive class the word-boundary guard exists for: terminal titles
-        // are mostly paths, and plenty of ordinary ones embed these letters.
+    fn an_ordinary_title_claims_no_status_even_when_it_embeds_the_letters() {
         for title in [
             "~/src/already/main.rs",
             "vim ~/notes/readyish.md",
             "npm run networking-tests",
             "~/code/rethinking/mod.rs",
             "~/work/idleness.txt",
+            "colin@jerry: ~/spike/ade",
+            "bash",
+            "",
+            "make -j8",
+            "\u{2713} tests passed",
+            "日本語のタイトル",
         ] {
             assert_eq!(
                 classify_title(title),
@@ -219,51 +212,5 @@ mod tests {
                 "{title:?} must not be read as a status claim"
             );
         }
-    }
-
-    #[test]
-    fn an_ordinary_shell_title_is_unknown() {
-        for title in [
-            "colin@jerry: ~/spike/ade",
-            "bash",
-            "",
-            "make -j8",
-            "\u{2713} tests passed",
-        ] {
-            assert_eq!(classify_title(title), TitleSignal::Unknown, "{title:?}");
-        }
-    }
-
-    #[test]
-    fn classification_is_case_insensitive_for_keywords() {
-        assert_eq!(classify_title("WORKING"), TitleSignal::Busy);
-        assert_eq!(classify_title("Idle"), TitleSignal::Idle);
-        assert_eq!(
-            classify_title("PERMISSION needed"),
-            TitleSignal::NeedsAttention
-        );
-    }
-
-    #[test]
-    fn a_word_at_either_end_of_the_title_still_matches() {
-        // The boundary check has to treat "start of string" and "end of string" as boundaries,
-        // not as missing characters that fail the test.
-        assert_eq!(classify_title("ready"), TitleSignal::Idle);
-        assert_eq!(classify_title("ready to go"), TitleSignal::Idle);
-        assert_eq!(classify_title("all ready"), TitleSignal::Idle);
-    }
-
-    #[test]
-    fn a_real_word_after_a_non_matching_occurrence_is_still_found() {
-        // Exercises `has_word`'s scan-onward loop: the first "ready" is inside "already" and
-        // must be rejected without ending the search.
-        assert_eq!(classify_title("already ready"), TitleSignal::Idle);
-    }
-
-    #[test]
-    fn multibyte_titles_do_not_panic_and_classify_by_their_glyph() {
-        assert_eq!(classify_title("日本語のタイトル"), TitleSignal::Unknown);
-        assert_eq!(classify_title("\u{25c7} 準備完了"), TitleSignal::Idle);
-        assert_eq!(classify_title("……ready……"), TitleSignal::Idle);
     }
 }

--- a/crates/app/src/rail/worktree_watch.rs
+++ b/crates/app/src/rail/worktree_watch.rs
@@ -52,65 +52,31 @@ pub fn spawn_worktree_watcher(repo_path: &Path, dirty: DirtyFlag) -> Option<Reco
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::fs;
-    use std::process::Command;
-    use std::time::{Duration, Instant};
-    use tempfile::TempDir;
-
-    fn git(dir: &Path, args: &[&str]) {
-        let output = Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {:?} failed in {:?}:\nstdout: {}\nstderr: {}",
-            args,
-            dir,
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
-    fn init_repo() -> TempDir {
-        let dir = TempDir::new().expect("tempdir");
-        git(dir.path(), &["init", "-b", "main"]);
-        git(dir.path(), &["config", "user.email", "test@example.com"]);
-        git(dir.path(), &["config", "user.name", "Test User"]);
-        fs::write(dir.path().join("base.txt"), "base\n").expect("write");
-        git(dir.path(), &["add", "base.txt"]);
-        git(dir.path(), &["commit", "-m", "initial"]);
-        dir
-    }
+    use std::time::Duration;
 
     /// Real-time bounded wait for the watcher's async, OS-thread-delivered callback to fire -
     /// there is no deterministic/simulated clock to advance here (unlike `gpui`'s test
-    /// executor), since `notify`'s events come from the real kernel on a real background
-    /// thread. A generous 3s ceiling, polled every 10ms; real inotify delivery is normally
-    /// sub-millisecond, so this only ever times out on a genuine failure to detect the change.
+    /// executor), since `notify`'s events come from the real kernel on a real background thread.
+    /// `test_support::wait_until` is the workspace's one sanctioned wall-clock wait
+    /// (`docs/testing.md`); real inotify delivery is normally sub-millisecond, so the generous
+    /// ceiling only ever elapses on a genuine failure to detect the change.
     fn wait_until_dirty(dirty: &DirtyFlag) -> bool {
-        let deadline = Instant::now() + Duration::from_secs(3);
-        while Instant::now() < deadline {
-            if dirty.swap(false, Ordering::SeqCst) {
-                return true;
-            }
-            std::thread::sleep(Duration::from_millis(10));
-        }
-        false
+        test_support::wait_until(Duration::from_secs(3), || {
+            dirty.swap(false, Ordering::SeqCst)
+        })
     }
 
     #[test]
     fn a_real_worktree_add_is_noticed() {
-        let repo = init_repo();
+        let repo = crate::test_support::temp_repo();
         let dirty: DirtyFlag = Arc::new(AtomicBool::new(false));
         let _watcher =
             spawn_worktree_watcher(repo.path(), dirty.clone()).expect("spawn_worktree_watcher");
 
-        let container = TempDir::new().expect("tempdir");
+        let container = crate::test_support::temp_root();
         let linked_path = container.path().join("added-wt");
         drop(container);
-        git(
+        test_support::git(
             repo.path(),
             &[
                 "worktree",
@@ -129,11 +95,11 @@ mod tests {
 
     #[test]
     fn a_real_worktree_remove_is_noticed() {
-        let repo = init_repo();
-        let container = TempDir::new().expect("tempdir");
+        let repo = crate::test_support::temp_repo();
+        let container = crate::test_support::temp_root();
         let linked_path = container.path().join("removed-wt");
         drop(container);
-        git(
+        test_support::git(
             repo.path(),
             &[
                 "worktree",
@@ -148,7 +114,7 @@ mod tests {
         let _watcher =
             spawn_worktree_watcher(repo.path(), dirty.clone()).expect("spawn_worktree_watcher");
 
-        git(
+        test_support::git(
             repo.path(),
             &[
                 "worktree",
@@ -165,11 +131,11 @@ mod tests {
 
     #[test]
     fn a_real_worktree_lock_is_noticed() {
-        let repo = init_repo();
-        let container = TempDir::new().expect("tempdir");
+        let repo = crate::test_support::temp_repo();
+        let container = crate::test_support::temp_root();
         let linked_path = container.path().join("locked-wt");
         drop(container);
-        git(
+        test_support::git(
             repo.path(),
             &[
                 "worktree",
@@ -184,7 +150,7 @@ mod tests {
         let _watcher =
             spawn_worktree_watcher(repo.path(), dirty.clone()).expect("spawn_worktree_watcher");
 
-        git(
+        test_support::git(
             repo.path(),
             &[
                 "worktree",
@@ -203,14 +169,14 @@ mod tests {
 
     #[test]
     fn a_branch_switch_in_the_main_worktree_is_noticed() {
-        let repo = init_repo();
-        git(repo.path(), &["branch", "other"]);
+        let repo = crate::test_support::temp_repo();
+        test_support::git(repo.path(), &["branch", "other"]);
 
         let dirty: DirtyFlag = Arc::new(AtomicBool::new(false));
         let _watcher =
             spawn_worktree_watcher(repo.path(), dirty.clone()).expect("spawn_worktree_watcher");
 
-        git(repo.path(), &["checkout", "other"]);
+        test_support::git(repo.path(), &["checkout", "other"]);
 
         assert!(
             wait_until_dirty(&dirty),
@@ -220,11 +186,11 @@ mod tests {
 
     #[test]
     fn a_branch_switch_in_a_linked_worktree_is_noticed() {
-        let repo = init_repo();
-        let container = TempDir::new().expect("tempdir");
+        let repo = crate::test_support::temp_repo();
+        let container = crate::test_support::temp_root();
         let linked_path = container.path().join("switch-wt");
         drop(container);
-        git(
+        test_support::git(
             repo.path(),
             &[
                 "worktree",
@@ -234,13 +200,13 @@ mod tests {
                 linked_path.to_str().expect("utf8 path"),
             ],
         );
-        git(&linked_path, &["branch", "switch-target"]);
+        test_support::git(&linked_path, &["branch", "switch-target"]);
 
         let dirty: DirtyFlag = Arc::new(AtomicBool::new(false));
         let _watcher =
             spawn_worktree_watcher(repo.path(), dirty.clone()).expect("spawn_worktree_watcher");
 
-        git(&linked_path, &["checkout", "switch-target"]);
+        test_support::git(&linked_path, &["checkout", "switch-target"]);
 
         assert!(
             wait_until_dirty(&dirty),
@@ -250,14 +216,14 @@ mod tests {
 
     #[test]
     fn a_non_repository_yields_no_watcher_rather_than_panicking() {
-        let dir = TempDir::new().expect("tempdir");
+        let dir = crate::test_support::temp_root();
         let dirty: DirtyFlag = Arc::new(AtomicBool::new(false));
         assert!(spawn_worktree_watcher(dir.path(), dirty).is_none());
     }
 
     #[test]
     fn the_very_first_worktree_add_in_a_repo_is_still_noticed_via_the_fallback_watch() {
-        let repo = init_repo();
+        let repo = crate::test_support::temp_repo();
         assert!(
             !repo.path().join(".git").join("worktrees").exists(),
             "precondition: this repo has never had a linked worktree"
@@ -272,10 +238,10 @@ mod tests {
         );
         let _watcher = watcher;
 
-        let container = TempDir::new().expect("tempdir");
+        let container = crate::test_support::temp_root();
         let linked_path = container.path().join("first-ever-wt");
         drop(container);
-        git(
+        test_support::git(
             repo.path(),
             &[
                 "worktree",

--- a/crates/app/src/rail/worktrees.rs
+++ b/crates/app/src/rail/worktrees.rs
@@ -203,101 +203,77 @@ mod tests {
         }
     }
 
+    /// A row's label, in the three-way order the function itself resolves it: the branch name
+    /// when there is one, else the short sha of the commit it is detached at, else the directory
+    /// name (an unborn worktree with no commit at all).
     #[test]
-    fn labels_use_branch_name_when_available() {
-        let items = build_worktree_items(vec![status("/repo", Some("main"), true)]);
-        assert_eq!(items.len(), 1);
-        assert_eq!(items[0].label, "main");
-        assert_eq!(items[0].path, PathBuf::from("/repo"));
-        assert!(items[0].is_main);
-        assert!(items[0].error.is_none());
-    }
+    fn a_label_is_the_branch_then_the_short_sha_then_the_directory_name() {
+        let on_branch = build_worktree_items(vec![status("/repo", Some("main"), true)]);
+        assert_eq!(on_branch[0].label, "main");
+        assert_eq!(on_branch[0].path, PathBuf::from("/repo"));
+        assert!(on_branch[0].is_main);
 
-    #[test]
-    fn detached_head_labels_with_the_short_sha_not_the_directory_name() {
-        let items = build_worktree_items(vec![status("/repos/feature-x", None, false)]);
-        assert_eq!(items[0].label, "deadbee");
-        assert_eq!(items[0].short_sha.as_deref(), Some("deadbee"));
-        assert_eq!(items[0].branch, None);
-        assert!(items[0].is_detached);
-        assert!(!items[0].is_main);
-    }
+        let detached = build_worktree_items(vec![status("/repos/feature-x", None, false)]);
+        assert_eq!(detached[0].label, "deadbee");
+        assert_eq!(detached[0].short_sha.as_deref(), Some("deadbee"));
+        assert_eq!(detached[0].branch, None);
+        assert!(detached[0].is_detached && !detached[0].is_main);
 
-    #[test]
-    fn falls_back_to_directory_name_when_there_is_no_commit_at_all() {
         let mut unborn = status("/repos/fresh", None, false);
         unborn.head_commit = None;
-        let items = build_worktree_items(vec![unborn]);
-        assert_eq!(items[0].label, "fresh");
-        assert_eq!(items[0].short_sha, None);
+        let unborn = build_worktree_items(vec![unborn]);
+        assert_eq!(unborn[0].label, "fresh");
+        assert_eq!(unborn[0].short_sha, None);
     }
 
+    /// The lock and bare flags git reports carry through to the row unchanged, and an empty
+    /// listing maps to no rows rather than a synthesised one.
     #[test]
-    fn empty_list_maps_to_empty_items() {
-        assert_eq!(build_worktree_items(Vec::new()), Vec::new());
-    }
-
-    #[test]
-    fn locked_state_and_reason_are_preserved() {
+    fn lock_and_bare_state_carry_through_and_an_empty_listing_makes_no_rows() {
         let mut locked = status("/repo-wt/locked", Some("locked-branch"), false);
         locked.is_locked = true;
         locked.lock_reason = Some("external disk".to_string());
-        let items = build_worktree_items(vec![locked]);
-        assert!(items[0].is_locked);
-        assert_eq!(items[0].lock_reason.as_deref(), Some("external disk"));
-    }
+        let locked = build_worktree_items(vec![locked]);
+        assert!(locked[0].is_locked);
+        assert_eq!(locked[0].lock_reason.as_deref(), Some("external disk"));
 
-    #[test]
-    fn unlocked_state_is_preserved() {
-        let items = build_worktree_items(vec![status("/repo-wt/unlocked", Some("x"), false)]);
-        assert!(!items[0].is_locked);
-        assert_eq!(items[0].lock_reason, None);
-    }
-
-    #[test]
-    fn bare_entry_is_flagged_bare_and_never_main() {
         let mut bare = status("/bare-repo", None, false);
         bare.is_bare = true;
         bare.head_commit = None;
         bare.is_detached = false;
-        let items = build_worktree_items(vec![bare]);
-        assert!(items[0].is_bare);
-        assert!(!items[0].is_main);
+        let bare = build_worktree_items(vec![bare]);
+        assert!(bare[0].is_bare && !bare[0].is_main);
+
+        assert_eq!(build_worktree_items(Vec::new()), Vec::new());
     }
 
     #[test]
-    fn a_prunable_entry_is_marked_broken_and_unusable() {
+    fn a_prunable_entry_is_marked_broken_and_unusable_with_or_without_a_reason() {
         let mut gone = status("/repo-wt/gone", Some("gone-branch"), false);
         gone.is_prunable = true;
         gone.prunable_reason = Some("gitdir file points to non-existent location".to_string());
-        let items = build_worktree_items(vec![gone]);
-        assert!(items[0].is_broken);
+        let gone = build_worktree_items(vec![gone]);
+        assert!(gone[0].is_broken);
         assert_eq!(
-            items[0].broken_reason.as_deref(),
+            gone[0].broken_reason.as_deref(),
             Some("gitdir file points to non-existent location")
         );
         assert!(
-            items[0].error.is_some(),
+            gone[0].error.is_some(),
             "a broken worktree must also fail the existing error.is_none() usability gate"
         );
-    }
 
-    #[test]
-    fn a_prunable_entry_with_no_reason_still_reports_a_real_error() {
-        let mut gone = status("/repo-wt/gone-no-reason", Some("gone"), false);
-        gone.is_prunable = true;
-        let items = build_worktree_items(vec![gone]);
-        assert!(items[0].is_broken);
-        assert_eq!(items[0].broken_reason, None);
-        assert!(items[0].error.is_some());
-    }
+        let mut unexplained = status("/repo-wt/gone-no-reason", Some("gone"), false);
+        unexplained.is_prunable = true;
+        let unexplained = build_worktree_items(vec![unexplained]);
+        assert!(unexplained[0].is_broken);
+        assert_eq!(unexplained[0].broken_reason, None);
+        assert!(unexplained[0].error.is_some());
 
-    #[test]
-    fn a_healthy_entry_is_not_broken() {
-        let items = build_worktree_items(vec![status("/repo", Some("main"), true)]);
-        assert!(!items[0].is_broken);
-        assert_eq!(items[0].broken_reason, None);
-        assert!(items[0].error.is_none());
+        let healthy = build_worktree_items(vec![status("/repo", Some("main"), true)]);
+        assert!(!healthy[0].is_broken);
+        assert_eq!(healthy[0].broken_reason, None);
+        assert!(healthy[0].error.is_none());
     }
 
     // --- `recover_selection` ------------------------------------------------------------
@@ -319,34 +295,33 @@ mod tests {
         }
     }
 
+    /// Nothing to recover: no prior selection at all, or one that is still there and usable.
     #[test]
-    fn no_prior_selection_needs_no_recovery() {
-        let new_items = vec![item("/repo", true, None)];
-        assert_eq!(
-            recover_selection(None, &new_items),
-            SelectionRecovery::NoPriorSelection
-        );
-    }
-
-    #[test]
-    fn a_selection_that_is_still_present_is_unchanged() {
-        let previous = item("/repo-wt/feature", false, None);
+    fn a_still_usable_or_absent_selection_needs_no_recovery() {
         let new_items = vec![
             item("/repo", true, None),
             item("/repo-wt/feature", false, None),
         ];
+        assert_eq!(
+            recover_selection(None, &new_items),
+            SelectionRecovery::NoPriorSelection
+        );
+
+        let previous = item("/repo-wt/feature", false, None);
         assert_eq!(
             recover_selection(Some(&previous), &new_items),
             SelectionRecovery::Unchanged(1)
         );
     }
 
+    /// A selection that vanished - or that is still listed but has since gone broken - falls back
+    /// to the main worktree with a real notice naming what was lost, and reports `None` honestly
+    /// when there is no usable main to fall back to either.
     #[test]
-    fn a_vanished_selection_falls_back_to_main_with_a_notice() {
+    fn a_vanished_or_broken_selection_falls_back_to_a_usable_main_or_to_nothing() {
         let previous = item("/repo-wt/feature", false, None);
-        let new_items = vec![item("/repo", true, None)];
-        let recovery = recover_selection(Some(&previous), &new_items);
-        match recovery {
+
+        match recover_selection(Some(&previous), &[item("/repo", true, None)]) {
             SelectionRecovery::FellBackToMain { new_index, notice } => {
                 assert_eq!(new_index, Some(0));
                 assert!(notice.contains("/repo-wt/feature"));
@@ -354,32 +329,21 @@ mod tests {
             }
             other => panic!("expected FellBackToMain, got {other:?}"),
         }
-    }
 
-    #[test]
-    fn a_selection_that_became_broken_also_falls_back_to_main() {
-        let previous = item("/repo-wt/feature", false, None);
-        let new_items = vec![
+        let now_broken = vec![
             item("/repo", true, None),
             item("/repo-wt/feature", false, Some("worktree is prunable")),
         ];
-        let recovery = recover_selection(Some(&previous), &new_items);
         assert!(matches!(
-            recovery,
+            recover_selection(Some(&previous), &now_broken),
             SelectionRecovery::FellBackToMain {
                 new_index: Some(0),
                 ..
             }
         ));
-    }
 
-    #[test]
-    fn falling_back_with_no_usable_main_at_all_reports_none() {
-        let previous = item("/repo-wt/feature", false, None);
-        let new_items: Vec<WorktreeItem> = Vec::new();
-        let recovery = recover_selection(Some(&previous), &new_items);
         assert!(matches!(
-            recovery,
+            recover_selection(Some(&previous), &[]),
             SelectionRecovery::FellBackToMain {
                 new_index: None,
                 ..
@@ -389,66 +353,57 @@ mod tests {
 
     // --- `selection_for_opened_repo` -----------------------------------------------------
 
+    /// The three real launch shapes: `jerry .` at the repo root (both of this function's rules
+    /// agree on the one obvious row), `jerry ~/repo-wt/feature` directly inside a linked worktree
+    /// (which must win over main, never be silently redirected), and the live-reproduced
+    /// subdirectory launch `jerry ./crates`. Before that last rule existed,
+    /// `AdeApp::current_worktree_path` fell back to the bare subdirectory path and the startup
+    /// shell it spawned there belonged to no rail row at all - a real, live tab that no worktree
+    /// claimed, permanently unreachable the moment any worktree row was clicked.
     #[test]
-    fn opening_a_repo_root_selects_its_own_main_worktree() {
+    fn an_opened_path_selects_its_own_worktree_or_the_main_one_it_sits_under() {
         let items = vec![
             item("/repo", true, None),
             item("/repo-wt/feature", false, None),
         ];
-        assert_eq!(
-            selection_for_opened_repo(Path::new("/repo"), &items),
-            Some(0)
-        );
+        for (opened, expected, why) in [
+            ("/repo", Some(0), "the repo root is its own main worktree"),
+            (
+                "/repo-wt/feature",
+                Some(1),
+                "the worktree the user actually pointed at must win over the main worktree",
+            ),
+            (
+                "/repo/crates",
+                Some(0),
+                "a subdirectory is not a worktree, so this must land on the real main worktree",
+            ),
+        ] {
+            assert_eq!(
+                selection_for_opened_repo(Path::new(opened), &items),
+                expected,
+                "{why}"
+            );
+        }
     }
 
     #[test]
-    fn opening_a_linked_worktree_directly_selects_that_worktree_not_main() {
-        let items = vec![
-            item("/repo", true, None),
-            item("/repo-wt/feature", false, None),
-        ];
-        assert_eq!(
-            selection_for_opened_repo(Path::new("/repo-wt/feature"), &items),
-            Some(1),
-            "the worktree the user actually pointed at must win over the main worktree"
-        );
-    }
-
-    #[test]
-    fn opening_a_subdirectory_of_a_repo_falls_back_to_the_main_worktree() {
-        let items = vec![
-            item("/repo", true, None),
-            item("/repo-wt/feature", false, None),
-        ];
-        assert_eq!(
-            selection_for_opened_repo(Path::new("/repo/crates"), &items),
-            Some(0),
-            "a subdirectory is not a worktree, so this must land on the real main worktree \
-             rather than on the subdirectory itself"
-        );
-    }
-
-    #[test]
-    fn opening_a_repo_with_no_usable_worktree_at_all_selects_nothing() {
-        assert_eq!(selection_for_opened_repo(Path::new("/repo"), &[]), None);
-    }
-
-    #[test]
-    fn a_broken_exact_match_is_skipped_in_favour_of_a_usable_main() {
-        let items = vec![
+    fn an_unusable_row_is_never_selected_even_on_an_exact_path_match() {
+        let broken_match = vec![
             item("/repo", true, None),
             item("/repo-wt/gone", false, Some("worktree is prunable")),
         ];
         assert_eq!(
-            selection_for_opened_repo(Path::new("/repo-wt/gone"), &items),
+            selection_for_opened_repo(Path::new("/repo-wt/gone"), &broken_match),
             Some(0),
             "a prunable exact match is not usable, so this must fall back to main"
         );
-    }
 
-    #[test]
-    fn a_broken_main_worktree_is_not_selected_either() {
-        let items = vec![item("/repo", true, Some("worktree is prunable"))];
-        assert_eq!(selection_for_opened_repo(Path::new("/repo"), &items), None);
+        let broken_main = vec![item("/repo", true, Some("worktree is prunable"))];
+        assert_eq!(
+            selection_for_opened_repo(Path::new("/repo"), &broken_main),
+            None
+        );
+        assert_eq!(selection_for_opened_repo(Path::new("/repo"), &[]), None);
     }
 }

--- a/crates/app/src/review/render.rs
+++ b/crates/app/src/review/render.rs
@@ -630,58 +630,27 @@ mod review_flow_tests {
     use super::*;
     use crate::review::state::BaselineReason;
     use crate::root::focus::palette_focus_tests;
+    use crate::test_support::{temp_repo_with, TempRoot};
     use crate::work_surface::agents::{AgentKind, ProcessKind};
     use gpui::TestAppContext;
-
-    fn git(dir: &Path, args: &[&str]) {
-        let output = std::process::Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {:?} failed in {:?}:\nstdout: {}\nstderr: {}",
-            args,
-            dir,
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
-    fn git_stdout(dir: &Path, args: &[&str]) -> String {
-        let output = std::process::Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        String::from_utf8_lossy(&output.stdout).into_owned()
-    }
+    use test_support::{git, git_output, git_try};
 
     /// A real repo whose branch has **already diverged from `main`**, with a real committed
     /// change on it. That divergence is the whole point: it gives the worktree a real, non-empty
     /// *git* diff that has nothing to do with any agent, which is exactly the state that used to
     /// make an agent falsely report "review ready".
-    fn diverged_repo() -> tempfile::TempDir {
-        let repo = tempfile::tempdir().expect("tempdir");
-        git(repo.path(), &["init", "-b", "main"]);
-        git(repo.path(), &["config", "user.email", "test@example.com"]);
-        git(repo.path(), &["config", "user.name", "Test User"]);
-        std::fs::write(repo.path().join("base.txt"), "base\n").expect("write");
-        git(repo.path(), &["add", "."]);
-        git(repo.path(), &["commit", "-m", "initial"]);
-        git(repo.path(), &["checkout", "-b", "feature"]);
-        std::fs::write(
-            repo.path().join("already_here.txt"),
-            "committed on feature\n",
-        )
-        .expect("write");
-        git(repo.path(), &["add", "."]);
-        git(
-            repo.path(),
-            &["commit", "-m", "work that predates any agent"],
-        );
-        repo
+    fn diverged_repo() -> TempRoot {
+        temp_repo_with(|root| {
+            test_support::seed_empty_repo_at(root);
+            test_support::commit(root, "base.txt", "base\n", "initial");
+            git(root, &["checkout", "-b", "feature"]);
+            test_support::commit(
+                root,
+                "already_here.txt",
+                "committed on feature\n",
+                "work that predates any agent",
+            );
+        })
     }
 
     /// Every window starts with exactly one agent - a plain shell `AdeApp::new` spawns into the
@@ -744,22 +713,20 @@ mod review_flow_tests {
         git(repo.path(), &["add", "staged.txt"]);
         std::fs::write(repo.path().join("base.txt"), "base\nedited\n").expect("write");
         std::fs::write(repo.path().join("untracked.txt"), "untracked\n").expect("write");
-        let status_before = git_stdout(repo.path(), &["status", "--porcelain"]);
-        let head_before = git_stdout(repo.path(), &["rev-parse", "HEAD"]);
+        let status_before = git_output(repo.path(), &["status", "--porcelain"]);
+        let head_before = git_output(repo.path(), &["rev-parse", "HEAD"]);
 
         let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
         let id = sole_agent(&app, cx);
 
         assert_eq!(
-            git_stdout(repo.path(), &["status", "--porcelain"]),
+            git_output(repo.path(), &["status", "--porcelain"]),
             status_before,
             "capturing a baseline must not change one byte of the worktree's real git state"
         );
-        assert_eq!(git_stdout(repo.path(), &["rev-parse", "HEAD"]), head_before);
-        assert!(git_stdout(repo.path(), &["stash", "list"])
-            .trim()
-            .is_empty());
+        assert_eq!(git_output(repo.path(), &["rev-parse", "HEAD"]), head_before);
+        assert!(git_output(repo.path(), &["stash", "list"]).is_empty());
 
         let (tree_id, ref_name, reason) = app.read_with(cx, |app, _| {
             let review = app
@@ -779,12 +746,12 @@ mod review_flow_tests {
             "a baseline must be anchored inside this app's own ref namespace - got {ref_name}"
         );
         assert_eq!(
-            git_stdout(repo.path(), &["rev-parse", &ref_name]).trim(),
+            git_output(repo.path(), &["rev-parse", &ref_name]),
             tree_id,
             "the anchored ref must really resolve to the captured tree in the real repository"
         );
         assert_eq!(
-            git_stdout(repo.path(), &["cat-file", "-t", &tree_id]).trim(),
+            git_output(repo.path(), &["cat-file", "-t", &tree_id]),
             "tree",
             "and that object must really be a tree"
         );
@@ -907,7 +874,7 @@ mod review_flow_tests {
             assert!(!app.agent_has_unreviewed_changes(id));
             assert!(review.open_file.is_none());
             assert_eq!(
-                git_stdout(repo.path(), &["rev-parse", &ref_name]).trim(),
+                git_output(repo.path(), &["rev-parse", &ref_name]),
                 review.baseline.tree_id,
                 "the real ref must really point at the new snapshot"
             );
@@ -1123,7 +1090,7 @@ mod review_flow_tests {
                 "and a real snapshot behind it, not an empty placeholder"
             );
             assert_eq!(
-                git_stdout(repo.path(), &["rev-parse", &review.baseline.ref_name]).trim(),
+                git_output(repo.path(), &["rev-parse", &review.baseline.ref_name]),
                 review.baseline.tree_id,
                 "the real ref must point at that snapshot"
             );
@@ -1144,7 +1111,7 @@ mod review_flow_tests {
                  released, so without one it has nothing at all to review against",
             );
             assert_eq!(
-                git_stdout(repo.path(), &["rev-parse", &review.baseline.ref_name]).trim(),
+                git_output(repo.path(), &["rev-parse", &review.baseline.ref_name]),
                 review.baseline.tree_id
             );
         });
@@ -1165,16 +1132,14 @@ mod review_flow_tests {
                 .ref_name
                 .clone()
         });
-        assert!(!git_stdout(repo.path(), &["rev-parse", &ref_name])
-            .trim()
-            .is_empty());
+        assert!(!git_output(repo.path(), &["rev-parse", &ref_name]).is_empty());
 
         app.update_in(cx, |app, window, cx| app.close_agent(id, window, cx));
         cx.run_until_parked();
 
         assert!(
-            git_stdout(repo.path(), &["rev-parse", "--verify", &ref_name])
-                .trim()
+            git_try(repo.path(), &["rev-parse", "--verify", &ref_name])
+                .stdout
                 .is_empty(),
             "a closed agent's baseline ref must really be deleted"
         );
@@ -1502,7 +1467,7 @@ mod review_flow_tests {
         });
         for (cwd, ref_name) in &refs {
             assert!(
-                !git_stdout(cwd, &["rev-parse", ref_name]).trim().is_empty(),
+                !git_output(cwd, &["rev-parse", ref_name]).is_empty(),
                 "{ref_name} must really exist in {}",
                 cwd.display()
             );
@@ -1526,16 +1491,14 @@ mod review_flow_tests {
             name != &refs[0].1
         }) {
             assert!(
-                git_stdout(cwd, &["rev-parse", "--verify", ref_name])
-                    .trim()
+                git_try(cwd, &["rev-parse", "--verify", ref_name])
+                    .stdout
                     .is_empty(),
                 "{ref_name} must really have been deleted"
             );
         }
         assert!(
-            !git_stdout(&refs[0].0, &["rev-parse", "--verify", &refs[0].1])
-                .trim()
-                .is_empty(),
+            !git_output(&refs[0].0, &["rev-parse", "--verify", &refs[0].1]).is_empty(),
             "the still-open sole agent's own baseline ref must be untouched"
         );
         app.read_with(cx, |app, _| {

--- a/crates/app/src/review_notes/integration_tests.rs
+++ b/crates/app/src/review_notes/integration_tests.rs
@@ -9,13 +9,12 @@
 use super::render::notes_bar_label;
 use super::{FileNoteState, NoteAnchor};
 use crate::provenance::{store::ProvenanceStore, AgentKey};
-use crate::root::focus::palette_focus_tests::open_test_app;
 use crate::root::AdeApp;
 use crate::sidebar::render::RightSidebarView;
+use crate::test_support::{open_test_app, temp_repo_with, TempRoot};
 use crate::work_surface::agents::{AgentId, AgentKind, ProcessKind};
 use gpui::TestAppContext;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 use std::time::Duration;
 use tempfile::TempDir;
 
@@ -39,31 +38,14 @@ impl UserApi {
 }
 ";
 
-fn git(dir: &Path, args: &[&str]) {
-    let output = Command::new("git")
-        .args(args)
-        .current_dir(dir)
-        .output()
-        .expect("failed to spawn git");
-    assert!(
-        output.status.success(),
-        "git {args:?} failed: {}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-}
-
 /// A real repo with a real one-line change in `src/api/users.rs`, plus provenance recording that
 /// one real agent wrote it.
-fn repo_with_an_agent_authored_change(spawned_at: i64) -> (TempDir, ProvenanceStore) {
-    let dir = TempDir::new().expect("tempdir");
+fn repo_with_an_agent_authored_change(spawned_at: i64) -> (TempRoot, ProvenanceStore) {
+    let dir = temp_repo_with(|root| {
+        test_support::seed_empty_repo_at(root);
+        test_support::commit(root, PATH, BASE, "initial");
+    });
     let repo = dir.path();
-    git(repo, &["init", "-b", "main"]);
-    git(repo, &["config", "user.email", "test@example.com"]);
-    git(repo, &["config", "user.name", "Test User"]);
-    std::fs::create_dir_all(repo.join("src/api")).expect("mkdir");
-    std::fs::write(repo.join(PATH), BASE).expect("seed");
-    git(repo, &["add", "-A"]);
-    git(repo, &["commit", "-m", "initial"]);
 
     let file = repo.join(PATH);
     let mut store = ProvenanceStore::default();
@@ -100,7 +82,7 @@ fn agent_stand_in(dir: &Path) -> String {
 /// agent tab whose child is [`agent_stand_in`].
 fn open_review<'a>(
     cx: &'a mut TestAppContext,
-    repo: &TempDir,
+    repo: &TempRoot,
     shim_dir: &TempDir,
     store: ProvenanceStore,
     spawned_at: i64,
@@ -840,13 +822,10 @@ fn plain_letters_bound_over_the_diff_are_typed_into_a_note_not_swallowed(cx: &mu
 
 #[gpui::test]
 fn typing_into_a_note_keeps_working_after_the_card_scrolls_out_of_view(cx: &mut TestAppContext) {
-    let repo = TempDir::new().expect("tempdir");
-    git(repo.path(), &["init", "-b", "main"]);
-    git(repo.path(), &["config", "user.email", "test@example.com"]);
-    git(repo.path(), &["config", "user.name", "Test User"]);
-    std::fs::write(repo.path().join("big.rs"), "fn noop() {}\n").expect("seed");
-    git(repo.path(), &["add", "-A"]);
-    git(repo.path(), &["commit", "-m", "initial"]);
+    let repo = temp_repo_with(|root| {
+        test_support::seed_empty_repo_at(root);
+        test_support::commit(root, "big.rs", "fn noop() {}\n", "initial");
+    });
     // Far more lines than any viewport, so the note's own row genuinely leaves the built range.
     let mut content = String::from("fn noop() {}\n");
     for index in 0..300 {

--- a/crates/app/src/root/caret_blink.rs
+++ b/crates/app/src/root/caret_blink.rs
@@ -121,7 +121,6 @@ impl AdeApp {
 #[cfg(test)]
 mod caret_blink_focus_order_tests {
     use super::*;
-    use crate::root::focus::palette_focus_tests;
     use gpui::{Entity, TestAppContext, VisualTestContext};
 
     /// A real repo directory with a real file in it, opened in a real File view, so
@@ -130,11 +129,15 @@ mod caret_blink_focus_order_tests {
     /// `track_focus`'d (`crate::code_surface::render`).
     fn open_app_with_a_focusable_editor(
         cx: &mut TestAppContext,
-    ) -> (Entity<AdeApp>, &mut VisualTestContext, tempfile::TempDir) {
-        let repo = tempfile::tempdir().expect("tempdir");
+    ) -> (
+        Entity<AdeApp>,
+        &mut VisualTestContext,
+        crate::test_support::TempRoot,
+    ) {
+        let repo = crate::test_support::temp_root();
         let file_path = repo.path().join("notes.txt");
         std::fs::write(&file_path, "hello\n").expect("write notes.txt");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         // `on_focus`/`on_blur` only fire while GPUI considers the window itself active - a
         // freshly opened test window starts out inactive, so this is a real precondition, not
         // scaffolding (the same note every other caret-blink test in this codebase carries).

--- a/crates/app/src/root/focus.rs
+++ b/crates/app/src/root/focus.rs
@@ -187,32 +187,16 @@ impl AdeApp {
 #[cfg(test)]
 pub(crate) mod palette_focus_tests {
     use super::*;
-    use gpui::{Entity, TestAppContext};
+    use gpui::TestAppContext;
 
-    /// Opens an `AdeApp` in a test GPUI window against a throwaway temp directory (not a real
-    /// git repo, so `worktrees`/`diff_state` end up empty/errored - irrelevant to what these
-    /// tests check). `pub(crate)` since `settings_focus_tests` and others reuse this
-    /// same setup. Uses `AdeApp::new_with_settings` (in-memory `Settings::default()`, `None`
-    /// path), not `AdeApp::new`, so tests never read or write a real `settings.toml`.
-    pub(crate) fn open_test_app(
-        cx: &mut TestAppContext,
-        repo_path: PathBuf,
-    ) -> (Entity<AdeApp>, &mut gpui::VisualTestContext) {
-        cx.add_window_view(|window, cx| {
-            AdeApp::new_with_settings(
-                Some(repo_path),
-                true,
-                settings_store::Settings::default(),
-                None,
-                window,
-                cx,
-            )
-        })
-    }
+    /// The window fixture now lives in [`crate::test_support`]; re-exported here so the call
+    /// sites that still say `palette_focus_tests::open_test_app` keep resolving while they are
+    /// migrated (GitHub issue #425).
+    pub(crate) use crate::test_support::open_test_app;
 
     #[gpui::test]
     fn toggle_palette_reopens_after_being_closed(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
         let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
 
         cx.dispatch_action(TogglePalette);
@@ -237,22 +221,40 @@ pub(crate) mod palette_focus_tests {
     }
 
     #[gpui::test]
-    fn toggle_palette_works_on_a_fresh_window_with_nothing_clicked_yet(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+    fn scope_prefix_only_fires_on_an_empty_query(cx: &mut TestAppContext) {
+        let repo = crate::test_support::temp_root();
         let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
 
         cx.dispatch_action(TogglePalette);
+        cx.simulate_input(">");
+        app.read_with(cx, |app, _| {
+            assert_eq!(app.palette_scope, palette::PaletteScope::Commands);
+            assert_eq!(app.palette_query.as_str(), "");
+        });
 
-        assert!(
-            app.read_with(cx, |app, _| app.palette_open),
-            "secondary-p on a completely fresh window (nothing clicked yet) should still open the \
-             palette"
-        );
+        // Back to a fresh, empty-query palette state before the mid-query case.
+        cx.dispatch_action(TogglePalette);
+        cx.dispatch_action(TogglePalette);
+        app.read_with(cx, |app, _| {
+            assert_eq!(app.palette_scope, palette::PaletteScope::All);
+            assert_eq!(app.palette_query.as_str(), "");
+        });
+
+        cx.simulate_input("x");
+        cx.simulate_input(">");
+        app.read_with(cx, |app, _| {
+            assert_eq!(
+                app.palette_scope,
+                palette::PaletteScope::All,
+                "a `>` typed mid-query (query is non-empty) must not switch scope"
+            );
+            assert_eq!(app.palette_query.as_str(), "x>");
+        });
     }
 
     #[gpui::test]
     fn toggle_palette_still_works_after_a_palette_spawned_new_shell(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
         let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
 
         let initial_agent_id = app.read_with(cx, |app, _| app.agents.active_id());
@@ -283,42 +285,20 @@ pub(crate) mod palette_focus_tests {
         );
     }
 
-    #[gpui::test]
-    fn scope_prefix_only_fires_on_an_empty_query(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
-
-        cx.dispatch_action(TogglePalette);
-        cx.simulate_input(">");
-        app.read_with(cx, |app, _| {
-            assert_eq!(app.palette_scope, palette::PaletteScope::Commands);
-            assert_eq!(app.palette_query.as_str(), "");
-        });
-
-        cx.dispatch_action(TogglePalette);
-        cx.dispatch_action(TogglePalette);
-        app.read_with(cx, |app, _| {
-            assert_eq!(app.palette_scope, palette::PaletteScope::All);
-            assert_eq!(app.palette_query.as_str(), "");
-        });
-
-        cx.simulate_input("x");
-        cx.simulate_input(">");
-        app.read_with(cx, |app, _| {
-            assert_eq!(
-                app.palette_scope,
-                palette::PaletteScope::All,
-                "a `>` typed mid-query (query is non-empty) must not switch scope"
-            );
-            assert_eq!(app.palette_query.as_str(), "x>");
-        });
-    }
-
+    /// Unlike every other test in this module, which dispatches `TogglePalette` directly, this
+    /// binds `crate::default_key_bindings()` via `App::bind_keys`
+    /// (`vendor/zed/crates/gpui/src/app.rs:2130`) and simulates the real keystroke via
+    /// `VisualTestContext::simulate_keystrokes` (`vendor/zed/crates/gpui/src/app/
+    /// test_context.rs:794`) - so a wrong keystroke spec in `default_key_bindings` (e.g. `cmd-p`,
+    /// which GPUI resolves to Super/Windows on Linux, never Ctrl) fails this test even though a
+    /// direct `dispatch_action` test would stay green. `secondary_p` tracks the same
+    /// `cfg!(target_os = "macos")` resolution `default_key_bindings` itself uses, rather than
+    /// hardcoding `ctrl-p`.
     #[gpui::test]
     fn secondary_keystroke_opens_the_palette_through_the_real_key_bindings(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
         let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         cx.update(|_window, cx| cx.bind_keys(crate::default_key_bindings()));
 
@@ -355,38 +335,30 @@ mod tab_strip_keybinding_tests {
     }
 
     #[gpui::test]
-    fn opening_the_palette_closes_an_already_open_plus_menu(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
-
-        app.update(cx, |app, cx| {
-            app.plus_menu_open = true;
-            cx.notify();
-        });
-        cx.dispatch_action(TogglePalette);
-
-        assert!(app.read_with(cx, |app, _| app.palette_open));
-        assert!(
-            !app.read_with(cx, |app, _| app.plus_menu_open),
-            "opening the palette should have closed the still-open plus menu"
-        );
-    }
-
-    #[gpui::test]
-    fn opening_settings_closes_an_already_open_plus_menu(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+    fn opening_the_palette_or_settings_closes_an_already_open_plus_menu(cx: &mut TestAppContext) {
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         app.update(cx, |app, cx| {
             app.plus_menu_open = true;
             cx.notify();
         });
         cx.dispatch_action(ToggleSettings);
-
         assert!(app.read_with(cx, |app, _| app.settings_open));
         assert!(
             !app.read_with(cx, |app, _| app.plus_menu_open),
             "opening Settings should have closed the still-open plus menu"
+        );
+
+        app.update(cx, |app, cx| {
+            app.plus_menu_open = true;
+            cx.notify();
+        });
+        cx.dispatch_action(TogglePalette);
+        assert!(app.read_with(cx, |app, _| app.palette_open));
+        assert!(
+            !app.read_with(cx, |app, _| app.plus_menu_open),
+            "and opening the palette should have closed it too"
         );
     }
 
@@ -394,8 +366,8 @@ mod tab_strip_keybinding_tests {
     fn ctrl_shift_t_spawns_a_real_shell_agent_through_the_real_key_bindings(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         bind_real_keys(cx);
 
         let agents_before = app.read_with(cx, |app, _| app.agents.iter().count());
@@ -426,8 +398,8 @@ mod tab_strip_keybinding_tests {
     fn secondary_shift_n_spawns_a_real_agent_through_the_real_key_bindings(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         bind_real_keys(cx);
 
         let agents_before = app.read_with(cx, |app, _| app.agents.iter().count());
@@ -455,8 +427,8 @@ mod tab_strip_keybinding_tests {
 
     #[gpui::test]
     fn ctrl_p_opens_the_palette_even_while_a_terminal_is_focused(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         bind_real_keys(cx);
 
         // Explicitly focus the initial shell agent - the real, concrete "a terminal pane
@@ -499,9 +471,9 @@ mod tab_strip_keybinding_tests {
 
     #[gpui::test]
     fn ctrl_p_still_works_after_ctrl_shift_t_with_a_file_tab_active(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
         std::fs::write(repo.path().join("a.txt"), "hello\n").expect("write a.txt");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         bind_real_keys(cx);
 
         app.update_in(cx, |app, window, cx| {
@@ -533,8 +505,8 @@ mod tab_strip_keybinding_tests {
 
     #[gpui::test]
     fn ctrl_p_still_works_after_closing_the_active_agent_tab(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         bind_real_keys(cx);
 
         let first_id = app.read_with(cx, |app, _| {
@@ -577,8 +549,8 @@ mod tab_strip_keybinding_tests {
 
     #[gpui::test]
     fn ctrl_p_still_works_after_archiving_the_active_agent(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         bind_real_keys(cx);
 
         let first_id = app.read_with(cx, |app, _| {
@@ -619,22 +591,6 @@ mod tab_strip_keybinding_tests {
         );
     }
 
-    fn git(dir: &std::path::Path, args: &[&str]) {
-        let output = std::process::Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {:?} failed in {:?}:\nstdout: {}\nstderr: {}",
-            args,
-            dir,
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
     #[gpui::test]
     fn bracket_advances_to_the_next_changed_file_through_the_real_key_bindings(
         cx: &mut TestAppContext,
@@ -643,19 +599,19 @@ mod tab_strip_keybinding_tests {
         // bare `]` would swallow a literal `]` typed into any focused terminal instead of
         // forwarding it to the pty. This opens a file first (`AdeApp::open_change_diff`) to
         // establish "diff"-context focus before simulating the keystroke.
-        let repo = tempfile::tempdir().expect("tempdir");
-        git(repo.path(), &["init", "-b", "main"]);
-        git(repo.path(), &["config", "user.email", "test@example.com"]);
-        git(repo.path(), &["config", "user.name", "Test User"]);
+        let repo = crate::test_support::temp_root();
+        test_support::git(repo.path(), &["init", "-b", "main"]);
+        test_support::git(repo.path(), &["config", "user.email", "test@example.com"]);
+        test_support::git(repo.path(), &["config", "user.name", "Test User"]);
         std::fs::write(repo.path().join("a.txt"), "1\n").expect("write a.txt");
         std::fs::write(repo.path().join("b.txt"), "1\n").expect("write b.txt");
-        git(repo.path(), &["add", "."]);
-        git(repo.path(), &["commit", "-m", "initial"]);
-        git(repo.path(), &["checkout", "-b", "feature"]);
+        test_support::git(repo.path(), &["add", "."]);
+        test_support::git(repo.path(), &["commit", "-m", "initial"]);
+        test_support::git(repo.path(), &["checkout", "-b", "feature"]);
         std::fs::write(repo.path().join("a.txt"), "1\nchanged\n").expect("rewrite a.txt");
         std::fs::write(repo.path().join("b.txt"), "1\nchanged\n").expect("rewrite b.txt");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
         bind_real_keys(cx);
 
@@ -690,17 +646,17 @@ mod tab_strip_keybinding_tests {
 
     #[gpui::test]
     fn bracket_does_not_fire_globally_while_a_terminal_is_focused(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        git(repo.path(), &["init", "-b", "main"]);
-        git(repo.path(), &["config", "user.email", "test@example.com"]);
-        git(repo.path(), &["config", "user.name", "Test User"]);
+        let repo = crate::test_support::temp_root();
+        test_support::git(repo.path(), &["init", "-b", "main"]);
+        test_support::git(repo.path(), &["config", "user.email", "test@example.com"]);
+        test_support::git(repo.path(), &["config", "user.name", "Test User"]);
         std::fs::write(repo.path().join("a.txt"), "1\n").expect("write a.txt");
-        git(repo.path(), &["add", "."]);
-        git(repo.path(), &["commit", "-m", "initial"]);
-        git(repo.path(), &["checkout", "-b", "feature"]);
+        test_support::git(repo.path(), &["add", "."]);
+        test_support::git(repo.path(), &["commit", "-m", "initial"]);
+        test_support::git(repo.path(), &["checkout", "-b", "feature"]);
         std::fs::write(repo.path().join("a.txt"), "1\nchanged\n").expect("rewrite a.txt");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
         bind_real_keys(cx);
 
@@ -730,8 +686,8 @@ mod tab_strip_keybinding_tests {
     fn secondary_3_jumps_to_the_third_real_agent_through_the_real_key_bindings(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         bind_real_keys(cx);
 
         // Tab 1 is `open_test_app`'s own startup shell. Four more, then retagged so the strip
@@ -792,8 +748,8 @@ mod tab_strip_keybinding_tests {
 
     #[gpui::test]
     fn jump_to_agent_at_activates_the_right_agent_by_position(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         let mut ids = vec![app.read_with(cx, |app, _| {
             app.agents.active_id().expect("the initial shell agent")
@@ -856,8 +812,8 @@ mod settings_focus_tests {
     fn toggle_settings_action_opens_then_real_escape_closes_it_and_focus_stays_live(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         cx.dispatch_action(ToggleSettings);
         assert!(
@@ -882,25 +838,18 @@ mod settings_focus_tests {
         );
     }
 
-    #[gpui::test]
-    fn toggle_settings_works_on_a_fresh_window_with_nothing_clicked_yet(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
-
-        cx.dispatch_action(ToggleSettings);
-
-        assert!(
-            app.read_with(cx, |app, _| app.settings_open),
-            "secondary-, on a completely fresh window (nothing clicked yet) should still open Settings"
-        );
-    }
-
+    /// With the old `"cmd-,"` binding, `Ctrl+,` was never recognized as matching any
+    /// `KeyBinding` (`"cmd"`/`"super"`/`"win"` only ever mean the platform modifier, never Ctrl,
+    /// on Linux - `vendor/zed/crates/gpui/src/platform/keystroke.rs`), so the keystroke fell
+    /// through to whatever text input had focus and got typed as a literal `,`. This test binds
+    /// `default_key_bindings()` and simulates the real keystroke, unlike every other test in
+    /// this module which dispatches `ToggleSettings` directly and so couldn't catch this.
     #[gpui::test]
     fn secondary_comma_keystroke_opens_settings_through_the_real_key_bindings(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.update(|_window, cx| cx.bind_keys(crate::default_key_bindings()));
 
         let secondary_comma = if cfg!(target_os = "macos") {
@@ -922,8 +871,8 @@ mod settings_focus_tests {
 
     #[gpui::test]
     fn closing_settings_leaves_open_agent_tabs_intact(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         let agents_before = app.read_with(cx, |app, _| app.agents.iter().count());
         let active_before = app.read_with(cx, |app, _| app.agents.active_id());
@@ -953,10 +902,15 @@ mod settings_focus_tests {
 
     #[gpui::test]
     fn settings_page_selection_persists_across_a_close_and_reopen(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         cx.dispatch_action(ToggleSettings);
+        assert_eq!(
+            app.read_with(cx, |app, _| app.settings_page),
+            SettingsPage::General,
+            "a fresh window opens Settings on General"
+        );
         app.update_in(cx, |app, window, cx| {
             app.select_settings_page(SettingsPage::Worktrees, window, cx);
         });
@@ -980,8 +934,8 @@ mod settings_focus_tests {
 
     #[gpui::test]
     fn open_settings_palette_command_leaves_real_focus_on_settings(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         cx.dispatch_action(TogglePalette);
         app.update_in(cx, |app, window, cx| {
@@ -1012,17 +966,19 @@ mod settings_focus_tests {
     }
 
     #[gpui::test]
-    fn opening_settings_populates_real_agent_rows_from_a_background_path_search(
+    fn opening_settings_populates_both_row_lists_from_a_background_path_search(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
-        assert!(
-            app.read_with(cx, |app, _| app.agent_rows.is_empty()),
-            "agent_rows should still be empty before Settings has ever been opened - nothing \
-             should eagerly run a $PATH search that's only ever shown on the Agents page"
-        );
+        app.read_with(cx, |app, _| {
+            assert!(
+                app.agent_rows.is_empty() && app.lsp_rows.is_empty(),
+                "neither list may be populated before Settings has ever been opened - nothing \
+                 should eagerly run a $PATH search that's only ever shown on those pages"
+            );
+        });
 
         cx.dispatch_action(ToggleSettings);
         cx.run_until_parked();
@@ -1041,45 +997,23 @@ mod settings_focus_tests {
                 "{kind:?} should have a real row after a real $PATH search"
             );
         }
-    }
 
-    #[gpui::test]
-    fn opening_settings_populates_real_lsp_rows_from_a_background_path_search(
-        cx: &mut TestAppContext,
-    ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
-
-        assert!(app.read_with(cx, |app, _| app.lsp_rows.is_empty()));
-
-        cx.dispatch_action(ToggleSettings);
-        cx.run_until_parked();
-
-        let rows = app.read_with(cx, |app, _| app.lsp_rows.clone());
+        let lsp_rows = app.read_with(cx, |app, _| app.lsp_rows.clone());
         let languages = settings::lsp_languages();
-        assert_eq!(rows.len(), languages.len());
+        assert_eq!(lsp_rows.len(), languages.len());
         for def in languages {
-            assert!(rows.iter().any(|row| row.language == def.language));
+            assert!(lsp_rows.iter().any(|row| row.language == def.language));
         }
     }
 
-    #[gpui::test]
-    fn settings_opens_to_general_by_default_on_a_fresh_window(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
-
-        cx.dispatch_action(ToggleSettings);
-
-        assert_eq!(
-            app.read_with(cx, |app, _| app.settings_page),
-            SettingsPage::General
-        );
-    }
-
+    /// Every page in `SettingsPage::ALL` must render without panicking. Running the test
+    /// executor to a parked state (`cx.run_until_parked`) is what actually exercises
+    /// `AdeApp::render_settings_content`'s per-page render, not just the state transition
+    /// `select_settings_page` performs.
     #[gpui::test]
     fn every_settings_page_renders_without_panicking(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         cx.dispatch_action(ToggleSettings);
         cx.run_until_parked();
@@ -1102,8 +1036,8 @@ mod settings_focus_tests {
     fn window_controls_style_change_updates_the_real_persisted_settings_field(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         assert_eq!(
             app.read_with(cx, |app, _| app.window_controls_style()),
@@ -1139,15 +1073,25 @@ mod code_focus_tests {
     fn open_test_app_with_a_plain_text_file(
         cx: &mut TestAppContext,
     ) -> (Entity<AdeApp>, &mut gpui::VisualTestContext, PathBuf) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
         let file_path = repo.path().join("notes.txt");
         std::fs::write(&file_path, "hello\n").expect("write notes.txt");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         (app, cx, file_path)
     }
 
+    /// Every window-level action must still reach its real handler once a plain `.txt` File
+    /// view is mounted. Without [`AdeApp::code_focus_handle`] tracking real focus there, these
+    /// dispatches silently fall back to the window's internal dispatch root (GPUI's own
+    /// `Window::focus_node_id_in_rendered_frame` falls back to `dispatch_tree.root_node_id()`
+    /// whenever the focused `FocusId` isn't found in the last rendered frame) instead of
+    /// reaching the handler at all.
+    ///
+    /// `GotoDefinition` is included even though a `.txt` file has no hover entry for it to act
+    /// on: `handle_goto_definition_action`'s early return with `hover == None` is harmless, and
+    /// what is under test is that dispatch reached the handler, not what it did once there.
     #[gpui::test]
-    fn toggle_settings_action_reaches_the_real_handler_with_a_file_view_open(
+    fn every_window_action_still_reaches_its_handler_with_a_file_view_open(
         cx: &mut TestAppContext,
     ) {
         let (app, cx, file_path) = open_test_app_with_a_plain_text_file(cx);
@@ -1162,53 +1106,14 @@ mod code_focus_tests {
         );
 
         cx.dispatch_action(ToggleSettings);
-        assert!(
-            app.read_with(cx, |app, _| app.settings_open),
-            "secondary-, must still reach handle_toggle_settings_action once a plain .txt File view is \
-             mounted - without AdeApp::code_focus_handle tracking real focus there, this dispatch \
-             would silently fall back to the window's internal dispatch root (GPUI's own \
-             `Window::focus_node_id_in_rendered_frame` falls back to `dispatch_tree.root_node_id\
-             ()` whenever the focused FocusId isn't found in the last rendered frame) instead of \
-             reaching this handler"
-        );
-    }
-
-    #[gpui::test]
-    fn toggle_palette_action_reaches_the_real_handler_with_a_file_view_open(
-        cx: &mut TestAppContext,
-    ) {
-        let (app, cx, file_path) = open_test_app_with_a_plain_text_file(cx);
-
-        app.update_in(cx, |app, window, cx| {
-            app.open_file_view(file_path.clone(), window, cx);
-        });
-        cx.run_until_parked();
+        assert!(app.read_with(cx, |app, _| app.settings_open));
 
         cx.dispatch_action(TogglePalette);
-        assert!(
-            app.read_with(cx, |app, _| app.palette_open),
-            "secondary-p must still reach handle_toggle_palette_action once a File view is mounted, \
-             for exactly the same real reason secondary-, must"
-        );
-    }
-
-    #[gpui::test]
-    fn goto_definition_action_reaches_the_real_handler_with_a_file_view_open(
-        cx: &mut TestAppContext,
-    ) {
-        let (app, cx, file_path) = open_test_app_with_a_plain_text_file(cx);
-
-        app.update_in(cx, |app, window, cx| {
-            app.open_file_view(file_path.clone(), window, cx);
-        });
-        cx.run_until_parked();
+        assert!(app.read_with(cx, |app, _| app.palette_open));
 
         assert_eq!(app.read_with(cx, |app, _| app.hover.clone()), None);
         cx.dispatch_action(GotoDefinition);
         cx.run_until_parked();
-        // `handle_goto_definition_action` only has a harmless early return with `hover == None`
-        // (a .txt file has no hover entry) - what's under test is that dispatch reached the
-        // handler at all with a File view open, not what it did once there.
         assert_eq!(app.read_with(cx, |app, _| app.hover.clone()), None);
     }
 
@@ -1281,10 +1186,10 @@ mod text_undo_scoping_tests {
 
     #[gpui::test]
     fn secondary_z_with_a_terminal_focused_does_not_reach_text_undo(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
         let file_path = repo.path().join("notes.txt");
         std::fs::write(&file_path, "hello\n").expect("write notes.txt");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         bind_real_keys(cx);
         let relative = PathBuf::from("notes.txt");
@@ -1332,10 +1237,10 @@ mod text_undo_scoping_tests {
     fn secondary_z_with_the_palette_open_undoes_the_query_not_the_file_editor_behind_it(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
         let file_path = repo.path().join("notes.txt");
         std::fs::write(&file_path, "hello\n").expect("write notes.txt");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         bind_real_keys(cx);
         let relative = PathBuf::from("notes.txt");
@@ -1383,8 +1288,8 @@ mod text_undo_scoping_tests {
 
     #[gpui::test]
     fn reopening_the_palette_starts_a_genuinely_fresh_history(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         bind_real_keys(cx);
 
         app.update_in(cx, |app, window, cx| app.open_palette(window, cx));
@@ -1405,8 +1310,8 @@ mod text_undo_scoping_tests {
 
     #[gpui::test]
     fn secondary_z_in_the_settings_keybindings_filter_undoes_the_filter(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         bind_real_keys(cx);
 
         app.update_in(cx, |app, window, cx| {
@@ -1441,8 +1346,8 @@ mod text_undo_scoping_tests {
     fn secondary_z_in_the_rail_filter_undoes_it_including_a_real_escape_clear(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         bind_real_keys(cx);
 
         app.update_in(cx, |app, window, cx| {
@@ -1480,8 +1385,8 @@ mod text_undo_scoping_tests {
     fn secondary_z_in_the_new_file_prompt_undoes_the_name_and_a_fresh_prompt_has_no_history(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         bind_real_keys(cx);
 
         app.update_in(cx, |app, window, cx| {
@@ -1546,11 +1451,10 @@ mod palette_result_focus_tests {
     use crate::palette::state as palette;
     use gpui::{Entity, TestAppContext};
     use std::fs;
-    use tempfile::TempDir;
 
     /// `src/main.rs` (the file every test opens) plus a sibling, so the palette's own filtering
     /// has something to actually discriminate between.
-    fn seed(repo: &TempDir) {
+    fn seed(repo: &crate::test_support::TempRoot) {
         fs::create_dir_all(repo.path().join("src")).expect("mkdir");
         fs::write(repo.path().join("src/main.rs"), "fn main() {}\n").expect("write");
         fs::write(repo.path().join("src/other.rs"), "pub fn o() {}\n").expect("write");
@@ -1558,10 +1462,14 @@ mod palette_result_focus_tests {
 
     fn open_seeded(
         cx: &mut TestAppContext,
-    ) -> (TempDir, Entity<AdeApp>, &mut gpui::VisualTestContext) {
-        let repo = TempDir::new().expect("tempdir");
+    ) -> (
+        crate::test_support::TempRoot,
+        Entity<AdeApp>,
+        &mut gpui::VisualTestContext,
+    ) {
+        let repo = crate::test_support::temp_root();
         seed(&repo);
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.update(|_window, cx| cx.bind_keys(crate::default_key_bindings()));
         cx.run_until_parked();
         (repo, app, cx)
@@ -1940,8 +1848,8 @@ mod palette_result_focus_tests {
 
     #[gpui::test]
     fn every_palette_command_is_findable_by_its_own_label(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         for command in palette::PaletteCommand::ALL {
             if matches!(
@@ -2005,13 +1913,13 @@ mod tabless_window_keybinding_tests {
     ) -> (
         Entity<AdeApp>,
         &mut gpui::VisualTestContext,
-        tempfile::TempDir,
+        crate::test_support::TempRoot,
         PathBuf,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
         let file_path = repo.path().join("a.txt");
         std::fs::write(&file_path, "hello\n").expect("write a.txt");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
         (app, cx, repo, file_path)
     }

--- a/crates/app/src/root/layout.rs
+++ b/crates/app/src/root/layout.rs
@@ -40,43 +40,64 @@ pub fn panel_width_for_cursor(body_right: f32, cursor_x: f32) -> f32 {
 mod tests {
     use super::*;
 
+    /// The rail's width is how far right of the body's *own* left edge the cursor is, clamped to
+    /// its documented range. The body deliberately does not start at window x=0 in the middle
+    /// case, so a dropped `body_left` term cannot pass.
     #[test]
-    fn rail_width_is_the_cursors_distance_from_the_bodys_left_edge() {
-        assert_eq!(rail_width_for_cursor(0.0, 300.0), 300.0);
+    fn rail_width_measures_from_the_bodys_left_edge_and_clamps_to_its_range() {
+        for (body_left, cursor_x, expected, why) in [
+            (
+                0.0,
+                300.0,
+                300.0,
+                "the plain distance from the body's left edge",
+            ),
+            (
+                50.0,
+                350.0,
+                300.0,
+                "measured from the body, not the window origin",
+            ),
+            (
+                0.0,
+                10_000.0,
+                RAIL_MAX,
+                "never wider than its documented maximum",
+            ),
+            (
+                0.0,
+                -10_000.0,
+                RAIL_MIN,
+                "never narrower than its documented minimum",
+            ),
+        ] {
+            assert_eq!(
+                rail_width_for_cursor(body_left, cursor_x),
+                expected,
+                "{why}"
+            );
+        }
     }
 
+    /// The panel's handle sits on its *left* edge and the panel is flush against the body's right
+    /// edge, so it grows as the cursor moves left - the mirror image of the rail's measurement,
+    /// clamped to its own documented range.
     #[test]
-    fn rail_never_exceeds_its_documented_maximum() {
-        assert_eq!(rail_width_for_cursor(0.0, 10_000.0), RAIL_MAX);
-    }
-
-    #[test]
-    fn rail_never_drops_below_its_documented_minimum() {
-        assert_eq!(rail_width_for_cursor(0.0, -10_000.0), RAIL_MIN);
-    }
-
-    #[test]
-    fn rail_width_still_measures_from_a_body_thats_not_flush_with_the_window_origin() {
-        // The body (the div `rail_width_for_cursor` is really measuring against) doesn't
-        // itself start at window x=0 - confirm the offset is subtracted, not assumed away.
-        assert_eq!(rail_width_for_cursor(50.0, 350.0), 300.0);
-    }
-
-    #[test]
-    fn panel_width_is_the_cursors_distance_from_the_bodys_right_edge() {
-        // The panel's handle sits on its *left* edge, and the panel itself is flush against
-        // the body's right edge, so the panel grows as the cursor moves left (away from that
-        // right edge) - the mirror image of the rail's left-edge measurement.
-        assert_eq!(panel_width_for_cursor(1200.0, 900.0), 300.0);
-    }
-
-    #[test]
-    fn panel_never_exceeds_its_maximum() {
-        assert_eq!(panel_width_for_cursor(1200.0, -10_000.0), PANEL_MAX);
-    }
-
-    #[test]
-    fn panel_never_drops_below_its_documented_floor() {
-        assert_eq!(panel_width_for_cursor(1200.0, 10_000.0), PANEL_MIN);
+    fn panel_width_measures_back_from_the_bodys_right_edge_and_clamps_to_its_range() {
+        for (cursor_x, expected, why) in [
+            (
+                900.0,
+                300.0,
+                "the plain distance back from the body's right edge",
+            ),
+            (-10_000.0, PANEL_MAX, "never wider than its maximum"),
+            (
+                10_000.0,
+                PANEL_MIN,
+                "never narrower than its documented floor",
+            ),
+        ] {
+            assert_eq!(panel_width_for_cursor(1200.0, cursor_x), expected, "{why}");
+        }
     }
 }

--- a/crates/app/src/root/menu_commands.rs
+++ b/crates/app/src/root/menu_commands.rs
@@ -421,12 +421,12 @@ impl AdeApp {
 #[cfg(test)]
 mod menu_command_tests {
     use super::*;
-    use crate::root::focus::palette_focus_tests::open_test_app;
+    use crate::test_support::open_test_app;
     use gpui::TestAppContext;
 
     #[gpui::test]
     fn menu_command_enabled_save_tracks_the_real_active_edit_buffer(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
         let file_path = repo.path().join("notes.txt");
         std::fs::write(&file_path, "hello\n").expect("write notes.txt");
         let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
@@ -449,7 +449,7 @@ mod menu_command_tests {
 
     #[gpui::test]
     fn menu_command_enabled_zoom_requires_a_real_code_surface(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
         let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
 
         assert!(
@@ -460,7 +460,7 @@ mod menu_command_tests {
 
     #[gpui::test]
     fn menu_command_enabled_archive_agent_tracks_the_real_active_agent(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
         let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
@@ -492,7 +492,7 @@ mod menu_command_tests {
 
     #[gpui::test]
     fn dispatching_zoom_in_action_reaches_the_real_zoom_in_handler(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
         let file_path = repo.path().join("notes.rs");
         std::fs::write(&file_path, "fn main() {}\n").expect("write notes.rs");
         let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
@@ -518,7 +518,7 @@ mod menu_command_tests {
 
     #[gpui::test]
     fn zoom_in_action_is_unavailable_with_no_code_surface_showing(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
         let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         let _ = app;
 

--- a/crates/app/src/root/menus.rs
+++ b/crates/app/src/root/menus.rs
@@ -181,7 +181,7 @@ impl AdeApp {
 #[cfg(test)]
 mod menu_surface_tests {
     use super::*;
-    use crate::root::focus::palette_focus_tests::open_test_app;
+    use crate::test_support::open_test_app;
     use gpui::TestAppContext;
 
     /// Opens every one of them at once by writing their real state fields directly - the state
@@ -223,7 +223,7 @@ mod menu_surface_tests {
 
     #[gpui::test]
     fn closing_all_menu_surfaces_really_closes_every_one_of_them(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
         let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
 
         app.update(cx, |app, cx| {
@@ -256,7 +256,7 @@ mod menu_surface_tests {
 
     #[gpui::test]
     fn opening_any_one_surface_closes_all_the_others(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
         let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
 
         for keep in MenuSurface::ALL {
@@ -287,7 +287,7 @@ mod menu_surface_tests {
 
     #[gpui::test]
     fn the_window_losing_focus_really_closes_every_open_menu(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
         let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
 
         // `deactivate_window` is a no-op unless this window really is the platform's active one,

--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -3352,8 +3352,8 @@ mod settings_persist_tests {
     fn a_later_edit_queued_while_an_earlier_one_is_delayed_is_never_overwritten_by_it(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let settings_dir = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
+        let settings_dir = crate::test_support::temp_root();
         let settings_path = settings_dir.path().join("settings.toml");
 
         let (app, cx) = open_test_app_with_real_settings_path(
@@ -3415,8 +3415,8 @@ mod settings_persist_tests {
     fn a_burst_of_edits_with_decreasing_delays_converges_on_the_final_value(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let settings_dir = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
+        let settings_dir = crate::test_support::temp_root();
         let settings_path = settings_dir.path().join("settings.toml");
 
         let (app, cx) = open_test_app_with_real_settings_path(
@@ -3485,17 +3485,6 @@ mod repo_list_tests {
     /// in this module use) has no worktrees `wt_core::list_worktrees_porcelain` can report at
     /// all, which is fine for tests about agent persistence but not for one that needs a real
     /// main-worktree row to select.
-    fn init_repo() -> tempfile::TempDir {
-        let dir = tempfile::tempdir().expect("tempdir");
-        git(dir.path(), &["init", "-b", "main"]);
-        git(dir.path(), &["config", "user.email", "test@example.com"]);
-        git(dir.path(), &["config", "user.name", "Test User"]);
-        std::fs::write(dir.path().join("README.md"), "hello\n").expect("write");
-        git(dir.path(), &["add", "README.md"]);
-        git(dir.path(), &["commit", "-m", "initial"]);
-        dir
-    }
-
     fn open_test_app_with_real_settings_path(
         cx: &mut TestAppContext,
         repo_path: PathBuf,
@@ -3515,8 +3504,8 @@ mod repo_list_tests {
 
     #[gpui::test]
     fn a_fresh_window_starts_with_exactly_one_focused_repo(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = focus::palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         app.read_with(cx, |app, _| {
             assert_eq!(app.repos.len(), 1);
@@ -3528,9 +3517,9 @@ mod repo_list_tests {
 
     #[gpui::test]
     fn add_repo_appends_a_new_entry_without_changing_focus(cx: &mut TestAppContext) {
-        let repo_a = tempfile::tempdir().expect("tempdir");
-        let repo_b = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = focus::palette_focus_tests::open_test_app(cx, repo_a.path().to_path_buf());
+        let repo_a = crate::test_support::temp_root();
+        let repo_b = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo_a.path().to_path_buf());
         let focused_before = app.read_with(cx, |app, _| app.focused_repo_path());
 
         app.update(cx, |app, cx| {
@@ -3550,8 +3539,8 @@ mod repo_list_tests {
 
     #[gpui::test]
     fn add_repo_is_idempotent_for_the_same_path(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = focus::palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         let (first_id, second_id) = app.update(cx, |app, cx| {
             let first = app.repos[0].id;
@@ -3574,9 +3563,9 @@ mod repo_list_tests {
 
     #[gpui::test]
     fn focus_repo_moves_focus_to_a_known_repo(cx: &mut TestAppContext) {
-        let repo_a = tempfile::tempdir().expect("tempdir");
-        let repo_b = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = focus::palette_focus_tests::open_test_app(cx, repo_a.path().to_path_buf());
+        let repo_a = crate::test_support::temp_root();
+        let repo_b = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo_a.path().to_path_buf());
 
         let repo_b_id = app.update(cx, |app, cx| app.add_repo(repo_b.path().to_path_buf(), cx));
         app.update(cx, |app, cx| app.focus_repo(repo_b_id, cx));
@@ -3588,8 +3577,8 @@ mod repo_list_tests {
 
     #[gpui::test]
     fn focus_repo_with_an_unknown_id_is_a_no_op(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = focus::palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         let focused_before = app.read_with(cx, |app, _| app.focused_repo_path());
 
         app.update(cx, |app, cx| app.focus_repo(RepoId(u64::MAX), cx));
@@ -3601,9 +3590,9 @@ mod repo_list_tests {
 
     #[gpui::test]
     fn adding_a_repo_persists_to_a_real_repos_toml(cx: &mut TestAppContext) {
-        let repo_a = tempfile::tempdir().expect("tempdir");
-        let repo_b = tempfile::tempdir().expect("tempdir");
-        let settings_dir = tempfile::tempdir().expect("tempdir");
+        let repo_a = crate::test_support::temp_root();
+        let repo_b = crate::test_support::temp_root();
+        let settings_dir = crate::test_support::temp_root();
         let settings_path = settings_dir.path().join("settings.toml");
 
         let (app, cx) = open_test_app_with_real_settings_path(
@@ -3631,9 +3620,9 @@ mod repo_list_tests {
     fn opening_against_one_repo_does_not_erase_another_instances_already_persisted_repo(
         cx: &mut TestAppContext,
     ) {
-        let repo_a = tempfile::tempdir().expect("tempdir");
-        let repo_b = tempfile::tempdir().expect("tempdir");
-        let settings_dir = tempfile::tempdir().expect("tempdir");
+        let repo_a = crate::test_support::temp_root();
+        let repo_b = crate::test_support::temp_root();
+        let settings_dir = crate::test_support::temp_root();
         let settings_path = settings_dir.path().join("settings.toml");
 
         let repo_state_path = repo::repo_state_path_for(&settings_path);
@@ -3671,7 +3660,7 @@ mod repo_list_tests {
 
     #[gpui::test]
     fn no_cli_arg_and_nothing_persisted_is_a_genuinely_empty_window(cx: &mut TestAppContext) {
-        let settings_dir = tempfile::tempdir().expect("tempdir");
+        let settings_dir = crate::test_support::temp_root();
         let settings_path = settings_dir.path().join("settings.toml");
 
         let (app, _cx) = cx.add_window_view(|window, cx| {
@@ -3700,8 +3689,8 @@ mod repo_list_tests {
     fn a_fresh_launch_with_no_cli_arg_reopens_the_remembered_last_focused_repo(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let settings_dir = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
+        let settings_dir = crate::test_support::temp_root();
         let settings_path = settings_dir.path().join("settings.toml");
 
         // "Launch 1": a real CLI-argument launch against `repo`, which focuses (and so persists)
@@ -3746,9 +3735,9 @@ mod repo_list_tests {
     fn a_remembered_repo_that_no_longer_exists_falls_back_to_a_genuinely_empty_window(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
         let repo_path = repo.path().to_path_buf();
-        let settings_dir = tempfile::tempdir().expect("tempdir");
+        let settings_dir = crate::test_support::temp_root();
         let settings_path = settings_dir.path().join("settings.toml");
 
         let (_first, cx) =
@@ -3784,8 +3773,8 @@ mod repo_list_tests {
     fn use_remembered_repo_false_stays_empty_even_with_a_real_remembered_repo(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let settings_dir = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
+        let settings_dir = crate::test_support::temp_root();
         let settings_path = settings_dir.path().join("settings.toml");
 
         let (_first, cx) = open_test_app_with_real_settings_path(
@@ -3821,9 +3810,9 @@ mod repo_list_tests {
     fn open_repo_in_current_window_focuses_and_reloads_a_real_repo_from_empty(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
         std::fs::write(repo.path().join("a.txt"), "hello\n").expect("write");
-        let settings_dir = tempfile::tempdir().expect("tempdir");
+        let settings_dir = crate::test_support::temp_root();
         let settings_path = settings_dir.path().join("settings.toml");
 
         let (app, cx) = cx.add_window_view(|window, cx| {
@@ -3862,11 +3851,11 @@ mod repo_list_tests {
     fn open_repo_in_current_window_clears_stale_ui_state_from_the_previous_repo(
         cx: &mut TestAppContext,
     ) {
-        let repo_a = tempfile::tempdir().expect("tempdir");
-        let repo_b = tempfile::tempdir().expect("tempdir");
+        let repo_a = crate::test_support::temp_root();
+        let repo_b = crate::test_support::temp_root();
         std::fs::write(repo_b.path().join("y.txt"), "b\n").expect("write");
 
-        let (app, cx) = focus::palette_focus_tests::open_test_app(cx, repo_a.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo_a.path().to_path_buf());
         cx.run_until_parked();
 
         // Arm several pieces of real per-repo UI state against repo A - the same kinds of state
@@ -3905,23 +3894,23 @@ mod repo_list_tests {
     fn switching_away_from_a_zero_linked_worktree_repo_and_back_keeps_its_worktree_row(
         cx: &mut TestAppContext,
     ) {
-        let repo_a = tempfile::tempdir().expect("tempdir");
-        git(repo_a.path(), &["init", "-b", "main"]);
-        git(repo_a.path(), &["config", "user.email", "test@example.com"]);
-        git(repo_a.path(), &["config", "user.name", "Test User"]);
+        let repo_a = crate::test_support::temp_root();
+        test_support::git(repo_a.path(), &["init", "-b", "main"]);
+        test_support::git(repo_a.path(), &["config", "user.email", "test@example.com"]);
+        test_support::git(repo_a.path(), &["config", "user.name", "Test User"]);
         std::fs::write(repo_a.path().join("a.txt"), "hello\n").expect("write");
-        git(repo_a.path(), &["add", "a.txt"]);
-        git(repo_a.path(), &["commit", "-m", "init"]);
+        test_support::git(repo_a.path(), &["add", "a.txt"]);
+        test_support::git(repo_a.path(), &["commit", "-m", "init"]);
 
-        let repo_b = tempfile::tempdir().expect("tempdir");
-        git(repo_b.path(), &["init", "-b", "main"]);
-        git(repo_b.path(), &["config", "user.email", "test@example.com"]);
-        git(repo_b.path(), &["config", "user.name", "Test User"]);
+        let repo_b = crate::test_support::temp_root();
+        test_support::git(repo_b.path(), &["init", "-b", "main"]);
+        test_support::git(repo_b.path(), &["config", "user.email", "test@example.com"]);
+        test_support::git(repo_b.path(), &["config", "user.name", "Test User"]);
         std::fs::write(repo_b.path().join("b.txt"), "hello\n").expect("write");
-        git(repo_b.path(), &["add", "b.txt"]);
-        git(repo_b.path(), &["commit", "-m", "init"]);
+        test_support::git(repo_b.path(), &["add", "b.txt"]);
+        test_support::git(repo_b.path(), &["commit", "-m", "init"]);
 
-        let (app, cx) = focus::palette_focus_tests::open_test_app(cx, repo_a.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo_a.path().to_path_buf());
         cx.run_until_parked();
 
         app.read_with(cx, |app, _| {
@@ -3971,29 +3960,21 @@ mod repo_list_tests {
         });
     }
 
-    fn git(dir: &std::path::Path, args: &[&str]) {
-        let output = std::process::Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {:?} failed in {:?}:\nstdout: {}\nstderr: {}",
-            args,
-            dir,
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
+    /// Critical fix (independent audit): the original `open_repo_in_current_window` never
+    /// (re)started the real status-polling loop or the worktree filesystem watcher - a window
+    /// that starts empty and only later opens a folder never got either at all. `repo` is a real
+    /// `git init`-ed directory, not a bare `tempfile::tempdir()`: `spawn_worktree_watcher` returns
+    /// `None` for a path that isn't inside a real git repository at all
+    /// (`wt_core::git_common_dir` failing), so a bare tempdir would make this test pass "by
+    /// accident" - `_worktree_watcher` would read `None` regardless of whether the real fix ever
+    /// ran, proving nothing about the watcher half of the fix.
     #[gpui::test]
     fn open_repo_in_current_window_starts_status_polling_and_worktree_watch(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        git(repo.path(), &["init", "-b", "main"]);
-        let settings_dir = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
+        test_support::git(repo.path(), &["init", "-b", "main"]);
+        let settings_dir = crate::test_support::temp_root();
         let settings_path = settings_dir.path().join("settings.toml");
 
         let (app, cx) = cx.add_window_view(|window, cx| {
@@ -4044,11 +4025,11 @@ mod repo_list_tests {
     fn open_repo_in_current_window_rebinds_the_worktree_watcher_to_the_new_repo(
         cx: &mut TestAppContext,
     ) {
-        let repo_a = tempfile::tempdir().expect("tempdir");
-        git(repo_a.path(), &["init", "-b", "main"]);
-        let repo_b = tempfile::tempdir().expect("tempdir");
+        let repo_a = crate::test_support::temp_root();
+        test_support::git(repo_a.path(), &["init", "-b", "main"]);
+        let repo_b = crate::test_support::temp_root();
 
-        let (app, cx) = focus::palette_focus_tests::open_test_app(cx, repo_a.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo_a.path().to_path_buf());
         cx.run_until_parked();
         app.read_with(cx, |app, _| {
             assert!(
@@ -4077,10 +4058,10 @@ mod repo_list_tests {
     fn open_repo_in_current_window_leaves_the_previous_repos_agents_running(
         cx: &mut TestAppContext,
     ) {
-        let repo_a = tempfile::tempdir().expect("tempdir");
-        let repo_b = tempfile::tempdir().expect("tempdir");
+        let repo_a = crate::test_support::temp_root();
+        let repo_b = crate::test_support::temp_root();
 
-        let (app, cx) = focus::palette_focus_tests::open_test_app(cx, repo_a.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo_a.path().to_path_buf());
         cx.run_until_parked();
         let repo_a_agent_id = app.read_with(cx, |app, _| {
             assert_eq!(
@@ -4160,12 +4141,26 @@ mod repo_list_tests {
         });
     }
 
+    /// The rail-native mirror of
+    /// [`open_repo_in_current_window_leaves_the_previous_repos_agents_running`] just above:
+    /// [`AdeApp::checkout_repo_from_rail`] shares the identical real cross-repo agent persistence
+    /// contract, not a partial or weaker version of it. Proves two real agents belonging to repo
+    /// A (its initial shell plus a spawned Claude session) are both still genuinely running -
+    /// still present in [`crate::work_surface::agents::Agents`]'s own list, real PTY processes
+    /// and all - after checking out repo B from the rail, the same "really alive, not leaked or
+    /// killed" guarantee the `open_repo_in_current_window` mirror test proves via the identical
+    /// technique (asserting against the live agent list and each one's own `TerminalPane::
+    /// is_running`).
+    // Asserts `TerminalPane::is_running` on a spawned `claude` CLI, so it needs that binary to
+    // exist: without it the PTY child exits at once and the persistence being proven here cannot
+    // be observed at all. The `external` tier.
+    #[ignore = "external: claude; see docs/testing.md"]
     #[gpui::test]
     fn checkout_repo_from_rail_leaves_the_previous_repos_agents_running(cx: &mut TestAppContext) {
-        let repo_a = tempfile::tempdir().expect("tempdir");
-        let repo_b = tempfile::tempdir().expect("tempdir");
+        let repo_a = crate::test_support::temp_root();
+        let repo_b = crate::test_support::temp_root();
 
-        let (app, cx) = focus::palette_focus_tests::open_test_app(cx, repo_a.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo_a.path().to_path_buf());
         cx.run_until_parked();
 
         let claude_agent_id = app.update_in(cx, |app, window, cx| {
@@ -4244,10 +4239,10 @@ mod repo_list_tests {
     fn checking_out_a_repo_from_the_rail_clears_the_centre_pane_instead_of_reactivating(
         cx: &mut TestAppContext,
     ) {
-        let repo_a = tempfile::tempdir().expect("tempdir");
-        let repo_b = tempfile::tempdir().expect("tempdir");
+        let repo_a = crate::test_support::temp_root();
+        let repo_b = crate::test_support::temp_root();
 
-        let (app, cx) = focus::palette_focus_tests::open_test_app(cx, repo_a.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo_a.path().to_path_buf());
         cx.run_until_parked();
 
         let repo_b_id = app.update(cx, |app, cx| app.add_repo(repo_b.path().to_path_buf(), cx));
@@ -4327,10 +4322,10 @@ mod repo_list_tests {
     fn checking_out_a_repo_from_the_rail_never_selects_a_worktree_on_its_own(
         cx: &mut TestAppContext,
     ) {
-        let repo_a = init_repo();
-        let repo_b = init_repo();
+        let repo_a = crate::test_support::temp_repo();
+        let repo_b = crate::test_support::temp_repo();
 
-        let (app, cx) = focus::palette_focus_tests::open_test_app(cx, repo_a.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo_a.path().to_path_buf());
         cx.run_until_parked();
 
         let repo_b_id = app.update(cx, |app, cx| app.add_repo(repo_b.path().to_path_buf(), cx));
@@ -4365,10 +4360,10 @@ mod repo_list_tests {
     fn checking_out_a_repo_from_the_rail_never_shows_the_previous_repos_worktrees_even_briefly(
         cx: &mut TestAppContext,
     ) {
-        let repo_a = init_repo();
-        let repo_b = init_repo();
+        let repo_a = crate::test_support::temp_repo();
+        let repo_b = crate::test_support::temp_repo();
 
-        let (app, cx) = focus::palette_focus_tests::open_test_app(cx, repo_a.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo_a.path().to_path_buf());
         cx.run_until_parked();
 
         let repo_b_id = app.update(cx, |app, cx| app.add_repo(repo_b.path().to_path_buf(), cx));
@@ -4398,8 +4393,8 @@ mod repo_list_tests {
     fn open_repo_in_current_window_forgets_a_dangling_empty_state_focus_target(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let settings_dir = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
+        let settings_dir = crate::test_support::temp_root();
         let settings_path = settings_dir.path().join("settings.toml");
 
         let (app, cx) = cx.add_window_view(|window, cx| {
@@ -4441,8 +4436,8 @@ mod repo_list_tests {
 
     #[gpui::test]
     fn new_agent_and_new_agent_pane_are_no_ops_with_no_focused_repo(cx: &mut TestAppContext) {
-        let other_repo = tempfile::tempdir().expect("tempdir");
-        let settings_dir = tempfile::tempdir().expect("tempdir");
+        let other_repo = crate::test_support::temp_root();
+        let settings_dir = crate::test_support::temp_root();
         let settings_path = settings_dir.path().join("settings.toml");
 
         // A real *other* repo is known to this process (persisted from a previous focus) - the

--- a/crates/app/src/root/new_file.rs
+++ b/crates/app/src/root/new_file.rs
@@ -444,7 +444,6 @@ impl AdeApp {
 
 #[cfg(test)]
 mod tests {
-    use crate::root::focus::palette_focus_tests;
     use gpui::TestAppContext;
     use std::time::Instant;
 
@@ -452,9 +451,9 @@ mod tests {
     fn cancelling_new_file_while_a_file_tab_is_open_does_not_leave_focus_dangling(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
         std::fs::write(repo.path().join("a.txt"), "hello\n").expect("write a.txt");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.update(|_window, cx| cx.bind_keys(crate::default_key_bindings()));
 
         app.update_in(cx, |app, window, cx| {
@@ -481,8 +480,8 @@ mod tests {
     fn cancelling_new_file_with_no_file_tab_and_no_active_agent_does_not_leave_focus_dangling(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.update(|_window, cx| cx.bind_keys(crate::default_key_bindings()));
 
         let initial_id = app.read_with(cx, |app, _| {
@@ -520,8 +519,8 @@ mod tests {
     fn creating_a_new_file_writes_a_real_empty_file_with_no_false_conflict(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         app.update_in(cx, |app, window, cx| {
             app.start_new_file(repo.path().to_path_buf(), window, cx);
@@ -566,9 +565,9 @@ mod tests {
 
     #[gpui::test]
     fn creating_a_file_that_already_exists_is_refused_with_a_real_error(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
         std::fs::write(repo.path().join("existing.txt"), "already here").expect("seed file");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         app.update_in(cx, |app, window, cx| {
             app.start_new_file(repo.path().to_path_buf(), window, cx);
@@ -600,8 +599,8 @@ mod tests {
 
     #[gpui::test]
     fn escape_cancels_the_new_file_prompt_without_touching_disk(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         app.update_in(cx, |app, window, cx| {
             app.start_new_file(repo.path().to_path_buf(), window, cx);
@@ -629,15 +628,14 @@ mod tests {
 /// measured-bounds technique.
 #[cfg(test)]
 mod new_file_caret_tests {
-    use crate::root::focus::palette_focus_tests;
     use gpui::TestAppContext;
 
     #[gpui::test]
     fn caret_sits_before_the_placeholder_when_empty_and_after_the_text_once_typed(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         app.update_in(cx, |app, window, cx| {
             app.start_new_file(repo.path().to_path_buf(), window, cx);
@@ -698,8 +696,8 @@ mod new_file_caret_tests {
 
     #[gpui::test]
     fn blurring_the_new_file_prompt_stops_the_real_shared_blink_loop(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         // `on_focus`/`on_blur` listeners (`AdeApp::wire_caret_blink`'s own mechanism) only
         // fire while GPUI considers the window itself "active" - a real, freshly opened test
         // window starts out not active at all, so this is a real, necessary precondition, not

--- a/crates/app/src/root/scrollbar_geometry.rs
+++ b/crates/app/src/root/scrollbar_geometry.rs
@@ -65,105 +65,112 @@ pub fn offset_for_pointer(viewport: f32, max_offset: f32, track_start: f32, poin
 mod tests {
     use super::*;
 
+    /// The proportional relationship, its floor, and its cap, in one table: the thumb is the
+    /// visible fraction of the whole document, never shorter than [`MIN_THUMB_LENGTH`], and never
+    /// longer than the viewport it lives in.
     #[test]
-    fn thumb_fills_the_track_when_content_fits_without_scrolling() {
-        assert_eq!(thumb_length(400.0, 0.0), 400.0);
+    fn thumb_length_is_the_visible_fraction_floored_and_capped() {
+        for (viewport, max_offset, expected, why) in [
+            (
+                400.0,
+                0.0,
+                400.0,
+                "content that fits without scrolling fills the track",
+            ),
+            (
+                400.0,
+                1200.0,
+                100.0,
+                "400 visible of 1600 total is a quarter of the track",
+            ),
+            (
+                400.0,
+                100_000.0,
+                MIN_THUMB_LENGTH,
+                "an enormous document would compute a sub-pixel thumb without the floor",
+            ),
+            (
+                10.0,
+                5.0,
+                10.0,
+                "and the floor never pushes past the viewport itself",
+            ),
+        ] {
+            assert_eq!(thumb_length(viewport, max_offset), expected, "{why}");
+        }
     }
 
+    /// The thumb travels the whole track and stops at both ends - including for a stale or
+    /// overshot `scrolled` value (e.g. a frame where the content just shrank), the same real bug
+    /// class `list_example.rs`'s own `bug_detected` assertion exists to catch.
     #[test]
-    fn thumb_shrinks_proportionally_to_how_much_of_the_document_is_visible() {
-        // Viewport 400, document 1600 total (400 visible + 1200 more to scroll) -> the visible
-        // fraction is 1/4, so the thumb should be 1/4 of the 400px track (100px) - well above the
-        // floor, so the floor doesn't mask the proportional math here.
-        assert_eq!(thumb_length(400.0, 1200.0), 100.0);
+    fn thumb_position_spans_the_track_and_clamps_at_both_ends() {
+        let (viewport, max_offset) = (400.0, 1200.0);
+        let track = viewport - thumb_length(viewport, max_offset);
+
+        for (scrolled, expected, why) in [
+            (0.0, 0.0, "unscrolled sits at the track top"),
+            (max_offset, track, "fully scrolled sits at the track bottom"),
+            (
+                -50.0,
+                0.0,
+                "a negative offset must not send the thumb off-track",
+            ),
+            (5_000.0, track, "and neither must an overshot one"),
+        ] {
+            assert_eq!(
+                thumb_position(viewport, max_offset, scrolled),
+                expected,
+                "{why}"
+            );
+        }
+        assert_eq!(
+            thumb_position(400.0, 0.0, 0.0),
+            0.0,
+            "an unscrollable region has no meaningful thumb position"
+        );
     }
 
+    /// A click centers the thumb under the pointer and clamps to the track's own ends - measured
+    /// from a `track_start` that is deliberately not the window origin, so a dropped
+    /// `track_start` term cannot pass.
     #[test]
-    fn thumb_never_shrinks_below_the_documented_floor() {
-        // An enormous document (100,000px more to scroll) against a 400px viewport would compute
-        // a sub-pixel raw thumb length without the floor.
-        assert_eq!(thumb_length(400.0, 100_000.0), MIN_THUMB_LENGTH);
-    }
-
-    #[test]
-    fn thumb_never_exceeds_the_viewport_even_for_a_viewport_smaller_than_the_floor() {
-        assert_eq!(thumb_length(10.0, 5.0), 10.0);
-    }
-
-    #[test]
-    fn thumb_sits_at_the_track_top_when_unscrolled() {
-        assert_eq!(thumb_position(400.0, 1200.0, 0.0), 0.0);
-    }
-
-    #[test]
-    fn thumb_sits_at_the_track_bottom_when_scrolled_to_the_end() {
-        let viewport = 400.0;
-        let max_offset = 1200.0;
+    fn a_click_centers_the_thumb_under_the_pointer_and_clamps_to_the_track() {
+        let (viewport, max_offset, track_start) = (400.0, 1200.0, 50.0);
         let thumb = thumb_length(viewport, max_offset);
-        let expected_track = viewport - thumb;
+
+        for (pointer, expected, why) in [
+            (
+                track_start + thumb / 2.0,
+                0.0,
+                "the very top of the track jumps to the start",
+            ),
+            (
+                track_start + viewport - thumb / 2.0,
+                max_offset,
+                "the very bottom jumps to the end",
+            ),
+            (
+                -1_000.0,
+                0.0,
+                "a pointer above the track clamps rather than undershooting",
+            ),
+            (
+                10_000.0,
+                max_offset,
+                "and one below it clamps rather than overshooting",
+            ),
+        ] {
+            assert_eq!(
+                offset_for_pointer(viewport, max_offset, track_start, pointer),
+                expected,
+                "{why}"
+            );
+        }
         assert_eq!(
-            thumb_position(viewport, max_offset, max_offset),
-            expected_track
+            offset_for_pointer(400.0, 0.0, 0.0, 200.0),
+            0.0,
+            "an unscrollable region always jumps to zero"
         );
-    }
-
-    #[test]
-    fn thumb_position_is_never_negative_or_past_the_track_even_for_out_of_range_input() {
-        // A stale/overshot `scrolled` value (e.g. a frame where content just shrank) must not
-        // send the thumb off-track - the same real bug class `list_example.rs`'s own
-        // `bug_detected` assertion exists to catch, guarded against here instead by clamping.
-        assert_eq!(thumb_position(400.0, 1200.0, -50.0), 0.0);
-        let viewport = 400.0;
-        let max_offset = 1200.0;
-        let thumb = thumb_length(viewport, max_offset);
-        assert_eq!(
-            thumb_position(viewport, max_offset, 5_000.0),
-            viewport - thumb
-        );
-    }
-
-    #[test]
-    fn an_unscrollable_region_has_no_meaningful_thumb_position() {
-        assert_eq!(thumb_position(400.0, 0.0, 0.0), 0.0);
-    }
-
-    #[test]
-    fn clicking_the_very_top_of_the_track_jumps_to_the_start() {
-        let viewport = 400.0;
-        let max_offset = 1200.0;
-        let thumb = thumb_length(viewport, max_offset);
-        assert_eq!(
-            offset_for_pointer(viewport, max_offset, 0.0, thumb / 2.0),
-            0.0
-        );
-    }
-
-    #[test]
-    fn clicking_the_very_bottom_of_the_track_jumps_to_the_end() {
-        let viewport = 400.0;
-        let max_offset = 1200.0;
-        let thumb = thumb_length(viewport, max_offset);
-        let track_start = 50.0; // a viewport that doesn't start at window y=0
-        let pointer_at_bottom = track_start + viewport - thumb / 2.0;
-        assert_eq!(
-            offset_for_pointer(viewport, max_offset, track_start, pointer_at_bottom),
-            max_offset
-        );
-    }
-
-    #[test]
-    fn clicking_above_or_below_the_track_clamps_rather_than_over_or_under_shooting() {
-        let viewport = 400.0;
-        let max_offset = 1200.0;
-        assert_eq!(offset_for_pointer(viewport, max_offset, 0.0, -1_000.0), 0.0);
-        assert_eq!(
-            offset_for_pointer(viewport, max_offset, 0.0, 10_000.0),
-            max_offset
-        );
-    }
-
-    #[test]
-    fn an_unscrollable_region_always_jumps_to_zero() {
-        assert_eq!(offset_for_pointer(400.0, 0.0, 0.0, 200.0), 0.0);
     }
 }

--- a/crates/app/src/root/state.rs
+++ b/crates/app/src/root/state.rs
@@ -1928,89 +1928,43 @@ pub(super) fn reset_per_worktree_ui_state(
 mod tests {
     use super::*;
 
+    /// Every piece of per-worktree UI state this function owns is cleared in one call - staged
+    /// files, the open change, expanded directories, and both halves of the tree selection - and
+    /// calling it against already-empty state is a real no-op rather than a panic.
     #[test]
-    fn reset_per_worktree_ui_state_clears_staged_files_and_open_change() {
-        let mut staged_files = HashSet::new();
-        staged_files.insert(PathBuf::from("src/main.rs"));
-        staged_files.insert(PathBuf::from("Cargo.toml"));
+    fn reset_per_worktree_ui_state_clears_every_field_it_owns() {
+        let mut staged_files: HashSet<PathBuf> = ["src/main.rs", "Cargo.toml"]
+            .into_iter()
+            .map(PathBuf::from)
+            .collect();
         let mut open_change = Some(PathBuf::from("src/main.rs"));
-        let mut expanded_dirs = HashSet::new();
-        let mut selected_tree_path = None;
-        let mut additional_tree_selection = HashSet::new();
-
-        reset_per_worktree_ui_state(
-            &mut staged_files,
-            &mut open_change,
-            &mut expanded_dirs,
-            &mut selected_tree_path,
-            &mut additional_tree_selection,
-        );
-
-        assert!(staged_files.is_empty());
-        assert_eq!(open_change, None);
-    }
-
-    #[test]
-    fn reset_per_worktree_ui_state_is_a_no_op_when_already_empty() {
-        let mut staged_files = HashSet::new();
-        let mut open_change = None;
-        let mut expanded_dirs = HashSet::new();
-        let mut selected_tree_path = None;
-        let mut additional_tree_selection = HashSet::new();
-
-        reset_per_worktree_ui_state(
-            &mut staged_files,
-            &mut open_change,
-            &mut expanded_dirs,
-            &mut selected_tree_path,
-            &mut additional_tree_selection,
-        );
-
-        assert!(staged_files.is_empty());
-        assert_eq!(open_change, None);
-        assert!(expanded_dirs.is_empty());
-    }
-
-    #[test]
-    fn reset_per_worktree_ui_state_clears_expanded_dirs_too() {
-        let mut staged_files = HashSet::new();
-        let mut open_change = None;
-        let mut expanded_dirs = HashSet::new();
-        let mut selected_tree_path = None;
-        let mut additional_tree_selection = HashSet::new();
-        expanded_dirs.insert(PathBuf::from("/repo/worktree-a/src"));
-        expanded_dirs.insert(PathBuf::from("/repo/worktree-a/tests"));
-
-        reset_per_worktree_ui_state(
-            &mut staged_files,
-            &mut open_change,
-            &mut expanded_dirs,
-            &mut selected_tree_path,
-            &mut additional_tree_selection,
-        );
-
-        assert!(expanded_dirs.is_empty());
-    }
-
-    #[test]
-    fn reset_per_worktree_ui_state_clears_selected_tree_path() {
-        let mut staged_files = HashSet::new();
-        let mut open_change = None;
-        let mut expanded_dirs = HashSet::new();
+        let mut expanded_dirs: HashSet<PathBuf> =
+            ["/repo/worktree-a/src", "/repo/worktree-a/tests"]
+                .into_iter()
+                .map(PathBuf::from)
+                .collect();
         let mut selected_tree_path = Some(PathBuf::from("/repo/worktree-a/src/main.rs"));
-        let mut additional_tree_selection = HashSet::new();
-        additional_tree_selection.insert(PathBuf::from("/repo/worktree-a/src/lib.rs"));
+        let mut additional_tree_selection: HashSet<PathBuf> =
+            [PathBuf::from("/repo/worktree-a/src/lib.rs")]
+                .into_iter()
+                .collect();
 
-        reset_per_worktree_ui_state(
-            &mut staged_files,
-            &mut open_change,
-            &mut expanded_dirs,
-            &mut selected_tree_path,
-            &mut additional_tree_selection,
-        );
+        // Twice: once against real state, once against the empty state it leaves behind.
+        for _ in 0..2 {
+            reset_per_worktree_ui_state(
+                &mut staged_files,
+                &mut open_change,
+                &mut expanded_dirs,
+                &mut selected_tree_path,
+                &mut additional_tree_selection,
+            );
 
-        assert_eq!(selected_tree_path, None);
-        assert!(additional_tree_selection.is_empty());
+            assert!(staged_files.is_empty());
+            assert_eq!(open_change, None);
+            assert!(expanded_dirs.is_empty());
+            assert_eq!(selected_tree_path, None);
+            assert!(additional_tree_selection.is_empty());
+        }
     }
 
     #[test]
@@ -2101,61 +2055,22 @@ mod tests {
 #[cfg(test)]
 mod load_worktrees_integration_tests {
     use super::*;
-    use crate::root::focus::palette_focus_tests;
     use gpui::TestAppContext;
     use std::fs;
     use std::path::Path;
-    use std::process::Command;
-    use tempfile::TempDir;
-
-    fn git(dir: &Path, args: &[&str]) {
-        let output = Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {:?} failed in {:?}:\nstdout: {}\nstderr: {}",
-            args,
-            dir,
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
-    fn init_repo() -> TempDir {
-        let dir = TempDir::new().expect("tempdir");
-        git(dir.path(), &["init", "-b", "main"]);
-        git(dir.path(), &["config", "user.email", "test@example.com"]);
-        git(dir.path(), &["config", "user.name", "Test User"]);
-        fs::write(dir.path().join("base.txt"), "base\n").expect("write");
-        git(dir.path(), &["add", "base.txt"]);
-        git(dir.path(), &["commit", "-m", "initial"]);
-        dir
-    }
 
     fn add_worktree(repo_path: &Path, branch: &str, name: &str) -> PathBuf {
-        let container = TempDir::new().expect("tempdir");
+        let container = crate::test_support::temp_root();
         let path = container.path().join(name);
         drop(container);
-        git(
-            repo_path,
-            &[
-                "worktree",
-                "add",
-                "-b",
-                branch,
-                path.to_str().expect("utf8 path"),
-            ],
-        );
+        test_support::add_worktree(repo_path, branch, &path);
         path
     }
 
     #[gpui::test]
     fn a_real_worktree_add_appears_after_a_refresh(cx: &mut TestAppContext) {
-        let repo = init_repo();
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_repo();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
         assert_eq!(
             app.read_with(cx, |app, _| app.worktrees.len()),
@@ -2180,9 +2095,9 @@ mod load_worktrees_integration_tests {
 
     #[gpui::test]
     fn a_real_worktree_remove_disappears_after_a_refresh(cx: &mut TestAppContext) {
-        let repo = init_repo();
+        let repo = crate::test_support::temp_repo();
         let feature = add_worktree(repo.path(), "feature", "removed-wt");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
         assert_eq!(app.read_with(cx, |app, _| app.worktrees.len()), 2);
 
@@ -2202,12 +2117,12 @@ mod load_worktrees_integration_tests {
 
     #[gpui::test]
     fn a_real_lock_with_reason_is_reflected_after_a_refresh(cx: &mut TestAppContext) {
-        let repo = init_repo();
+        let repo = crate::test_support::temp_repo();
         let feature = add_worktree(repo.path(), "feature", "locked-wt");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
-        git(
+        test_support::git(
             repo.path(),
             &[
                 "worktree",
@@ -2234,9 +2149,9 @@ mod load_worktrees_integration_tests {
     fn a_manually_deleted_worktree_directory_is_marked_broken_after_a_refresh(
         cx: &mut TestAppContext,
     ) {
-        let repo = init_repo();
+        let repo = crate::test_support::temp_repo();
         let feature = add_worktree(repo.path(), "feature", "gone-wt");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         fs::remove_dir_all(&feature).expect("manually delete the worktree directory");
@@ -2260,9 +2175,9 @@ mod load_worktrees_integration_tests {
     fn selection_survives_a_refresh_when_the_selected_worktree_is_still_present(
         cx: &mut TestAppContext,
     ) {
-        let repo = init_repo();
+        let repo = crate::test_support::temp_repo();
         let feature = add_worktree(repo.path(), "feature", "stays-wt");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         let feature_index = app
@@ -2304,9 +2219,9 @@ mod load_worktrees_integration_tests {
     fn selecting_a_worktree_then_really_removing_it_falls_back_to_main_with_a_notice(
         cx: &mut TestAppContext,
     ) {
-        let repo = init_repo();
+        let repo = crate::test_support::temp_repo();
         let feature = add_worktree(repo.path(), "feature", "vanishes-wt");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         let feature_index = app
@@ -2373,44 +2288,14 @@ mod load_worktrees_integration_tests {
 #[cfg(test)]
 mod multi_repo_worktree_loading_tests {
     use super::*;
-    use crate::root::focus::palette_focus_tests;
     use gpui::TestAppContext;
     use std::path::Path;
-    use std::process::Command;
-    use tempfile::TempDir;
-
-    fn git(dir: &Path, args: &[&str]) {
-        let output = Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {:?} failed in {:?}:\nstdout: {}\nstderr: {}",
-            args,
-            dir,
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
-    fn init_repo() -> TempDir {
-        let dir = TempDir::new().expect("tempdir");
-        git(dir.path(), &["init", "-b", "main"]);
-        git(dir.path(), &["config", "user.email", "test@example.com"]);
-        git(dir.path(), &["config", "user.name", "Test User"]);
-        std::fs::write(dir.path().join("base.txt"), "base\n").expect("write");
-        git(dir.path(), &["add", "base.txt"]);
-        git(dir.path(), &["commit", "-m", "initial"]);
-        dir
-    }
 
     fn add_worktree(repo_path: &Path, branch: &str, name: &str) {
-        let container = TempDir::new().expect("tempdir");
+        let container = crate::test_support::temp_root();
         let path = container.path().join(name);
         drop(container);
-        git(
+        test_support::git(
             repo_path,
             &[
                 "worktree",
@@ -2424,9 +2309,9 @@ mod multi_repo_worktree_loading_tests {
 
     #[gpui::test]
     fn a_non_focused_repos_worktrees_load_in_the_background(cx: &mut TestAppContext) {
-        let repo_a = init_repo();
-        let repo_b = init_repo();
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo_a.path().to_path_buf());
+        let repo_a = crate::test_support::temp_repo();
+        let repo_b = crate::test_support::temp_repo();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo_a.path().to_path_buf());
         cx.run_until_parked();
 
         let repo_b_id = app.update(cx, |app, cx| app.add_repo(repo_b.path().to_path_buf(), cx));
@@ -2482,12 +2367,12 @@ mod multi_repo_worktree_loading_tests {
 
     #[gpui::test]
     fn a_repo_whose_path_disappears_before_its_first_load_does_not_panic(cx: &mut TestAppContext) {
-        let repo_a = init_repo();
-        let doomed = TempDir::new().expect("tempdir");
+        let repo_a = crate::test_support::temp_repo();
+        let doomed = crate::test_support::temp_root();
         let doomed_path = doomed.path().to_path_buf();
-        git(&doomed_path, &["init", "-b", "main"]);
+        test_support::git(&doomed_path, &["init", "-b", "main"]);
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo_a.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo_a.path().to_path_buf());
         cx.run_until_parked();
 
         let doomed_id = app.update(cx, |app, cx| app.add_repo(doomed_path.clone(), cx));
@@ -2519,9 +2404,9 @@ mod multi_repo_worktree_loading_tests {
     fn a_non_focused_repos_worktrees_are_not_refetched_before_the_poll_interval_elapses(
         cx: &mut TestAppContext,
     ) {
-        let repo_a = init_repo();
-        let repo_b = init_repo();
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo_a.path().to_path_buf());
+        let repo_a = crate::test_support::temp_repo();
+        let repo_b = crate::test_support::temp_repo();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo_a.path().to_path_buf());
         cx.run_until_parked();
 
         let repo_b_id = app.update(cx, |app, cx| app.add_repo(repo_b.path().to_path_buf(), cx));
@@ -2585,11 +2470,13 @@ mod multi_repo_worktree_loading_tests {
     fn the_periodic_sweep_refreshes_every_repo_even_with_more_than_the_concurrency_cap(
         cx: &mut TestAppContext,
     ) {
-        let repo_focused = init_repo();
+        let repo_focused = crate::test_support::temp_repo();
         let extra_count = REPO_WORKTREES_FETCH_CONCURRENCY * 2 + 1;
-        let extra_repos: Vec<TempDir> = (0..extra_count).map(|_| init_repo()).collect();
+        let extra_repos: Vec<crate::test_support::TempRoot> = (0..extra_count)
+            .map(|_| crate::test_support::temp_repo())
+            .collect();
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo_focused.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo_focused.path().to_path_buf());
         cx.run_until_parked();
 
         let extra_ids: Vec<RepoId> = extra_repos
@@ -2651,35 +2538,7 @@ mod file_tree_watch_integration_tests {
     use crate::root::AdeApp;
     use crate::settings::store as settings_store;
     use gpui::TestAppContext;
-    use std::fs;
-    use std::path::{Path, PathBuf};
-    use std::process::Command;
-    use tempfile::TempDir;
-
-    fn git(dir: &Path, args: &[&str]) {
-        let output = Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {:?} failed in {:?}",
-            args,
-            dir
-        );
-    }
-
-    fn init_repo() -> TempDir {
-        let dir = TempDir::new().expect("tempdir");
-        git(dir.path(), &["init", "-b", "main"]);
-        git(dir.path(), &["config", "user.email", "test@example.com"]);
-        git(dir.path(), &["config", "user.name", "Test User"]);
-        fs::write(dir.path().join("base.txt"), "base\n").expect("write");
-        git(dir.path(), &["add", "base.txt"]);
-        git(dir.path(), &["commit", "-m", "initial"]);
-        dir
-    }
+    use std::path::PathBuf;
 
     /// `Self::start_file_tree_watch` only ever arms a real watcher for a real, `Some` settings
     /// path (see that method's own docs on why) - `root::focus::palette_focus_tests::
@@ -2689,7 +2548,7 @@ mod file_tree_watch_integration_tests {
         cx: &mut TestAppContext,
         repo_path: PathBuf,
     ) -> (gpui::Entity<AdeApp>, &mut gpui::VisualTestContext) {
-        let config_dir = tempfile::tempdir().expect("tempdir");
+        let config_dir = crate::test_support::temp_root();
         let settings_path = config_dir.path().join("settings.toml");
         // Leaked deliberately: `config_dir` must outlive the returned `AdeApp`, and this helper
         // has no later point to drop it at - the OS reclaims it at process exit either way, the
@@ -2709,7 +2568,7 @@ mod file_tree_watch_integration_tests {
 
     #[gpui::test]
     fn opening_the_app_arms_a_real_file_tree_watcher(cx: &mut TestAppContext) {
-        let repo = init_repo();
+        let repo = crate::test_support::temp_repo();
         let (app, cx) = open_test_app_with_real_settings_path(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
@@ -2721,11 +2580,11 @@ mod file_tree_watch_integration_tests {
 
     #[gpui::test]
     fn selecting_a_different_worktree_re_arms_the_watcher_on_the_new_root(cx: &mut TestAppContext) {
-        let repo = init_repo();
-        let container = TempDir::new().expect("tempdir");
+        let repo = crate::test_support::temp_repo();
+        let container = crate::test_support::temp_root();
         let linked_path = container.path().join("added-wt");
         drop(container);
-        git(
+        test_support::git(
             repo.path(),
             &[
                 "worktree",

--- a/crates/app/src/run_history/render.rs
+++ b/crates/app/src/run_history/render.rs
@@ -420,35 +420,17 @@ mod history_surface_tests {
     use crate::hooks::store::LiveRun;
     use crate::rail::status::Status;
     use crate::root::focus::palette_focus_tests;
+    use crate::test_support::{temp_repo_with, TempRoot};
     use crate::work_surface::agents::AgentKind;
     use crate::work_surface::state::TabRef;
     use gpui::TestAppContext;
     use std::path::Path;
-    use std::process::Command;
-    use tempfile::TempDir;
 
-    fn git(dir: &Path, args: &[&str]) {
-        let output = Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {args:?} failed in {dir:?}: {}",
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
-    fn init_repo() -> TempDir {
-        let dir = TempDir::new().expect("tempdir");
-        git(dir.path(), &["init", "-b", "main"]);
-        git(dir.path(), &["config", "user.email", "test@example.com"]);
-        git(dir.path(), &["config", "user.name", "Test User"]);
-        std::fs::write(dir.path().join("base.txt"), "base\n").expect("write");
-        git(dir.path(), &["add", "base.txt"]);
-        git(dir.path(), &["commit", "-m", "initial"]);
-        dir
+    fn init_repo() -> TempRoot {
+        temp_repo_with(|root| {
+            test_support::seed_empty_repo_at(root);
+            test_support::commit(root, "base.txt", "base\n", "initial");
+        })
     }
 
     /// Files one real, *finished* run into the real status store, exactly the way
@@ -728,7 +710,7 @@ mod history_surface_tests {
     #[gpui::test]
     fn opening_another_checkouts_run_selects_that_checkout(cx: &mut TestAppContext) {
         let repo = init_repo();
-        let wt = TempDir::new().expect("tempdir wt");
+        let wt = temp_repo_with(|_| {});
         let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
         app.update(cx, |app, cx| {
@@ -852,7 +834,7 @@ mod history_surface_tests {
     #[gpui::test]
     fn a_worktree_with_history_and_no_agent_gets_the_earlier_runs_line(cx: &mut TestAppContext) {
         let repo = init_repo();
-        let wt = TempDir::new().expect("tempdir wt");
+        let wt = temp_repo_with(|_| {});
         let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
         app.update(cx, |app, cx| {
@@ -929,7 +911,7 @@ mod history_surface_tests {
         cx: &mut TestAppContext,
     ) {
         let repo = init_repo();
-        let wt = TempDir::new().expect("tempdir wt with history, no agent");
+        let wt = temp_repo_with(|_| {});
         let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
         app.update(cx, |app, cx| {

--- a/crates/app/src/search/engine.rs
+++ b/crates/app/src/search/engine.rs
@@ -1329,16 +1329,7 @@ mod worktree_tests {
 #[cfg(test)]
 mod layered_exclude_tests {
     use super::*;
-    use std::process::Command;
-
-    fn git(dir: &Path, args: &[&str]) {
-        let status = Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .status()
-            .expect("git runs");
-        assert!(status.success(), "git {args:?} failed");
-    }
+    use test_support::{git, seed_empty_repo_at};
 
     /// A real git worktree with:
     /// - `target/`, a real `.gitignore`d build directory sized enough that including it would
@@ -1352,9 +1343,7 @@ mod layered_exclude_tests {
     fn fixture() -> tempfile::TempDir {
         let dir = tempfile::tempdir().expect("a temp worktree");
         let root = dir.path();
-        git(root, &["init", "-q"]);
-        git(root, &["config", "user.email", "t@example.com"]);
-        git(root, &["config", "user.name", "Test"]);
+        seed_empty_repo_at(root);
 
         let write = |relative: &str, content: &str| {
             let path = root.join(relative);
@@ -1484,9 +1473,7 @@ mod layered_exclude_tests {
     fn an_ungitignored_build_directory_is_excluded_in_both_toggle_states() {
         let dir = tempfile::tempdir().expect("a temp worktree");
         let root = dir.path();
-        git(root, &["init", "-q"]);
-        git(root, &["config", "user.email", "t@example.com"]);
-        git(root, &["config", "user.name", "Test"]);
+        seed_empty_repo_at(root);
         let write = |relative: &str, content: &str| {
             let path = root.join(relative);
             fs::create_dir_all(path.parent().expect("a parent")).expect("mkdir");

--- a/crates/app/src/search/fixtures.rs
+++ b/crates/app/src/search/fixtures.rs
@@ -1,0 +1,34 @@
+//! Test-only fixtures shared by this folder's own test modules.
+//!
+//! Owns exactly one thing: handing a test a worktree root the app will agree with. Anything
+//! git-, wait- or process-shaped belongs in `crates/test-support`, and anything that opens a
+//! window in `crate::test_support`.
+
+use std::path::{Path, PathBuf};
+
+/// A real temporary directory whose [`Self::path`] is the root to hand
+/// [`crate::test_support::open_test_app`].
+///
+/// The path is canonicalized because `AdeApp` canonicalizes the repo root it is given
+/// ([`crate::rail::repo::canonical_repo_path`]) and then keys `open_files`/`edit_buffers` by
+/// `path.strip_prefix(file_tree_root)`. On macOS `std::env::temp_dir()` is itself behind a
+/// symlink (`/var` -> `/private/var`), so a fixture that builds paths from
+/// `tempfile::TempDir::path()` verbatim produces keys that never match the ones the app resolved
+/// — which is exactly how a replace-all could once overwrite a file the editor still held dirty.
+pub(in crate::search) struct TempRepo {
+    /// Held for its `Drop`; the directory is removed when this value is.
+    _dir: tempfile::TempDir,
+    root: PathBuf,
+}
+
+impl TempRepo {
+    pub(in crate::search) fn path(&self) -> &Path {
+        &self.root
+    }
+}
+
+pub(in crate::search) fn temp_repo() -> TempRepo {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path().canonicalize().expect("canonicalize tempdir");
+    TempRepo { _dir: dir, root }
+}

--- a/crates/app/src/search/mod.rs
+++ b/crates/app/src/search/mod.rs
@@ -6,4 +6,6 @@ pub mod glob;
 pub mod in_file;
 pub mod state;
 
+#[cfg(test)]
+pub(crate) mod fixtures;
 pub(crate) mod render;

--- a/crates/app/src/search/render.rs
+++ b/crates/app/src/search/render.rs
@@ -1263,16 +1263,15 @@ mod tests {
 #[cfg(test)]
 mod panel_tests {
     use super::*;
-    use crate::root::focus::palette_focus_tests;
     use crate::search::state::SearchField;
+    use crate::test_support::open_test_app;
     use gpui::TestAppContext;
-    use tempfile::TempDir;
 
     /// A real worktree on disk with `refresh_token` across four files - the same corpus
     /// `Jerry.dc.html`'s own search fixture uses, so what these tests see is what the design was
     /// drawn against.
-    fn fixture_repo() -> TempDir {
-        let repo = TempDir::new().expect("tempdir");
+    fn fixture_repo() -> crate::search::fixtures::TempRepo {
+        let repo = crate::search::fixtures::temp_repo();
         let write = |relative: &str, content: &str| {
             let path = repo.path().join(relative);
             std::fs::create_dir_all(path.parent().expect("a parent")).expect("mkdir");
@@ -1294,9 +1293,9 @@ mod panel_tests {
 
     fn open_search<'a>(
         cx: &'a mut TestAppContext,
-        repo: &TempDir,
+        repo: &crate::search::fixtures::TempRepo,
     ) -> (gpui::Entity<AdeApp>, &'a mut gpui::VisualTestContext) {
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| app.open_search_panel(window, cx));
         cx.run_until_parked();
         (app, cx)
@@ -1364,7 +1363,7 @@ mod panel_tests {
     #[gpui::test]
     fn mod_shift_f_opens_the_panel_with_the_query_focused(cx: &mut TestAppContext) {
         let repo = fixture_repo();
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         cx.dispatch_action(SearchInWorktree);
         cx.run_until_parked();
 
@@ -1651,7 +1650,7 @@ mod panel_tests {
 
     #[gpui::test]
     fn clicking_a_match_row_opens_the_file_on_exactly_the_line_it_reports(cx: &mut TestAppContext) {
-        let repo = TempDir::new().expect("tempdir");
+        let repo = crate::search::fixtures::temp_repo();
         let mut content = String::new();
         for line in 1..=41 {
             content.push_str(&format!("// padding line {line}\n"));
@@ -1893,9 +1892,8 @@ mod panel_tests {
 #[cfg(test)]
 mod search_virtualization_tests {
     use super::*;
-    use crate::root::focus::palette_focus_tests;
+    use crate::test_support::open_test_app;
     use gpui::TestAppContext;
-    use tempfile::TempDir;
 
     /// Deliberately more match rows than any plausible test viewport can show at
     /// `theme::band::SEARCH_MATCH_ROW` each - a single file with `ROW_COUNT` distinct one-per-line
@@ -1903,8 +1901,8 @@ mod search_virtualization_tests {
     /// shape the live report itself described.
     const ROW_COUNT: usize = 300;
 
-    fn fixture_repo() -> TempDir {
-        let repo = TempDir::new().expect("tempdir");
+    fn fixture_repo() -> crate::search::fixtures::TempRepo {
+        let repo = crate::search::fixtures::temp_repo();
         let mut content = String::new();
         for i in 0..ROW_COUNT {
             content.push_str(&format!("let needle_{i} = needle;\n"));
@@ -1915,9 +1913,9 @@ mod search_virtualization_tests {
 
     fn open_search<'a>(
         cx: &'a mut TestAppContext,
-        repo: &TempDir,
+        repo: &crate::search::fixtures::TempRepo,
     ) -> (gpui::Entity<AdeApp>, &'a mut gpui::VisualTestContext) {
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| app.open_search_panel(window, cx));
         cx.run_until_parked();
         (app, cx)
@@ -2422,9 +2420,8 @@ impl AdeApp {
 #[cfg(test)]
 mod find_bar_tests {
     use super::*;
-    use crate::root::focus::palette_focus_tests;
+    use crate::test_support::open_test_app;
     use gpui::TestAppContext;
-    use tempfile::TempDir;
 
     const SAMPLE: &str = "let refresh_token = issue();\n\
                           if refresh_token.expired() { drop(refresh_token); }\n\
@@ -2433,11 +2430,15 @@ mod find_bar_tests {
 
     fn repo_with_open_file(
         cx: &mut TestAppContext,
-    ) -> (TempDir, gpui::Entity<AdeApp>, &mut gpui::VisualTestContext) {
-        let repo = TempDir::new().expect("tempdir");
+    ) -> (
+        crate::search::fixtures::TempRepo,
+        gpui::Entity<AdeApp>,
+        &mut gpui::VisualTestContext,
+    ) {
+        let repo = crate::search::fixtures::temp_repo();
         let file = repo.path().join("session.rs");
         std::fs::write(&file, SAMPLE).expect("write");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(file.clone(), window, cx);
         });

--- a/crates/app/src/settings/custom_theme.rs
+++ b/crates/app/src/settings/custom_theme.rs
@@ -897,30 +897,41 @@ keyword = "#ff79c6"
         assert_eq!(theme.base, None);
     }
 
+    /// Every real way a theme file can be wrong, and the exact error each one has to produce -
+    /// a typo'd key must be named, not silently ignored, or a user edits a file and sees nothing
+    /// change with no explanation.
     #[test]
-    fn an_unknown_key_is_a_real_rejection_not_a_silently_ignored_typo() {
-        let err =
-            parse_theme_file_str("name = \"T\"\n\n[syntax]\nkeywrod = \"#ff79c6\"\n").unwrap_err();
-        assert_eq!(
-            err,
-            ThemeFileError::UnknownKey("syntax.keywrod".to_string())
-        );
-    }
+    fn every_real_malformed_theme_file_is_rejected_with_an_error_naming_what_is_wrong() {
+        for (name, text, expected) in [
+            (
+                "a typo'd key",
+                "name = \"T\"\n\n[syntax]\nkeywrod = \"#ff79c6\"\n",
+                ThemeFileError::UnknownKey("syntax.keywrod".to_string()),
+            ),
+            (
+                "a typo'd table",
+                "name = \"T\"\n\n[surfaces]\nwindow = \"#0c0d10\"\n",
+                ThemeFileError::UnknownKey("surfaces.window".to_string()),
+            ),
+            (
+                "a top-level key outside any table",
+                "name = \"T\"\nwindow = \"#0c0d10\"\n",
+                ThemeFileError::UnknownTable("window".to_string()),
+            ),
+            (
+                "a blank name",
+                "name = \"   \"\n",
+                ThemeFileError::EmptyName,
+            ),
+            (
+                "a name a built-in theme already has",
+                "name = \"Jerry Dark\"\n",
+                ThemeFileError::NameCollidesWithBuiltin("Jerry Dark".to_string()),
+            ),
+        ] {
+            assert_eq!(parse_theme_file_str(text).unwrap_err(), expected, "{name}");
+        }
 
-    #[test]
-    fn an_unknown_table_is_a_real_rejection() {
-        let err =
-            parse_theme_file_str("name = \"T\"\n\n[surfaces]\nwindow = \"#0c0d10\"\n").unwrap_err();
-        assert_eq!(
-            err,
-            ThemeFileError::UnknownKey("surfaces.window".to_string())
-        );
-        let err = parse_theme_file_str("name = \"T\"\nwindow = \"#0c0d10\"\n").unwrap_err();
-        assert_eq!(err, ThemeFileError::UnknownTable("window".to_string()));
-    }
-
-    #[test]
-    fn every_real_invalid_colour_shape_is_rejected_with_the_offending_key_named() {
         for bad in ["0c0d10", "#0c0", "#gggggg", "#0c0d1012", "not-a-color", ""] {
             let err =
                 parse_theme_file_str(&format!("name = \"T\"\n\n[surface]\nwindow = \"{bad}\"\n"))
@@ -930,9 +941,27 @@ keyword = "#ff79c6"
                 ThemeFileError::InvalidColor {
                     key: "surface.window".to_string(),
                     value: bad.to_string(),
-                }
+                },
+                "colour {bad:?}"
             );
         }
+
+        for text in [
+            "name = \"T\"\npreview = [\"#010203\"]\n",
+            "name = \"T\"\npreview = \"#010203\"\n",
+            "name = \"T\"\npreview = [\"nope\", \"#040506\", \"#070809\", \"#0a0b0c\", \"#0d0e0f\"]\n",
+        ] {
+            let err = parse_theme_file_str(text).unwrap_err();
+            assert!(
+                matches!(err, ThemeFileError::InvalidPreview(_)),
+                "expected an InvalidPreview error for {text:?}, got {err:?}"
+            );
+        }
+
+        assert!(matches!(
+            parse_theme_file_str("this is not valid toml {{{").unwrap_err(),
+            ThemeFileError::Parse(_)
+        ));
     }
 
     #[test]
@@ -945,27 +974,8 @@ keyword = "#ff79c6"
         assert_eq!(theme.overrides["graph.lanes.0"], rgba(0x00ff00));
     }
 
-    #[test]
-    fn an_empty_name_is_a_real_rejection_not_a_silent_fallback() {
-        let err = parse_theme_file_str("name = \"   \"\n").unwrap_err();
-        assert_eq!(err, ThemeFileError::EmptyName);
-    }
-
-    #[test]
-    fn a_name_colliding_with_a_builtin_theme_is_rejected() {
-        let err = parse_theme_file_str("name = \"Jerry Dark\"\n").unwrap_err();
-        assert_eq!(
-            err,
-            ThemeFileError::NameCollidesWithBuiltin("Jerry Dark".to_string())
-        );
-    }
-
-    #[test]
-    fn parse_theme_file_str_rejects_garbage_toml_with_a_real_parse_error() {
-        let err = parse_theme_file_str("this is not valid toml {{{").unwrap_err();
-        assert!(matches!(err, ThemeFileError::Parse(_)));
-    }
-
+    /// A real round trip through this module's own writer and reader - the property
+    /// `import_theme_file`/`export_theme_to_path` depend on.
     #[test]
     fn a_theme_round_trips_through_to_toml_string_and_back_byte_for_byte() {
         let theme = valid_file().validate().expect("should validate");
@@ -1039,34 +1049,15 @@ keyword = "#ff79c6"
         );
     }
 
-    #[test]
-    fn a_malformed_preview_is_a_real_rejection() {
-        for (text, _) in [
-            ("name = \"T\"\npreview = [\"#010203\"]\n", ()),
-            ("name = \"T\"\npreview = \"#010203\"\n", ()),
-            (
-                "name = \"T\"\npreview = [\"nope\", \"#040506\", \"#070809\", \"#0a0b0c\", \"#0d0e0f\"]\n",
-                (),
-            ),
-        ] {
-            let err = parse_theme_file_str(text).unwrap_err();
-            assert!(
-                matches!(err, ThemeFileError::InvalidPreview(_)),
-                "expected an InvalidPreview error for {text:?}, got {err:?}"
-            );
-        }
-    }
-
     // ---- readability ------------------------------------------------------------------------
 
     #[test]
-    fn text_the_same_colour_as_its_background_is_rejected() {
-        let mut palette = theme::Palette::new();
-        palette.insert("surface.window", rgba(0x0c0d10));
-        palette.insert("text.body", rgba(0x0c0d10));
-        let err = check_palette_readability(&palette).unwrap_err();
+    fn text_that_does_not_clear_the_contrast_floor_against_its_background_is_rejected() {
+        let mut identical = theme::Palette::new();
+        identical.insert("surface.window", rgba(0x0c0d10));
+        identical.insert("text.body", rgba(0x0c0d10));
         assert_eq!(
-            err,
+            check_palette_readability(&identical).unwrap_err(),
             ThemeFileError::LowContrast {
                 what: "body text",
                 foreground: "text.body",
@@ -1075,19 +1066,16 @@ keyword = "#ff79c6"
                 floor_per_hundred: MIN_CONTRAST_PER_HUNDRED,
             }
         );
-    }
 
-    #[test]
-    fn text_a_few_hex_digits_off_from_its_background_is_still_rejected() {
-        let mut palette = theme::Palette::new();
-        palette.insert("surface.window", rgba(0x0c0d10));
-        palette.insert("text.body", rgba(0x11131a));
+        let mut near_miss = theme::Palette::new();
+        near_miss.insert("surface.window", rgba(0x0c0d10));
+        near_miss.insert("text.body", rgba(0x11131a));
         assert!(
             matches!(
-                check_palette_readability(&palette),
+                check_palette_readability(&near_miss),
                 Err(ThemeFileError::LowContrast { .. })
             ),
-            "expected a LowContrast rejection"
+            "a near-miss is still unreadable"
         );
     }
 
@@ -1122,21 +1110,11 @@ keyword = "#ff79c6"
         assert!(check_palette_readability(&theme::Palette::new()).is_ok());
     }
 
-    #[test]
-    fn every_built_in_theme_is_really_readable_once_compiled() {
-        for def in THEME_DEFS.iter() {
-            let palette = compile_palette_by_name(def.name, &[])
-                .expect("a bundled theme must compile")
-                .unwrap_or_default();
-            assert!(
-                check_palette_readability(&palette).is_ok(),
-                "{} is not readable: {:?}",
-                def.name,
-                check_palette_readability(&palette)
-            );
-        }
-    }
-
+    /// Pins the real measured headroom every bundled theme has over the floor - so a future edit
+    /// that quietly weakened the floor, or a palette change that quietly ate the margin, shows up
+    /// as a real test failure rather than passing on a technicality. Strictly stronger than
+    /// `check_palette_readability`'s own 1.6:1 validity floor, over the same pairs, so it stands
+    /// in for a plain "is it readable at all" check too.
     #[test]
     fn every_built_in_theme_clears_the_floor_with_real_headroom() {
         for def in THEME_DEFS.iter() {
@@ -1256,23 +1234,20 @@ keyword = "#ff79c6"
         assert_eq!(palette["surface.window"], rgba(0x333333));
     }
 
+    /// A cycle in the `base` chain must come back as a real reported error naming the loop, not
+    /// a hang - including the one-theme case, where a theme names itself.
     #[test]
     fn a_base_cycle_is_a_real_reported_error_not_a_hang() {
         let a = theme_named("A", Some("B"), &[]);
         let b = theme_named("B", Some("A"), &[]);
-        let err = compile_palette(&a, &[&a, &b]).unwrap_err();
         assert_eq!(
-            err,
+            compile_palette(&a, &[&a, &b]).unwrap_err(),
             ThemeFileError::BaseCycle(vec!["A".to_string(), "B".to_string(), "A".to_string()])
         );
-    }
 
-    #[test]
-    fn a_theme_naming_itself_as_its_own_base_is_a_real_reported_cycle() {
         let self_based = theme_named("Loop", Some("Loop"), &[]);
-        let err = compile_palette(&self_based, &[&self_based]).unwrap_err();
         assert_eq!(
-            err,
+            compile_palette(&self_based, &[&self_based]).unwrap_err(),
             ThemeFileError::BaseCycle(vec!["Loop".to_string(), "Loop".to_string()])
         );
     }
@@ -1773,19 +1748,19 @@ keyword = "#ff79c6"
 
     #[test]
     fn custom_themes_dir_for_is_a_real_sibling_of_the_given_settings_path() {
-        let settings_path = Path::new("/home/user/.config/jerry/settings.toml");
-        assert_eq!(
-            custom_themes_dir_for(settings_path),
-            Path::new("/home/user/.config/jerry/themes")
-        );
-    }
-
-    #[test]
-    fn custom_themes_dir_for_falls_back_to_a_bare_name_for_a_settings_path_with_no_parent() {
-        assert_eq!(
-            custom_themes_dir_for(Path::new("settings.toml")),
-            Path::new("themes")
-        );
+        for (settings_path, expected) in [
+            (
+                "/home/user/.config/jerry/settings.toml",
+                "/home/user/.config/jerry/themes",
+            ),
+            // No parent at all - a bare name rather than an empty path.
+            ("settings.toml", "themes"),
+        ] {
+            assert_eq!(
+                custom_themes_dir_for(Path::new(settings_path)),
+                Path::new(expected)
+            );
+        }
     }
 
     #[test]

--- a/crates/app/src/settings/render.rs
+++ b/crates/app/src/settings/render.rs
@@ -5126,7 +5126,7 @@ pub(in crate::settings) fn render_settings_placeholder_page() -> impl IntoElemen
 #[cfg(test)]
 mod settings_keymap_filter_tests {
     use super::*;
-    use crate::root::focus::palette_focus_tests;
+    use crate::test_support::open_test_app;
     use gpui::TestAppContext;
 
     #[gpui::test]
@@ -5134,7 +5134,7 @@ mod settings_keymap_filter_tests {
         cx: &mut TestAppContext,
     ) {
         let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
 
         cx.dispatch_action(ToggleSettings);
         app.update_in(cx, |app, window, cx| {
@@ -5189,7 +5189,7 @@ mod settings_keymap_filter_tests {
 #[cfg(test)]
 mod search_exclude_settings_tests {
     use super::*;
-    use crate::root::focus::palette_focus_tests;
+    use crate::test_support::open_test_app;
     use gpui::TestAppContext;
 
     fn open_test_app_with_real_settings_path(
@@ -5213,7 +5213,7 @@ mod search_exclude_settings_tests {
     #[gpui::test]
     fn typing_a_pattern_and_pressing_enter_adds_it_and_clears_the_field(cx: &mut TestAppContext) {
         let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
 
         cx.dispatch_action(ToggleSettings);
         app.update_in(cx, |app, window, cx| {
@@ -5260,7 +5260,7 @@ mod search_exclude_settings_tests {
     #[gpui::test]
     fn enter_on_a_blank_or_duplicate_pattern_is_a_silent_no_op(cx: &mut TestAppContext) {
         let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
 
         cx.dispatch_action(ToggleSettings);
         app.update_in(cx, |app, window, cx| {
@@ -5362,7 +5362,7 @@ mod search_exclude_settings_tests {
 #[cfg(test)]
 mod terminal_font_size_tests {
     use super::*;
-    use crate::root::focus::palette_focus_tests;
+    use crate::test_support::open_test_app;
     use gpui::TestAppContext;
 
     #[gpui::test]
@@ -5370,7 +5370,7 @@ mod terminal_font_size_tests {
         cx: &mut TestAppContext,
     ) {
         let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         let pane = app
@@ -5427,7 +5427,7 @@ mod terminal_font_size_tests {
         cx: &mut TestAppContext,
     ) {
         let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         app.update_in(cx, |app, window, cx| {
@@ -5465,7 +5465,7 @@ mod terminal_font_size_tests {
 #[cfg(test)]
 mod settings_lsp_install_action_tests {
     use super::*;
-    use crate::root::focus::palette_focus_tests;
+    use crate::test_support::open_test_app;
     use gpui::TestAppContext;
 
     fn synthetic_row(binary: &'static str, ready: bool) -> settings::LspRow {
@@ -5482,7 +5482,7 @@ mod settings_lsp_install_action_tests {
     #[gpui::test]
     fn install_action_renders_only_for_a_genuinely_not_installed_row(cx: &mut TestAppContext) {
         let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
 
         cx.dispatch_action(ToggleSettings);
         app.update_in(cx, |app, window, cx| {
@@ -5517,8 +5517,8 @@ mod settings_lsp_install_action_tests {
 mod shell_setting_tests {
     use super::*;
     use crate::rail::status::Status;
-    use crate::root::focus::palette_focus_tests;
     use crate::terminal::pane::TerminalSpec;
+    use crate::test_support::open_test_app;
     use gpui::TestAppContext;
 
     /// Same shape as the sibling test modules' own helper (`keybinding_rebind_tests`,
@@ -5585,7 +5585,7 @@ mod shell_setting_tests {
     #[gpui::test]
     fn an_unconfigured_shell_still_spawns_the_real_os_default(cx: &mut TestAppContext) {
         let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         let expected = PathBuf::from(TerminalSpec::default_shell_program_display())
@@ -6105,14 +6105,14 @@ mod shell_suggestion_dropdown_tests {
 /// actually persisted and applied" discipline.
 #[cfg(test)]
 mod caret_settings_tests {
-    use crate::root::focus::palette_focus_tests;
     use crate::settings::store::CaretStyle;
+    use crate::test_support::open_test_app;
     use gpui::TestAppContext;
 
     #[gpui::test]
     fn set_caret_style_changes_the_real_persisted_setting(cx: &mut TestAppContext) {
         let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
 
         assert_eq!(
             app.read_with(cx, |app, _| app.settings.appearance.caret_style),
@@ -6143,7 +6143,7 @@ mod caret_settings_tests {
         cx: &mut TestAppContext,
     ) {
         let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
 
         assert!(
             app.read_with(cx, |app, _| app.settings.appearance.caret_blink),
@@ -6261,7 +6261,7 @@ mod indent_guide_settings_tests {
 /// own measured-bounds technique rather than only reading the render code.
 #[cfg(test)]
 mod settings_keymap_filter_caret_tests {
-    use crate::root::focus::palette_focus_tests;
+    use crate::test_support::open_test_app;
     use gpui::TestAppContext;
     use std::time::Duration;
 
@@ -6270,7 +6270,7 @@ mod settings_keymap_filter_caret_tests {
         cx: &mut TestAppContext,
     ) {
         let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
 
         app.update_in(cx, |app, window, cx| {
             app.open_settings(window, cx);
@@ -6329,7 +6329,7 @@ mod settings_keymap_filter_caret_tests {
         cx: &mut TestAppContext,
     ) {
         let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_settings(window, cx);
             app.settings_page = crate::settings::SettingsPage::General;
@@ -6383,7 +6383,7 @@ mod settings_keymap_filter_caret_tests {
         cx: &mut TestAppContext,
     ) {
         let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         // `on_focus`/`on_blur` (`AdeApp::wire_caret_blink`'s own mechanism) only fire while GPUI
         // considers the window itself "active" - a real, freshly opened test window starts out
         // not active at all.
@@ -6425,7 +6425,7 @@ mod settings_keymap_filter_caret_tests {
 mod keybinding_rebind_tests {
     use super::*;
     use crate::keymap_overrides::BindingIdentity;
-    use crate::root::focus::palette_focus_tests;
+    use crate::test_support::open_test_app;
     use gpui::TestAppContext;
 
     fn open_test_app_with_real_settings_path(
@@ -6566,7 +6566,7 @@ mod keybinding_rebind_tests {
         let repo = tempfile::tempdir().expect("tempdir");
         let file_path = repo.path().join("main.rs");
         std::fs::write(&file_path, "fn main() {}\n").expect("write main.rs");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(file_path, window, cx);
         });
@@ -6628,7 +6628,7 @@ mod keybinding_rebind_tests {
 #[cfg(test)]
 mod theme_swap_tests {
     use super::*;
-    use crate::root::focus::palette_focus_tests;
+    use crate::test_support::open_test_app;
     use gpui::TestAppContext;
 
     /// `crate::theme::CURRENT_THEME` is real, thread-local, mutable state - reset it after this
@@ -6650,7 +6650,7 @@ mod theme_swap_tests {
     ) {
         let _guard = ResetThemeIndexOnDrop;
         let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
 
         assert!(
             theme::current_theme_palette().is_none(),
@@ -6694,7 +6694,7 @@ mod theme_swap_tests {
     fn follow_system_selects_paper_on_light_and_jerry_dark_on_dark(cx: &mut TestAppContext) {
         let _guard = ResetThemeIndexOnDrop;
         let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
 
         app.update(cx, |app, cx| {
             app.apply_follow_system_appearance(gpui::WindowAppearance::Light, cx);
@@ -6727,7 +6727,7 @@ mod theme_swap_tests {
     ) {
         let _guard = ResetThemeIndexOnDrop;
         let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
 
         app.update(cx, |app, cx| {
             app.set_theme_name("Slate".to_string(), cx);
@@ -6766,7 +6766,7 @@ mod theme_swap_tests {
     ) {
         let _guard = ResetThemeIndexOnDrop;
         let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         assert!(!app.read_with(cx, |app, _| app.settings.theme.follow_system));
 
         let appearance_before = app.read_with(cx, |_, cx| cx.window_appearance());

--- a/crates/app/src/settings/state.rs
+++ b/crates/app/src/settings/state.rs
@@ -482,6 +482,9 @@ pub struct KeybindingRow {
 pub(crate) fn action_label(action: &dyn gpui::Action) -> Option<&'static str> {
     match action.name() {
         "app::NewAgent" => Some("New agent"),
+        // macOS-only (`cmd-q`, registered in `crate::default_key_bindings`), and the same wording
+        // the application menu's own row uses (`title_bar::menu_model::MenuCommand::Quit`).
+        "app::Quit" => Some("Quit Jerry"),
         "app::TogglePalette" => Some("Command palette"),
         "app::ToggleSettings" => Some("Open settings"),
         "app::GotoDefinition" => Some("Go to definition"),
@@ -1222,65 +1225,6 @@ mod tests {
     }
 
     #[test]
-    fn nav_groups_match_the_documented_2026_07_29_regroup() {
-        let groups = nav_groups();
-        let labels: Vec<&str> = groups.iter().map(|g| g.label).collect();
-        assert_eq!(labels, vec!["Workspace", "Interface", "Editor", "Other"]);
-        assert_eq!(
-            groups[0].pages,
-            vec![
-                SettingsPage::General,
-                SettingsPage::Agents,
-                SettingsPage::Worktrees
-            ]
-        );
-        assert_eq!(
-            groups[1].pages,
-            vec![
-                SettingsPage::Appearance,
-                SettingsPage::Theme,
-                SettingsPage::Keymap
-            ]
-        );
-        assert_eq!(
-            groups[2].pages,
-            vec![SettingsPage::Editor, SettingsPage::LanguageServers]
-        );
-        assert_eq!(
-            groups[3].pages,
-            vec![
-                SettingsPage::Notifications,
-                SettingsPage::Integrations,
-                SettingsPage::About
-            ]
-        );
-    }
-
-    #[test]
-    fn exactly_the_nine_documented_pages_are_implemented() {
-        for page in SettingsPage::ALL {
-            let expected = matches!(
-                page,
-                SettingsPage::General
-                    | SettingsPage::Agents
-                    | SettingsPage::Worktrees
-                    | SettingsPage::Appearance
-                    | SettingsPage::Theme
-                    | SettingsPage::Keymap
-                    | SettingsPage::Editor
-                    | SettingsPage::LanguageServers
-                    | SettingsPage::Notifications
-            );
-            assert_eq!(
-                page.is_implemented(),
-                expected,
-                "{:?} implemented-ness should match the design's documented scope",
-                page.label()
-            );
-        }
-    }
-
-    #[test]
     fn nav_only_pages_share_the_same_honest_placeholder_subtitle() {
         // `About`, not `Notifications`: GitHub issue #226 made Notifications a real, implemented
         // page, so it no longer shows the shared nav-only placeholder text - `About` is still
@@ -1314,46 +1258,38 @@ mod tests {
         assert_eq!(ids.len(), original_len, "duplicate SettingsPage::id()");
     }
 
+    /// One row per `AGENT_KINDS` entry, each carrying its own real resolved path and status -
+    /// the mixed case is the one that matters, since an all-or-nothing bug passes both extremes.
     #[test]
-    fn detect_agent_rows_reports_ready_for_a_resolver_that_finds_the_binary() {
-        let rows = detect_agent_rows(|name| Some(PathBuf::from(format!("/usr/bin/{name}"))));
-        assert_eq!(rows.len(), 2, "one row per AGENT_KINDS entry");
-        assert!(rows.iter().all(|row| row.is_ready()));
-        assert!(rows.iter().all(|row| row.status_label() == "ready"));
-        let claude = rows
+    fn detect_agent_rows_reports_each_binarys_own_real_status() {
+        let all_found = detect_agent_rows(|name| Some(PathBuf::from(format!("/usr/bin/{name}"))));
+        assert_eq!(all_found.len(), 2, "one row per AGENT_KINDS entry");
+        assert!(all_found.iter().all(|row| row.is_ready()));
+        assert!(all_found.iter().all(|row| row.status_label() == "ready"));
+        let claude = all_found
             .iter()
             .find(|row| row.kind == AgentKind::Claude)
             .expect("a Claude row should exist");
         assert_eq!(claude.binary_name, "claude");
         assert_eq!(claude.resolved_path, Some(PathBuf::from("/usr/bin/claude")));
-    }
 
-    #[test]
-    fn detect_agent_rows_reports_not_found_for_a_resolver_that_finds_nothing() {
-        let rows = detect_agent_rows(|_name| None);
-        assert!(rows.iter().all(|row| !row.is_ready()));
-        assert!(rows.iter().all(|row| row.status_label() == "not found"));
-    }
+        let none_found = detect_agent_rows(|_name| None);
+        assert!(none_found.iter().all(|row| !row.is_ready()));
+        assert!(none_found
+            .iter()
+            .all(|row| row.status_label() == "not found"));
 
-    #[test]
-    fn detect_agent_rows_can_report_mixed_real_and_not_found_status() {
-        let rows = detect_agent_rows(|name| {
-            if name == "claude" {
-                Some(PathBuf::from("/usr/bin/claude"))
-            } else {
-                None
-            }
-        });
-        let claude = rows
-            .iter()
-            .find(|row| row.kind == AgentKind::Claude)
-            .expect("claude row");
-        let codex = rows
-            .iter()
-            .find(|row| row.kind == AgentKind::Codex)
-            .expect("codex row");
-        assert!(claude.is_ready());
-        assert!(!codex.is_ready());
+        let mixed =
+            detect_agent_rows(|name| (name == "claude").then(|| PathBuf::from("/usr/bin/claude")));
+        let ready = |kind| {
+            mixed
+                .iter()
+                .find(|row| row.kind == kind)
+                .expect("a row per kind")
+                .is_ready()
+        };
+        assert!(ready(AgentKind::Claude));
+        assert!(!ready(AgentKind::Codex));
     }
 
     fn note(clean: Option<bool>, merged: bool, is_locked: bool) -> WorktreeNote {
@@ -1369,87 +1305,86 @@ mod tests {
         }
     }
 
+    /// The dot a worktree row paints, over every real note shape. `Prunable` outranks plain
+    /// `Clean`, a main checkout is always `Main` however dirty it is, and a *locked* merged-clean
+    /// worktree is deliberately not prunable - the same rule `WorktreeNote::is_prunable` states,
+    /// which this is a thin reduction of rather than a second implementation.
     #[test]
-    fn worktree_dot_status_main_checkout_is_always_main_regardless_of_note() {
-        let dirty_main = note(Some(false), false, false);
-        assert_eq!(
-            worktree_dot_status(true, &dirty_main),
-            WorktreeDotStatus::Main
-        );
-    }
-
-    #[test]
-    fn worktree_dot_status_prunable_takes_priority_over_plain_clean() {
-        let merged_clean = note(Some(true), true, false);
-        assert_eq!(
-            worktree_dot_status(false, &merged_clean),
-            WorktreeDotStatus::Prunable
-        );
-    }
-
-    #[test]
-    fn worktree_dot_status_dirty_and_clean_and_unknown() {
-        assert_eq!(
-            worktree_dot_status(false, &note(Some(false), false, false)),
-            WorktreeDotStatus::Dirty
-        );
-        assert_eq!(
-            worktree_dot_status(false, &note(Some(true), false, false)),
-            WorktreeDotStatus::Clean
-        );
+    fn worktree_dot_status_reduces_every_real_note_to_its_own_dot() {
         let unknown = WorktreeNote {
             is_main: false,
             clean: None,
             merge: None,
             is_locked: false,
         };
-        assert_eq!(
-            worktree_dot_status(false, &unknown),
-            WorktreeDotStatus::Unknown
-        );
+        for (name, is_main, note, expected) in [
+            (
+                "a dirty main checkout",
+                true,
+                note(Some(false), false, false),
+                WorktreeDotStatus::Main,
+            ),
+            (
+                "merged and clean",
+                false,
+                note(Some(true), true, false),
+                WorktreeDotStatus::Prunable,
+            ),
+            (
+                "dirty",
+                false,
+                note(Some(false), false, false),
+                WorktreeDotStatus::Dirty,
+            ),
+            (
+                "clean but unmerged",
+                false,
+                note(Some(true), false, false),
+                WorktreeDotStatus::Clean,
+            ),
+            ("no note at all", false, unknown, WorktreeDotStatus::Unknown),
+            (
+                "locked, merged and clean",
+                false,
+                note(Some(true), true, true),
+                WorktreeDotStatus::Clean,
+            ),
+        ] {
+            assert_eq!(worktree_dot_status(is_main, &note), expected, "{name}");
+        }
     }
 
     #[test]
-    fn worktree_dot_status_locked_merged_clean_is_not_prunable_matching_worktree_note() {
-        // Mirrors `crate::rail::state`'s own locked-worktree test - this function is a thin reduction
-        // of `WorktreeNote::is_prunable`, not a second implementation of the same rule.
-        let locked = note(Some(true), true, true);
-        assert_eq!(
-            worktree_dot_status(false, &locked),
-            WorktreeDotStatus::Clean
-        );
-    }
-
-    #[test]
-    fn worktree_row_action_main_checkout_has_no_action() {
+    fn worktree_row_action_offers_prune_only_where_pruning_is_real() {
         let main_note = WorktreeNote {
             is_main: true,
             clean: Some(true),
             merge: None,
             is_locked: false,
         };
-        assert_eq!(
-            worktree_row_action(true, &main_note),
-            WorktreeRowAction::None
-        );
-    }
-
-    #[test]
-    fn worktree_row_action_prunable_gets_prune_others_get_open() {
-        let prunable = note(Some(true), true, false);
-        assert_eq!(
-            worktree_row_action(false, &prunable),
-            WorktreeRowAction::Prune
-        );
-
-        let unmerged = note(Some(true), false, false);
-        assert_eq!(
-            worktree_row_action(false, &unmerged),
-            WorktreeRowAction::Open
-        );
-
-        let dirty = note(Some(false), false, false);
-        assert_eq!(worktree_row_action(false, &dirty), WorktreeRowAction::Open);
+        for (name, is_main, note, expected) in [
+            ("a main checkout", true, main_note, WorktreeRowAction::None),
+            (
+                "merged and clean",
+                false,
+                note(Some(true), true, false),
+                WorktreeRowAction::Prune,
+            ),
+            (
+                "clean but unmerged",
+                false,
+                note(Some(true), false, false),
+                WorktreeRowAction::Open,
+            ),
+            (
+                "dirty",
+                false,
+                note(Some(false), false, false),
+                WorktreeRowAction::Open,
+            ),
+        ] {
+            assert_eq!(worktree_row_action(is_main, &note), expected, "{name}");
+        }
     }
 
     #[test]
@@ -1595,19 +1530,33 @@ mod tests {
             .all(|language| language.binary == "synthetic-binary"));
     }
 
+    /// One row per registered language, each carrying its own real status - the mixed case is
+    /// the one that matters, since an all-or-nothing bug passes both extremes.
     #[test]
-    fn detect_lsp_rows_reports_ready_for_a_resolver_that_finds_every_binary() {
-        let rows = detect_lsp_rows(|name| Some(PathBuf::from(format!("/usr/bin/{name}"))));
-        assert_eq!(rows.len(), lsp_languages().len());
-        assert!(rows.iter().all(|row| row.is_ready()));
-        assert!(rows.iter().all(|row| row.status_label() == "ready"));
-    }
+    fn detect_lsp_rows_reports_each_binarys_own_real_status() {
+        let all_found = detect_lsp_rows(|name| Some(PathBuf::from(format!("/usr/bin/{name}"))));
+        assert_eq!(all_found.len(), lsp_languages().len());
+        assert!(all_found.iter().all(|row| row.is_ready()));
+        assert!(all_found.iter().all(|row| row.status_label() == "ready"));
 
-    #[test]
-    fn detect_lsp_rows_reports_not_installed_for_a_resolver_that_finds_nothing() {
-        let rows = detect_lsp_rows(|_| None);
-        assert!(rows.iter().all(|row| !row.is_ready()));
-        assert!(rows.iter().all(|row| row.status_label() == "not installed"));
+        let none_found = detect_lsp_rows(|_| None);
+        assert!(none_found.iter().all(|row| !row.is_ready()));
+        assert!(none_found
+            .iter()
+            .all(|row| row.status_label() == "not installed"));
+
+        let mixed = detect_lsp_rows(|name| {
+            (name == "rust-analyzer").then(|| PathBuf::from("/usr/bin/rust-analyzer"))
+        });
+        let ready = |language| {
+            mixed
+                .iter()
+                .find(|row| row.language == language)
+                .unwrap_or_else(|| panic!("a {language} row should exist"))
+                .is_ready()
+        };
+        assert!(ready("Rust"));
+        assert!(!ready("Go"));
     }
 
     #[test]
@@ -1629,27 +1578,6 @@ mod tests {
             rust.install_url,
             "https://rust-analyzer.github.io/book/rust_analyzer_binary.html"
         );
-    }
-
-    #[test]
-    fn detect_lsp_rows_can_report_mixed_real_and_not_installed_status() {
-        let rows = detect_lsp_rows(|name| {
-            if name == "rust-analyzer" {
-                Some(PathBuf::from("/usr/bin/rust-analyzer"))
-            } else {
-                None
-            }
-        });
-        let rust = rows
-            .iter()
-            .find(|row| row.language == "Rust")
-            .expect("a Rust row should exist");
-        let go = rows
-            .iter()
-            .find(|row| row.language == "Go")
-            .expect("a Go row should exist");
-        assert!(rust.is_ready());
-        assert!(!go.is_ready());
     }
 
     #[test]
@@ -1689,296 +1617,44 @@ mod tests {
         }
     }
 
+    /// The keystroke-swallowing bug class this page's rows exist to make visible: a binding that
+    /// claims a plain letter or a bare `Ctrl+C` *globally* eats that keystroke out of a focused
+    /// terminal or text field. Each command below is registered with a real context predicate for
+    /// that reason, so each must report as scoped rather than global.
     #[test]
-    fn keybinding_rows_are_derived_in_real_registration_order() {
-        let bindings = crate::default_key_bindings();
-        let rows = keybinding_rows(&bindings, &[]);
-        let commands: Vec<&str> = rows.iter().map(|row| row.command).collect();
-        assert_eq!(
-            commands,
-            vec![
-                "New agent",
-                "Command palette",
-                "Open settings",
-                "Text: undo",
-                "Text: redo",
-                "Text: redo",
-                "Text: copy selection",
-                "Text: cut selection",
-                "Text: paste",
-                "Text: select all",
-                "Go to definition",
-                "New terminal",
-                "New agent pane",
-                "Open git graph",
-                "Search in this worktree",
-                "Find in this file",
-                "Next changed file",
-                "Mark file seen / unseen",
-                "Stage / unstage file",
-                "Jump to agent 1",
-                "Jump to agent 2",
-                "Jump to agent 3",
-                "Jump to agent 4",
-                "Jump to agent 5",
-                "Jump to agent 6",
-                "Jump to agent 7",
-                "Jump to agent 8",
-                "Editor: delete backward",
-                "Editor: delete forward",
-                "Editor: insert newline",
-                "Editor: move left",
-                "Editor: move right",
-                "Editor: move up",
-                "Editor: move down",
-                "Editor: extend selection left",
-                "Editor: extend selection right",
-                "Editor: extend selection up",
-                "Editor: extend selection down",
-                "Editor: move left one word",
-                "Editor: move right one word",
-                "Editor: extend selection left one word",
-                "Editor: extend selection right one word",
-                "Editor: go to line start",
-                "Editor: go to line end",
-                "Editor: select all",
-                "Editor: copy",
-                "Editor: cut",
-                "Editor: paste",
-                "Editor: save file",
-                "Editor: save file (overwrite external change)",
-                "Editor: select next occurrence",
-                "Editor: select all occurrences",
-                "Editor: skip occurrence",
-                // GitHub issue #26's real Tab/Shift+Tab indentation, scoped
-                // `"file-editor && !completions"` - see `crate::default_key_bindings`'s own docs
-                // for why `Tab` no longer falls through to plain-text insertion here.
-                "Editor: indent",
-                "Editor: dedent",
-                // `Escape` here is `EditorCollapseCursors`, not a separate `EditorEscape` - it
-                // composes GitHub issue #28's own multi-cursor collapse with issue #26's
-                // accessibility focus-out hatch, since only one binding can genuinely own the
-                // File view's plain `Escape` at equal context depth (see `crate::code_surface::
-                // editing::AdeApp::handle_editor_collapse_cursors_action`'s own docs).
-                "Editor: collapse cursors",
-                "Completions: select previous",
-                "Completions: select next",
-                "Completions: accept selected",
-                "Completions: accept selected",
-                "Completions: dismiss",
-                // GitHub issue #26's manual completion trigger/refresh, scoped plain
-                // `"file-editor"` (fires whether the popup is open or closed).
-                "Completions: trigger",
-                // Revision R8.5c's `"merge-editor"`-scoped bindings for Surface D's merge
-                // hand-edit whole-file editor - the same real `Editor*` action *types*/labels as
-                // the `"file-editor"` set above (reused, not duplicated - see
-                // `crate::code_surface::editing::AdeApp::active_edit_target`'s own docs), minus
-                // `EditorSaveAnyway` (deliberately never bound here - there is no
-                // external-change-conflict concept for a merge hand-edit buffer) and minus every
-                // `Completions*` binding (no completions popup is ever wired up for this
-                // surface).
-                "Editor: delete backward",
-                "Editor: delete forward",
-                "Editor: insert newline",
-                "Editor: move left",
-                "Editor: move right",
-                "Editor: move up",
-                "Editor: move down",
-                "Editor: extend selection left",
-                "Editor: extend selection right",
-                "Editor: extend selection up",
-                "Editor: extend selection down",
-                "Editor: move left one word",
-                "Editor: move right one word",
-                "Editor: extend selection left one word",
-                "Editor: extend selection right one word",
-                "Editor: go to line start",
-                "Editor: go to line end",
-                "Editor: select all",
-                "Editor: copy",
-                "Editor: cut",
-                "Editor: paste",
-                "Editor: save file",
-                // The same GitHub issue #26 indent/dedent/escape bindings, mirrored here for the
-                // merge hand-edit target - scoped plain `"merge-editor"` (no completions popup
-                // exists for this surface, so there's no `!completions` narrowing to mirror).
-                "Editor: indent",
-                "Editor: dedent",
-                "Editor: move focus out",
-                // GitHub issue #19's file-tree bindings, each scoped to
-                // `"file-tree && !tree-editing"` - see `crate::default_key_bindings`' own docs
-                // and `crate::sidebar::tree_ops`' module docs for why both halves of that
-                // predicate are load-bearing.
-                "Files tree: rename",
-                "Files tree: copy",
-                "Files tree: cut",
-                "Files tree: paste",
-                // GitHub issue #105's `Delete` (runs immediately, no confirmation) and its own
-                // real undo/redo, `Ctrl+Z`/`Ctrl+Shift+Z` - distinct actions from `TextUndo`/
-                // `TextRedo`, scoped the same `"file-tree && !tree-editing"` as every binding
-                // above.
-                "Files tree: delete",
-                "Files tree: undo",
-                "Files tree: redo",
-                "Close focused tab",
-                "Terminal: clear",
-                "Terminal: copy selection",
-                "Terminal: paste",
-                // GitHub issue #304's interactive-rebase plan verbs, scoped
-                // `Some("rebase-plan && !text-input")` (and plain `Some("rebase-plan")` for the
-                // last) - the real bindings behind design spec §1.4's footer keycap hints.
-                "Rebase plan: move row up",
-                "Rebase plan: move row down",
-                "Rebase plan: pick",
-                "Rebase plan: squash",
-                "Rebase plan: drop",
-                "Rebase plan: start rebase",
-                "Diff: send review notes to the agent",
-                "Diff: note on this line",
-            ]
-        );
-    }
-
-    #[test]
-    fn keybinding_rows_report_the_real_global_context_for_every_default_binding() {
-        // Regression coverage for the bug this replaced: a hand-copied list once labeled
-        // `Go to definition` `context: "editor"` even though it's actually registered global.
-        //
-        // Revision R8.5a added a second real scoped context (`"file-editor"`, the real File
-        // view text-editing actions) alongside the pre-existing `"diff"` one (`]` ->
-        // `NextChangedFile`) - both are deliberately non-global for the same real reason
-        // (swallowing ordinary keystrokes in a focused terminal agent), so the scoped count
-        // grew from 1 to 1 + 19 real `Editor*` bindings (a fix round added `EditorSaveAnyway`,
-        // the real escape hatch for a permanently-stuck `AdeApp::file_external_conflict`). A
-        // later fix round changed `]`'s own registered predicate from `Some("diff")` to
-        // `Some("diff && !file-editor")` (a real, live-reproduced bug: since `"file-editor"` is
-        // *added onto* the same node's context rather than replacing `"diff"`, the bare
-        // `"diff"` predicate kept matching - and kept swallowing a literal `]` keystroke - even
-        // while a file was actively being edited) - `KeybindingRow::context` only ever reports
-        // the coarse `"global"`/`"scoped"` distinction (see its own docs), so that predicate
-        // change doesn't move this test's own counts, but `]` is still exactly as "scoped" as
-        // before. Revision R8.5b added 5 more real scoped bindings for the Completions popup
-        // (`CompletionsUp`/`CompletionsDown`/`CompletionsDismiss`, plus `CompletionsAccept`
-        // bound twice - `tab` and `enter`), each `Some("file-editor && completions")`.
-        // Revision R8.5c added 18 more real scoped bindings for Surface D's merge hand-edit
-        // whole-file editor, each `Some("merge-editor")` - the same 18 `Editor*` actions as the
-        // `"file-editor"` set minus `EditorSaveAnyway` (see
-        // `keybinding_rows_are_derived_in_real_registration_order`'s own updated expectations
-        // for exactly which).
-        // GitHub issue #17 added 3 more real scoped bindings, `TextUndo` (`secondary-z`) and
-        // `TextRedo` (bound twice - `secondary-shift-z` and `ctrl-y`), each `Some("text-input")`:
-        // `secondary-z` resolves to plain `Ctrl+Z` on Linux/Windows, which a focused terminal
-        // needs unclaimed to send the real `SIGTSTP` suspend control byte
-        // (`crate::terminal::pane::keystroke_to_bytes`) - see `crate::default_key_bindings`'s own
-        // docs for the full reasoning.
-        // GitHub issue #27 added 8 more real scoped bindings: `EditorWordLeft`/`EditorWordRight`/
-        // `EditorSelectWordLeft`/`EditorSelectWordRight`, each bound once under `"file-editor"`
-        // and once under `"merge-editor"` - the same word-wise-caret-navigation set both real
-        // editors share, matching every other `Editor*` action's own dual registration.
-        // Revision R13 (issue #28) added 4 more real scoped bindings, all File-view-only
-        // (`crate::merge::editing`'s `"merge-editor"` context deliberately does not get these):
-        // `EditorSelectNextOccurrence` (`Ctrl+D`), `EditorSelectAllOccurrences` (`Ctrl+Shift+L`),
-        // `EditorSkipOccurrence` (`Ctrl+K Ctrl+D`, all three `Some("file-editor")`), and
-        // `EditorCollapseCursors` (`Esc`, `Some("file-editor && !completions")` - narrowed rather
-        // than the other three's bare `"file-editor"` because GitHub issue #26 also wants the
-        // File view's plain `Escape` for its own accessibility focus-out hatch, and only one
-        // binding can genuinely own a keystroke at equal context depth; see `crate::
-        // code_surface::editing::AdeApp::handle_editor_collapse_cursors_action`'s own docs for how
-        // it composes both real behaviors from this one binding rather than a separate
-        // `EditorEscape` shadowing or being shadowed by it).
-        // GitHub issue #26 added 7 more real scoped bindings on top of that (not counting
-        // `EditorCollapseCursors` above, which is issue #28's own action): `EditorIndent`/
-        // `EditorDedent` under `"file-editor && !completions"` (2), the same two again plus
-        // `EditorEscape` under plain `"merge-editor"` (3, `EditorEscape` here since
-        // `"merge-editor"` never gets multi-cursor actions and so never faces the same collision
-        // `EditorCollapseCursors` resolves in the File view), `CompletionsInvoke` under plain
-        // `"file-editor"` (1), and `CloseFocusedTab` under `Some("!terminal")` (1, the same real
-        // terminal-control-byte conflict class `"ctrl-shift-t"` above already established).
-        // GitHub issue #105 added 3 more real scoped bindings: `FileTreeDelete` (`Delete`, runs
-        // immediately - no confirmation step, so no different scoping from Copy/Cut/Paste/Rename
-        // above it) and its own `FileTreeUndo`/`FileTreeRedo` (`Ctrl+Z`/`Ctrl+Shift+Z`) - distinct
-        // actions from `TextUndo`/`TextRedo`, all three `Some("file-tree && !tree-editing")`.
-        // GitHub issue #20 added 1 more real scoped binding: `TerminalClear`
-        // (`cmd-k`/`ctrl-shift-l`), `Some("terminal")`.
-        // GitHub issue #155 removed 1: `FileTreeContextMenu` (`Shift+F10`) - right-click plus
-        // each row's own already-bound shortcut covers the same ground, so a second
-        // keyboard-only path to the menu had no real justification of its own.
-        // GitHub issue #158 added 2 more real scoped bindings: `TerminalCopy`/`TerminalPaste`
-        // (`cmd-c`/`cmd-v` on macOS, `ctrl-shift-c`/`ctrl-shift-v` elsewhere), both
-        // `Some("terminal")` - see `crate::default_key_bindings`'s own entry for why the shifted
-        // variants, and why leaving them unbound was the bug.
-        // GitHub issue #286 added 1 more real scoped binding: `v` -> `ToggleChangeSeen`, under
-        // the same `Some("diff && !file-editor")` predicate `]` carries and for the same reason -
-        // a plain letter must never be claimed over a focused terminal, and the seen-state it
-        // toggles belongs to the file whose diff is open.
-        // GitHub issue #304 added 6 more real scoped bindings: the interactive-rebase plan's own
-        // `RebaseReorderUp`/`RebaseReorderDown`/`RebasePickRow`/`RebaseSquashRow`/`RebaseDropRow`
-        // under `Some("rebase-plan && !text-input")` (5 - see `crate::default_key_bindings` for
-        // why the negated conjunct is load-bearing over a surface that contains a real text
-        // field) and `RebaseStart` under plain `Some("rebase-plan")` (1).
-        // GitHub issue #288 added 2 more real scoped bindings, on the diff's own review-notes
-        // surface: `SendReviewNotes` (`mod+enter`) under plain `Some("diff-view")` - the notes
-        // bar draws it as keycaps, and having just typed a note is the likeliest moment to send
-        // the batch - and `ToggleLineNote` (`c`) under `Some("diff-view && !text-input")`, the
-        // same negated conjunct and the same reason as the rebase plan's plain letters above:
-        // the pinned note card is a real text field inside that very container.
-        // GitHub issue #162 added 1 more scoped binding: `mod+F` -> `FindInFile` under
-        // `Some("file-editor")`. Its sibling `mod+shift+F` -> `SearchInWorktree` is deliberately
-        // *global* and so is not counted here - the right panel's Search tab has no editor to be
-        // scoped to, and a real Cmd/Ctrl-modified keystroke never reaches a focused pty anyway.
-        // The Changes-footer prose fix added 1 more: `space` -> `ToggleChangeStaged`, alongside
-        // `v` and `]` - `Jerry.dc.html`'s `changesHints` advertises `space stage` in that footer
-        // and nothing was bound to it. All three of those now also carry `&& !text-input`, since
-        // issue #288's pinned note card is a real text input *inside* the `"diff"` node that
-        // `"file-editor"` does not cover.
-        // GitHub issue #336 added 4 more scoped bindings: `TextCopy`/`TextCut`/`TextPaste`/
-        // `TextSelectAll` (`mod+C`/`mod+X`/`mod+V`/`mod+A`) under
-        // `Some("text-input && !file-editor && !merge-editor")` - the same `"text-input"` tag
-        // `TextUndo`/`TextRedo` above carry, with the two editor surfaces excluded because their
-        // own `Editor*` actions already own those exact keystrokes there at the same predicate
-        // depth (see `crate::default_key_bindings`' own entry).
-        let bindings = crate::default_key_bindings();
-        let rows = keybinding_rows(&bindings, &[]);
-        assert!(!rows.is_empty());
-        let scoped: Vec<&KeybindingRow> =
-            rows.iter().filter(|row| row.context != "global").collect();
-        assert_eq!(
-            scoped.len(),
-            90,
-            "expected `] -> NextChangedFile` (1) plus every real Editor* binding (19) plus \
-             every real Completions* binding (5) plus every real merge-editor binding (18) plus \
-             TextUndo/TextRedo (3, GitHub issue #17) plus every real \
-             file-tree binding (7, GitHub issues #19 and #105, less 1 for issue #155's removed \
-             FileTreeContextMenu) plus every real word-wise Editor* \
-             binding (8, GitHub issue #27) plus every real multi-cursor Editor* binding (4, \
-             GitHub issue #28) plus every real GitHub issue #26 binding (7, not counting \
-             EditorCollapseCursors above, which is issue #28's own action) plus TerminalClear \
-             (1, GitHub issue #20) plus TerminalCopy/TerminalPaste (2, GitHub issue #158) plus \
-             every real interactive-rebase plan binding (6, GitHub issue #304) plus every \
-             real review-note binding (2, GitHub issue #288) plus `space -> \
-             ToggleChangeStaged` (1, the Changes footer's own `space stage` hint) plus \
-             `mod+F -> FindInFile` (1, GitHub issue #162's in-file find) plus \
-             TextCopy/TextCut/TextPaste/TextSelectAll (4, GitHub issue #336) to be scoped, \
-             not global"
-        );
+    fn every_binding_registered_behind_a_context_is_reported_as_scoped_not_global() {
+        let rows = keymap_page_rows();
+        let scoped: Vec<&str> = rows
+            .iter()
+            .filter(|row| row.context != "global")
+            .map(|row| row.command)
+            .collect();
         assert!(
-            scoped
-                .iter()
-                .filter(|row| row.command.starts_with("Files tree: "))
-                .count()
-                == 7,
-            "every file-tree binding must be reported as scoped - a globally-bound Ctrl+C would \
-             be exactly the keystroke-swallowing bug class this list's own docs catalogue"
+            !scoped.is_empty(),
+            "premise: some bindings really are scoped"
         );
-        assert!(
-            scoped.iter().any(|row| row.command == "Next changed file"),
-            "the diff-scoped (now diff && !file-editor) ] binding must still be reported as \
-             scoped"
-        );
-        assert!(
-            scoped.iter().any(|row| row.command == "Editor: save file"),
-            "a real file-editor-scoped binding must be reported as scoped too"
-        );
+        for command in [
+            "Files tree: rename",
+            "Files tree: copy",
+            "Files tree: cut",
+            "Files tree: paste",
+            "Files tree: delete",
+            "Next changed file",
+            "Mark file seen / unseen",
+            "Stage / unstage file",
+            "Editor: save file",
+            "Completions: accept selected",
+            "Terminal: clear",
+            "Terminal: copy selection",
+            "Rebase plan: pick",
+            "Diff: note on this line",
+        ] {
+            assert!(
+                scoped.contains(&command),
+                "{command:?} must be reported as scoped - a global binding for it would swallow \
+                 that keystroke out of a focused terminal or text field"
+            );
+        }
     }
 
     #[test]

--- a/crates/app/src/settings/store.rs
+++ b/crates/app/src/settings/store.rs
@@ -1217,6 +1217,10 @@ mod tests {
         );
     }
 
+    /// Save then load has to be the identity on every field a user can change - a field that
+    /// silently reverts to its default on the next launch is not a real setting. Asserted as a
+    /// whole-value equality rather than field by field, so a newly added field is covered here
+    /// the moment it is mutated below.
     #[test]
     fn a_settings_value_round_trips_through_real_toml_save_and_load() {
         let dir = tempfile::tempdir().expect("tempdir");
@@ -1226,6 +1230,10 @@ mod tests {
         settings.window.controls = WindowControlsStyle::MacosStyle;
         settings.appearance.interface_scale_percent = 125;
         settings.appearance.editor_font_size = 15.5;
+        assert!(
+            settings.appearance.show_indent_guides,
+            "premise: the real default is guides on, so `false` below is a real change"
+        );
         settings.appearance.show_indent_guides = false;
         settings.theme.name = "Slate".to_string();
         settings.theme.high_contrast_diff = true;
@@ -1234,25 +1242,6 @@ mod tests {
         let loaded = Settings::load_or_init_at(&path);
 
         assert_eq!(settings, loaded);
-    }
-
-    #[test]
-    fn show_indent_guides_round_trips_through_real_toml_save_and_load() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let path = dir.path().join("settings.toml");
-
-        assert!(
-            Settings::default().appearance.show_indent_guides,
-            "sanity check: the real default is guides on"
-        );
-
-        let mut settings = Settings::default();
-        settings.appearance.show_indent_guides = false;
-        settings.save_at(&path).expect("save should succeed");
-        let loaded = Settings::load_or_init_at(&path);
-
-        assert_eq!(settings, loaded);
-        assert!(!loaded.appearance.show_indent_guides);
     }
 
     #[test]

--- a/crates/app/src/settings/widgets.rs
+++ b/crates/app/src/settings/widgets.rs
@@ -650,79 +650,42 @@ impl ChoiceOption {
 #[cfg(test)]
 mod open_command_tests {
     use super::open_command_for;
-    use std::ffi::OsString;
+    use std::ffi::{OsStr, OsString};
     use std::path::Path;
 
     fn os_strings(values: &[&str]) -> Vec<OsString> {
         values.iter().map(OsString::from).collect()
     }
 
+    /// Every platform's real command, for both target shapes this is genuinely reused for: a
+    /// local settings path, and the Language servers page's `https://` install URL
+    /// (`AdeApp::open_install_url`). An unrecognized OS falls back to `xdg-open` rather than
+    /// failing.
+    ///
+    /// Windows' empty-string argument is load-bearing, not incidental - see
+    /// [`open_command_for`]'s own docs: without it, `start` treats the target itself as its
+    /// window-title argument.
     #[test]
-    fn macos_uses_the_real_open_command() {
-        let (program, args) =
-            open_command_for("macos", Path::new("/home/x/settings.toml").as_os_str());
-        assert_eq!(program, "open");
-        assert_eq!(args, os_strings(&["/home/x/settings.toml"]));
-    }
-
-    #[test]
-    fn windows_uses_cmd_start_with_a_required_empty_title_argument() {
-        let (program, args) = open_command_for(
-            "windows",
+    fn every_platform_opens_every_real_target_with_its_own_command() {
+        const URL: &str = "https://rust-analyzer.github.io/book/rust_analyzer_binary.html";
+        for target in [
+            Path::new("/home/x/settings.toml").as_os_str(),
             Path::new(r"C:\Users\x\settings.toml").as_os_str(),
-        );
-        assert_eq!(program, "cmd");
-        // The empty string is load-bearing, not incidental - see `open_command_for`'s docs:
-        // without it, `start` would treat the path itself as its window-title argument.
-        assert_eq!(
-            args,
-            os_strings(&["/c", "start", "", r"C:\Users\x\settings.toml"])
-        );
-    }
-
-    #[test]
-    fn linux_uses_the_real_xdg_open_command() {
-        let (program, args) =
-            open_command_for("linux", Path::new("/home/x/settings.toml").as_os_str());
-        assert_eq!(program, "xdg-open");
-        assert_eq!(args, os_strings(&["/home/x/settings.toml"]));
-    }
-
-    #[test]
-    fn an_unrecognized_target_os_falls_back_to_xdg_open() {
-        let (program, _) = open_command_for("freebsd", Path::new("/x").as_os_str());
-        assert_eq!(program, "xdg-open");
-    }
-
-    #[test]
-    fn every_platform_command_works_unchanged_for_a_real_url_target() {
-        let url =
-            std::ffi::OsStr::new("https://rust-analyzer.github.io/book/rust_analyzer_binary.html");
-
-        let (program, args) = open_command_for("macos", url);
-        assert_eq!(program, "open");
-        assert_eq!(
-            args,
-            os_strings(&["https://rust-analyzer.github.io/book/rust_analyzer_binary.html"])
-        );
-
-        let (program, args) = open_command_for("windows", url);
-        assert_eq!(program, "cmd");
-        assert_eq!(
-            args,
-            os_strings(&[
-                "/c",
-                "start",
-                "",
-                "https://rust-analyzer.github.io/book/rust_analyzer_binary.html"
-            ])
-        );
-
-        let (program, args) = open_command_for("linux", url);
-        assert_eq!(program, "xdg-open");
-        assert_eq!(
-            args,
-            os_strings(&["https://rust-analyzer.github.io/book/rust_analyzer_binary.html"])
-        );
+            OsStr::new(URL),
+        ] {
+            let raw = target.to_string_lossy().into_owned();
+            for (os, program, args) in [
+                ("macos", "open", os_strings(&[&raw])),
+                ("windows", "cmd", os_strings(&["/c", "start", "", &raw])),
+                ("linux", "xdg-open", os_strings(&[&raw])),
+                ("freebsd", "xdg-open", os_strings(&[&raw])),
+            ] {
+                assert_eq!(
+                    open_command_for(os, target),
+                    (program, args),
+                    "{os} / {raw}"
+                );
+            }
+        }
     }
 }

--- a/crates/app/src/sidebar/changes.rs
+++ b/crates/app/src/sidebar/changes.rs
@@ -359,10 +359,12 @@ pub fn fold_gap_between(prev_header: &str, next_header: &str) -> Option<usize> {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
+mod diff_stat_tests {
+    use crate::sidebar::changes::{
+        diff_file_stats, staged_diff_stats, stat_bar_segments, StatSegment,
+    };
     use std::path::PathBuf;
-    use wt_core::diff::{DiffHunk, DiffLine};
+    use wt_core::diff::{DiffFile, DiffHunk, DiffLine, DiffLineKind, FileChangeStatus};
 
     fn line(kind: DiffLineKind, text: &str) -> DiffLine {
         DiffLine {
@@ -371,7 +373,14 @@ mod tests {
         }
     }
 
-    fn sample_file(status: FileChangeStatus, hunks: Vec<DiffHunk>) -> DiffFile {
+    fn hunk(lines: Vec<DiffLine>) -> DiffHunk {
+        DiffHunk {
+            header: "@@ -1,2 +1,3 @@".to_string(),
+            lines,
+        }
+    }
+
+    fn file_with(status: FileChangeStatus, hunks: Vec<DiffHunk>) -> DiffFile {
         DiffFile {
             path: PathBuf::from("src/main.rs"),
             old_path: None,
@@ -384,54 +393,85 @@ mod tests {
 
     #[test]
     fn diff_file_stats_counts_added_and_removed_lines_only() {
-        let file = sample_file(
+        let mixed = file_with(
             FileChangeStatus::Modified,
-            vec![DiffHunk {
-                header: "@@ -1,2 +1,3 @@".to_string(),
-                lines: vec![
-                    line(DiffLineKind::Context, "ctx"),
-                    line(DiffLineKind::Added, "a1"),
-                    line(DiffLineKind::Added, "a2"),
-                    line(DiffLineKind::Removed, "r1"),
-                ],
-            }],
+            vec![hunk(vec![
+                line(DiffLineKind::Context, "ctx"),
+                line(DiffLineKind::Added, "a1"),
+                line(DiffLineKind::Added, "a2"),
+                line(DiffLineKind::Removed, "r1"),
+            ])],
         );
-        assert_eq!(diff_file_stats(&file), (2, 1));
+        assert_eq!(diff_file_stats(&mixed), (2, 1));
+        assert_eq!(
+            diff_file_stats(&file_with(FileChangeStatus::Renamed, Vec::new())),
+            (0, 0),
+            "a file with no hunks at all contributes nothing"
+        );
+    }
+
+    /// The bar is always five segments, split in proportion, with the "bump a nonzero category up
+    /// to one segment" rule this function documents - so a single added line among 400 removed
+    /// still shows.
+    #[test]
+    fn the_stat_bar_is_five_segments_split_in_proportion() {
+        use StatSegment::{Add, Del, Empty};
+        for (add, del, expected) in [
+            (0, 0, [Empty, Empty, Empty, Empty, Empty]),
+            (40, 0, [Add, Add, Add, Add, Add]),
+            (0, 40, [Del, Del, Del, Del, Del]),
+            (1, 399, [Add, Del, Del, Del, Del]),
+        ] {
+            assert_eq!(stat_bar_segments(add, del), expected, "+{add} -{del}");
+        }
+        for (add, del) in [(1, 0), (0, 1), (1, 1), (3, 400), (400, 3), (7, 7)] {
+            assert_eq!(stat_bar_segments(add, del).len(), 5, "+{add} -{del}");
+        }
+    }
+
+    fn changed_file(path: &str, add_lines: u32, del_lines: u32) -> DiffFile {
+        let mut lines = Vec::new();
+        for _ in 0..add_lines {
+            lines.push(line(DiffLineKind::Added, "a"));
+        }
+        for _ in 0..del_lines {
+            lines.push(line(DiffLineKind::Removed, "d"));
+        }
+        let mut file = file_with(FileChangeStatus::Modified, vec![hunk(lines)]);
+        file.path = PathBuf::from(path);
+        file
     }
 
     #[test]
-    fn diff_file_stats_is_zero_for_a_file_with_no_hunks() {
-        let file = sample_file(FileChangeStatus::Renamed, Vec::new());
-        assert_eq!(diff_file_stats(&file), (0, 0));
+    fn staged_diff_stats_sums_only_the_staged_files() {
+        let a = changed_file("src/a.rs", 3, 1);
+        let b = changed_file("src/b.rs", 2, 5);
+        assert_eq!(staged_diff_stats(&[&a, &b]), (5, 6));
+        assert_eq!(staged_diff_stats(&[&a]), (3, 1));
+        assert_eq!(staged_diff_stats(&[]), (0, 0));
     }
+}
 
+#[cfg(test)]
+mod status_letter_tests {
+    use crate::sidebar::changes::{status_letter, StatusLetter};
+    use crate::theme;
+    use wt_core::diff::FileChangeStatus;
+
+    /// `STAGE-A-CHANGELOG.md` §4j: every status maps to a letter, including the common case. The
+    /// word pills this replaced returned `None` for `Modified`, which is the exact defect §4j
+    /// names - "only the exceptions were marked". A rename is a modification as far as the letter
+    /// column is concerned; the row's own `moved` chip is what states the rename.
     #[test]
     fn every_file_status_gets_a_letter_including_the_common_case() {
-        assert_eq!(status_letter(FileChangeStatus::Added), StatusLetter::Added);
-        assert_eq!(
-            status_letter(FileChangeStatus::Modified),
-            StatusLetter::Modified
-        );
-        assert_eq!(
-            status_letter(FileChangeStatus::Deleted),
-            StatusLetter::Deleted
-        );
-        // A rename is a modification as far as the letter column is concerned - the row's own
-        // `moved` chip is what states the rename. See `status_letter`'s own docs.
-        assert_eq!(
-            status_letter(FileChangeStatus::Renamed),
-            StatusLetter::Modified
-        );
-    }
-
-    #[test]
-    fn the_letters_are_gits_own_and_their_tooltips_spell_them_out() {
-        assert_eq!(StatusLetter::Added.glyph(), "A");
-        assert_eq!(StatusLetter::Modified.glyph(), "M");
-        assert_eq!(StatusLetter::Deleted.glyph(), "D");
-        assert_eq!(StatusLetter::Added.tooltip(), "Added");
-        assert_eq!(StatusLetter::Modified.tooltip(), "Modified");
-        assert_eq!(StatusLetter::Deleted.tooltip(), "Deleted");
+        for (status, letter) in [
+            (FileChangeStatus::Added, StatusLetter::Added),
+            (FileChangeStatus::Modified, StatusLetter::Modified),
+            (FileChangeStatus::Deleted, StatusLetter::Deleted),
+            (FileChangeStatus::Renamed, StatusLetter::Modified),
+        ] {
+            assert_eq!(status_letter(status), letter, "{status:?}");
+        }
     }
 
     #[test]
@@ -451,93 +491,76 @@ mod tests {
             StatusLetter::Deleted.color()
         );
     }
+}
 
-    #[test]
-    fn zero_changes_is_an_all_empty_bar() {
-        assert_eq!(stat_bar_segments(0, 0), [StatSegment::Empty; 5]);
+#[cfg(test)]
+mod staging_scope_tests {
+    use crate::sidebar::changes::{
+        commit_button_label, is_committed_clean, stageable_count, staged_subset, StagedProgress,
+    };
+    use std::collections::HashSet;
+    use std::path::{Path, PathBuf};
+    use wt_core::diff::{DiffFile, DiffHunk, DiffLine, DiffLineKind, FileChangeStatus};
+
+    fn changed_file(path: &str, add_lines: u32, del_lines: u32) -> DiffFile {
+        let mut lines = Vec::new();
+        for _ in 0..add_lines {
+            lines.push(DiffLine {
+                kind: DiffLineKind::Added,
+                content: "a".to_string(),
+            });
+        }
+        for _ in 0..del_lines {
+            lines.push(DiffLine {
+                kind: DiffLineKind::Removed,
+                content: "d".to_string(),
+            });
+        }
+        DiffFile {
+            path: PathBuf::from(path),
+            old_path: None,
+            status: FileChangeStatus::Modified,
+            is_binary: false,
+            hunks: vec![DiffHunk {
+                header: "@@ -1,1 +1,1 @@".to_string(),
+                lines,
+            }],
+            truncated: false,
+        }
     }
 
+    /// `None` is "the `git status` answer hasn't landed", not "nothing is dirty" - claiming a file
+    /// is committed on the strength of an absent answer is exactly the mislabelling GitHub issue
+    /// #220 is about, in the other direction.
     #[test]
-    fn pure_additions_fill_the_entire_bar_with_add_segments() {
-        assert_eq!(
-            stat_bar_segments(40, 0),
-            [
-                StatSegment::Add,
-                StatSegment::Add,
-                StatSegment::Add,
-                StatSegment::Add,
-                StatSegment::Add
-            ]
-        );
-    }
-
-    #[test]
-    fn pure_deletions_fill_the_entire_bar_with_del_segments() {
-        assert_eq!(
-            stat_bar_segments(0, 40),
-            [
-                StatSegment::Del,
-                StatSegment::Del,
-                StatSegment::Del,
-                StatSegment::Del,
-                StatSegment::Del
-            ]
-        );
-    }
-
-    #[test]
-    fn every_stat_bar_is_exactly_five_segments() {
-        for (add, del) in [(0, 0), (1, 0), (0, 1), (1, 1), (3, 400), (400, 3), (7, 7)] {
-            assert_eq!(stat_bar_segments(add, del).len(), 5);
+    fn only_a_path_absent_from_a_known_dirty_set_is_committed_clean() {
+        let dirty: HashSet<PathBuf> = [PathBuf::from("src/edited.rs")].into_iter().collect();
+        for (path, known_dirty, expected) in [
+            ("src/committed.rs", Some(&dirty), true),
+            ("src/edited.rs", Some(&dirty), false),
+            ("src/anything.rs", None, false),
+        ] {
+            assert_eq!(
+                is_committed_clean(Path::new(path), known_dirty),
+                expected,
+                "{path} with dirty set {known_dirty:?}"
+            );
         }
     }
 
     #[test]
-    fn a_tiny_minority_category_still_gets_at_least_one_visible_segment() {
-        // 1 out of 400 lines added would floor to 0/5 segments without the "bump nonzero up
-        // to 1" rule this function documents - confirm the bump actually applies.
-        let segments = stat_bar_segments(1, 399);
-        assert!(segments.contains(&StatSegment::Add));
-    }
-
-    #[test]
-    fn a_path_missing_from_a_known_dirty_set_is_committed_clean() {
-        let dirty: HashSet<PathBuf> = [PathBuf::from("src/edited.rs")].into_iter().collect();
-        assert!(is_committed_clean(
-            Path::new("src/committed.rs"),
-            Some(&dirty)
-        ));
-        assert!(!is_committed_clean(
-            Path::new("src/edited.rs"),
-            Some(&dirty)
-        ));
-    }
-
-    #[test]
-    fn nothing_is_committed_clean_while_the_dirty_set_is_still_unknown() {
-        // `None` is "the `git status` answer hasn't landed", not "nothing is dirty" - claiming a
-        // file is committed on the strength of an absent answer is exactly the mislabelling
-        // GitHub issue #220 is about, in the other direction.
-        assert!(!is_committed_clean(Path::new("src/anything.rs"), None));
-    }
-
-    #[test]
-    fn stageable_count_excludes_committed_clean_files() {
+    fn stageable_count_excludes_committed_clean_files_and_falls_back_when_unknown() {
         let files = vec![
             changed_file("src/committed.rs", 4, 0),
             changed_file("src/edited.rs", 1, 1),
         ];
         let dirty: HashSet<PathBuf> = [PathBuf::from("src/edited.rs")].into_iter().collect();
         assert_eq!(stageable_count(&files, Some(&dirty)), 1);
-    }
-
-    #[test]
-    fn stageable_count_falls_back_to_every_file_when_the_dirty_set_is_unknown() {
-        let files = vec![
-            changed_file("src/a.rs", 1, 0),
-            changed_file("src/b.rs", 0, 1),
-        ];
-        assert_eq!(stageable_count(&files, None), 2);
+        assert_eq!(
+            stageable_count(&files, None),
+            2,
+            "with no `git status` answer yet, every changed file is still a candidate"
+        );
     }
 
     #[test]
@@ -560,71 +583,74 @@ mod tests {
     }
 
     #[test]
-    fn staged_progress_fraction_handles_zero_total_without_dividing_by_zero() {
-        let progress = StagedProgress {
-            staged: 0,
-            total: 0,
-        };
-        assert_eq!(progress.fraction(), 0.0);
+    fn staged_progress_is_staged_over_total_and_never_divides_by_zero() {
+        for (staged, total, fraction) in [(0usize, 0usize, 0.0f32), (3, 12, 0.25)] {
+            let progress = StagedProgress { staged, total };
+            assert!(
+                (progress.fraction() - fraction).abs() < f32::EPSILON,
+                "{staged} of {total}"
+            );
+        }
     }
 
     #[test]
-    fn staged_progress_fraction_is_staged_over_total() {
-        let progress = StagedProgress {
-            staged: 3,
-            total: 12,
-        };
-        assert!((progress.fraction() - 0.25).abs() < f32::EPSILON);
-    }
+    fn staged_subset_only_keeps_files_in_the_staged_set() {
+        let files = vec![
+            changed_file("src/a.rs", 1, 0),
+            changed_file("src/b.rs", 2, 0),
+            changed_file("src/c.rs", 0, 3),
+        ];
+        let mut staged = HashSet::new();
+        staged.insert(PathBuf::from("src/b.rs"));
 
-    #[test]
-    fn split_dir_name_separates_a_nested_path() {
-        let (dir, name) = split_dir_name(Path::new("src/db/query_builder.rs"));
-        assert_eq!(dir, "src/db");
-        assert_eq!(name, "query_builder.rs");
-    }
-
-    #[test]
-    fn split_dir_name_leaves_dir_empty_for_a_root_level_file() {
-        let (dir, name) = split_dir_name(Path::new("Cargo.toml"));
-        assert_eq!(dir, "");
-        assert_eq!(name, "Cargo.toml");
-    }
-
-    #[test]
-    fn parse_hunk_new_range_reads_an_explicit_count() {
-        assert_eq!(
-            parse_hunk_new_range("@@ -10,5 +14,9 @@ fn foo() {"),
-            Some((14, 9))
+        let subset = staged_subset(&files, &staged);
+        assert_eq!(subset.len(), 1);
+        assert_eq!(subset[0].path, PathBuf::from("src/b.rs"));
+        assert!(
+            staged_subset(&files, &HashSet::new()).is_empty(),
+            "and nothing staged is an empty subset, not the whole list"
         );
     }
 
     #[test]
-    fn parse_hunk_new_range_defaults_a_missing_count_to_one() {
-        assert_eq!(parse_hunk_new_range("@@ -1 +1 @@"), Some((1, 1)));
+    fn the_commit_button_names_the_real_staged_count() {
+        for (staged, label) in [
+            (0, "Commit"),
+            (1, "Commit 1 file"),
+            (2, "Commit 2 files"),
+            (3, "Commit 3 files"),
+        ] {
+            assert_eq!(commit_button_label(staged), label, "{staged} staged");
+        }
+    }
+}
+
+#[cfg(test)]
+mod hunk_header_tests {
+    use crate::sidebar::changes::{
+        fold_gap_between, hunk_line_numbers, parse_hunk_new_range, parse_hunk_old_range,
+    };
+    use wt_core::diff::{DiffHunk, DiffLine, DiffLineKind};
+
+    fn line(kind: DiffLineKind, text: &str) -> DiffLine {
+        DiffLine {
+            kind,
+            content: text.to_string(),
+        }
     }
 
+    /// Both sides of a hunk header, an explicit count and the `@@ -1 +1 @@` form that means one,
+    /// and a header that isn't one at all.
     #[test]
-    fn parse_hunk_new_range_rejects_a_malformed_header() {
-        assert_eq!(parse_hunk_new_range("not a hunk header"), None);
-    }
-
-    #[test]
-    fn parse_hunk_old_range_reads_an_explicit_count() {
-        assert_eq!(
-            parse_hunk_old_range("@@ -10,5 +14,9 @@ fn foo() {"),
-            Some((10, 5))
-        );
-    }
-
-    #[test]
-    fn parse_hunk_old_range_defaults_a_missing_count_to_one() {
-        assert_eq!(parse_hunk_old_range("@@ -1 +1 @@"), Some((1, 1)));
-    }
-
-    #[test]
-    fn parse_hunk_old_range_rejects_a_malformed_header() {
-        assert_eq!(parse_hunk_old_range("not a hunk header"), None);
+    fn a_hunk_header_yields_both_ranges_or_none_at_all() {
+        for (header, old, new) in [
+            ("@@ -10,5 +14,9 @@ fn foo() {", Some((10, 5)), Some((14, 9))),
+            ("@@ -1 +1 @@", Some((1, 1)), Some((1, 1))),
+            ("not a hunk header", None, None),
+        ] {
+            assert_eq!(parse_hunk_old_range(header), old, "old range of {header:?}");
+            assert_eq!(parse_hunk_new_range(header), new, "new range of {header:?}");
+        }
     }
 
     #[test]
@@ -662,59 +688,66 @@ mod tests {
         assert_eq!(hunk_line_numbers(&hunk), vec![(None, None)]);
     }
 
+    /// The fold marker's own number: the unchanged span between two hunks, and the two cases that
+    /// have no marker to show - back-to-back hunks, and a header that couldn't be read.
     #[test]
-    fn fold_gap_between_computes_the_real_unchanged_span() {
+    fn the_fold_gap_is_the_real_unchanged_span_between_two_hunks() {
         // First hunk covers new lines 10..=14 (start 10, count 5); the next starts at 40 -
         // 25 real unchanged lines sit between them.
-        assert_eq!(
-            fold_gap_between("@@ -10,5 +10,5 @@", "@@ -30,5 +40,5 @@"),
-            Some(25)
-        );
-    }
-
-    #[test]
-    fn fold_gap_between_is_none_for_back_to_back_hunks() {
-        assert_eq!(fold_gap_between("@@ -1,5 +1,5 @@", "@@ -6,5 +6,5 @@"), None);
-    }
-
-    #[test]
-    fn fold_gap_between_is_none_when_a_header_is_unparseable() {
-        assert_eq!(fold_gap_between("garbage", "@@ -6,5 +6,5 @@"), None);
-    }
-
-    fn renamed_file(old_path: Option<PathBuf>) -> DiffFile {
-        DiffFile {
-            path: PathBuf::from("src/new_name.rs"),
-            old_path,
-            status: FileChangeStatus::Renamed,
-            is_binary: false,
-            hunks: Vec::new(),
-            truncated: false,
+        for (prev, next, gap) in [
+            ("@@ -10,5 +10,5 @@", "@@ -30,5 +40,5 @@", Some(25)),
+            ("@@ -1,5 +1,5 @@", "@@ -6,5 +6,5 @@", None),
+            ("garbage", "@@ -6,5 +6,5 @@", None),
+        ] {
+            assert_eq!(fold_gap_between(prev, next), gap, "{prev:?} -> {next:?}");
         }
     }
+}
+
+#[cfg(test)]
+mod row_label_tests {
+    use crate::sidebar::changes::{
+        empty_hunks_message, is_real_rename, rename_label, split_dir_name,
+    };
+    use std::path::{Path, PathBuf};
+    use wt_core::diff::{DiffFile, FileChangeStatus};
 
     #[test]
-    fn a_rename_with_a_real_different_old_path_is_a_real_rename() {
-        let file = renamed_file(Some(PathBuf::from("src/old_name.rs")));
-        assert!(is_real_rename(&file));
+    fn split_dir_name_separates_a_nested_path_and_leaves_a_root_level_one_bare() {
         assert_eq!(
-            rename_label(&file),
-            Some("src/old_name.rs \u{2192} src/new_name.rs".to_string())
+            split_dir_name(Path::new("src/db/query_builder.rs")),
+            ("src/db".to_string(), "query_builder.rs".to_string())
+        );
+        assert_eq!(
+            split_dir_name(Path::new("Cargo.toml")),
+            (String::new(), "Cargo.toml".to_string())
         );
     }
 
+    /// A rename is only real when git reports an old path that genuinely differs - an absent one,
+    /// or one identical to the current path (defensive: `wt_core::diff` shouldn't produce it, but
+    /// never assume it away), is not a rename and gets no label.
     #[test]
-    fn no_old_path_is_not_a_real_rename() {
-        let file = renamed_file(None);
-        assert!(!is_real_rename(&file));
-        assert_eq!(rename_label(&file), None);
-    }
-
-    #[test]
-    fn an_old_path_identical_to_the_current_path_is_not_a_real_rename() {
-        let file = renamed_file(Some(PathBuf::from("src/new_name.rs")));
-        assert!(!is_real_rename(&file));
-        assert_eq!(rename_label(&file), None);
+    fn only_a_genuinely_different_old_path_is_a_rename() {
+        for (old_path, label) in [
+            (
+                Some("src/old_name.rs"),
+                Some("src/old_name.rs \u{2192} src/new_name.rs".to_string()),
+            ),
+            (None, None),
+            (Some("src/new_name.rs"), None),
+        ] {
+            let file = DiffFile {
+                path: PathBuf::from("src/new_name.rs"),
+                old_path: old_path.map(PathBuf::from),
+                status: FileChangeStatus::Renamed,
+                is_binary: false,
+                hunks: Vec::new(),
+                truncated: false,
+            };
+            assert_eq!(is_real_rename(&file), label.is_some(), "{old_path:?}");
+            assert_eq!(rename_label(&file), label, "{old_path:?}");
+        }
     }
 
     #[test]
@@ -723,89 +756,12 @@ mod tests {
             empty_hunks_message(FileChangeStatus::Renamed),
             "no line changes (rename only)"
         );
-    }
-
-    #[test]
-    fn empty_hunks_message_is_generic_for_a_non_renamed_file() {
-        assert_eq!(
-            empty_hunks_message(FileChangeStatus::Added),
-            "no line changes"
-        );
-        assert_eq!(
-            empty_hunks_message(FileChangeStatus::Modified),
-            "no line changes"
-        );
-        assert_eq!(
-            empty_hunks_message(FileChangeStatus::Deleted),
-            "no line changes"
-        );
-    }
-
-    fn changed_file(path: &str, add_lines: u32, del_lines: u32) -> DiffFile {
-        let mut lines = Vec::new();
-        for _ in 0..add_lines {
-            lines.push(line(DiffLineKind::Added, "a"));
+        for status in [
+            FileChangeStatus::Added,
+            FileChangeStatus::Modified,
+            FileChangeStatus::Deleted,
+        ] {
+            assert_eq!(empty_hunks_message(status), "no line changes", "{status:?}");
         }
-        for _ in 0..del_lines {
-            lines.push(line(DiffLineKind::Removed, "d"));
-        }
-        DiffFile {
-            path: PathBuf::from(path),
-            old_path: None,
-            status: FileChangeStatus::Modified,
-            is_binary: false,
-            hunks: vec![DiffHunk {
-                header: "@@ -1,1 +1,1 @@".to_string(),
-                lines,
-            }],
-            truncated: false,
-        }
-    }
-
-    #[test]
-    fn staged_subset_only_keeps_files_in_the_staged_set() {
-        let files = vec![
-            changed_file("src/a.rs", 1, 0),
-            changed_file("src/b.rs", 2, 0),
-            changed_file("src/c.rs", 0, 3),
-        ];
-        let mut staged = HashSet::new();
-        staged.insert(PathBuf::from("src/b.rs"));
-
-        let subset = staged_subset(&files, &staged);
-        assert_eq!(subset.len(), 1);
-        assert_eq!(subset[0].path, PathBuf::from("src/b.rs"));
-    }
-
-    #[test]
-    fn staged_subset_is_empty_when_nothing_is_staged() {
-        let files = vec![changed_file("src/a.rs", 1, 0)];
-        let subset = staged_subset(&files, &HashSet::new());
-        assert!(subset.is_empty());
-    }
-
-    #[test]
-    fn staged_diff_stats_sums_only_the_staged_files() {
-        let a = changed_file("src/a.rs", 3, 1);
-        let b = changed_file("src/b.rs", 2, 5);
-        assert_eq!(staged_diff_stats(&[&a, &b]), (5, 6));
-        assert_eq!(staged_diff_stats(&[&a]), (3, 1));
-        assert_eq!(staged_diff_stats(&[]), (0, 0));
-    }
-
-    #[test]
-    fn commit_button_label_is_a_bare_ghost_commit_with_nothing_staged() {
-        assert_eq!(commit_button_label(0), "Commit");
-    }
-
-    #[test]
-    fn commit_button_label_is_singular_for_exactly_one_staged_file() {
-        assert_eq!(commit_button_label(1), "Commit 1 file");
-    }
-
-    #[test]
-    fn commit_button_label_is_plural_for_more_than_one_staged_file() {
-        assert_eq!(commit_button_label(2), "Commit 2 files");
-        assert_eq!(commit_button_label(3), "Commit 3 files");
     }
 }

--- a/crates/app/src/sidebar/file_tree.rs
+++ b/crates/app/src/sidebar/file_tree.rs
@@ -9,9 +9,6 @@ use std::path::{Path, PathBuf};
 
 use gpui::Rgba;
 
-#[cfg(test)]
-use crate::theme;
-
 /// One row in the flattened file tree: a real filesystem entry, its path, and its depth
 /// (0 = direct child of the tree root) for indentation.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -284,8 +281,11 @@ pub fn indent_guide_x(level: usize) -> f32 {
 const CARET_WIDTH: f32 = 8.0;
 
 #[cfg(test)]
-mod tests {
-    use super::*;
+mod file_tree_walk_tests {
+    use crate::sidebar::file_tree::{build_file_tree, directory_paths, FileTree, MAX_DEPTH};
+    use std::collections::HashSet;
+    use std::fs;
+    use std::path::{Path, PathBuf};
     use tempfile::TempDir;
 
     fn tree_of(root: &Path) -> FileTree {
@@ -392,26 +392,14 @@ mod tests {
         assert!(listing.partial);
     }
 
-    #[test]
-    fn a_large_directory_is_listed_completely() {
-        let dir = TempDir::new().expect("tempdir");
-        for index in 0..800 {
-            fs::write(dir.path().join(format!("f-{index:03}.txt")), "x").expect("write");
-        }
-
-        let listing = build_file_tree(dir.path()).expect("build_file_tree");
-
-        assert_eq!(listing.tree.len(), 800);
-        assert!(listing.is_complete());
-        let expanded = HashSet::new();
-        assert_eq!(
-            listing.tree.visible_entries(&expanded).len(),
-            800,
-            "every entry in a flat directory is visible with nothing expanded, and none of them \
-             may be dropped by a render cap"
-        );
-    }
-
+    /// GitHub issue #160, at the level the walk itself decides it: a tree with more entries than
+    /// the removed 20,000-entry default cap must come back whole, with no truncation flag left
+    /// anywhere to hang a "load more" row off, and no render cap dropping any of it either
+    /// (issue #18 §4 - the sidebar's virtualized list is what keeps a big tree cheap to draw).
+    ///
+    /// Built as a wide, shallow fan (200 directories x 105 files) rather than 21,000 files in one
+    /// folder, so it also exercises the recursive descent the old budget used to cut short
+    /// mid-subtree.
     #[test]
     fn a_tree_larger_than_the_removed_twenty_thousand_entry_cap_loads_completely() {
         const DIRS: usize = 200;
@@ -442,6 +430,12 @@ mod tests {
             listing.is_complete(),
             "and a walk that reached everything is a complete inventory"
         );
+        assert_eq!(
+            listing.tree.visible_entries(&HashSet::new()).len(),
+            DIRS,
+            "with nothing expanded every one of the directory rows is visible, and no render cap \
+             may drop any of them"
+        );
         // The last directory's last file is the entry furthest past the old cut-off; naming it
         // proves the walk really continued rather than merely counting to a bigger number.
         let last = dir
@@ -456,6 +450,100 @@ mod tests {
     }
 
     #[test]
+    fn directory_paths_collects_every_directory_and_no_files() {
+        let dir = TempDir::new().expect("tempdir");
+        fs::create_dir(dir.path().join("sub")).expect("mkdir");
+        fs::create_dir(dir.path().join("sub/deeper")).expect("mkdir");
+        fs::write(dir.path().join("sub/nested.txt"), "n").expect("write");
+
+        let dirs = directory_paths(&tree_of(dir.path()));
+
+        assert_eq!(dirs.len(), 2);
+        assert!(dirs.contains(&dir.path().join("sub")));
+        assert!(dirs.contains(&dir.path().join("sub/deeper")));
+    }
+}
+
+#[cfg(test)]
+mod tree_visibility_tests {
+    use crate::sidebar::file_tree::{
+        build_file_tree, visible_indices_by_depth, FileTree, FileTreeEntry,
+    };
+    use std::collections::HashSet;
+    use std::fs;
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+
+    fn entry(name: &str, depth: usize, is_dir: bool) -> FileTreeEntry {
+        FileTreeEntry {
+            path: PathBuf::from(name),
+            name: name.to_string(),
+            depth,
+            is_dir,
+        }
+    }
+
+    /// `sub/` holding `nested.txt` and `deeper/`, `deeper/` holding `deepest.txt`, plus a
+    /// root-level `a.txt` and an `empty-dir/` with nothing in it - one shape every expansion case
+    /// below reads out of.
+    fn sample_tree() -> FileTree {
+        FileTree::new(vec![
+            entry("empty-dir", 0, true),
+            entry("sub", 0, true),
+            entry("nested.txt", 1, false),
+            entry("deeper", 1, true),
+            entry("deepest.txt", 2, false),
+            entry("a.txt", 0, false),
+        ])
+    }
+
+    fn visible_names(tree: &FileTree, expanded: &[&str]) -> Vec<String> {
+        let expanded: HashSet<PathBuf> = expanded.iter().map(PathBuf::from).collect();
+        tree.visible_entries(&expanded)
+            .iter()
+            .map(|entry| entry.name.clone())
+            .collect()
+    }
+
+    /// Issue #18 §1's default state and the rules that grow out of it, over one tree: absence
+    /// from the expanded set means collapsed, expansion reveals only the folder's own immediate
+    /// children, and a stale deep expansion never punches a hole through a collapsed ancestor.
+    #[test]
+    fn expanding_reveals_exactly_the_expanded_folders_own_children() {
+        let tree = sample_tree();
+        for (expanded, expected) in [
+            (&[][..], &["empty-dir", "sub", "a.txt"][..]),
+            (
+                &["sub"][..],
+                &["empty-dir", "sub", "nested.txt", "deeper", "a.txt"][..],
+            ),
+            (
+                &["sub", "deeper"][..],
+                &[
+                    "empty-dir",
+                    "sub",
+                    "nested.txt",
+                    "deeper",
+                    "deepest.txt",
+                    "a.txt",
+                ][..],
+            ),
+            // `deeper` is expanded but its own parent is not - it must stay hidden regardless.
+            (&["deeper"][..], &["empty-dir", "sub", "a.txt"][..]),
+            // Expanding a folder with no children reveals nothing extra.
+            (&["empty-dir"][..], &["empty-dir", "sub", "a.txt"][..]),
+        ] {
+            assert_eq!(
+                visible_names(&tree, expanded),
+                expected,
+                "expanded {expanded:?}"
+            );
+        }
+    }
+
+    /// The span-based skip must agree with the depth-scan it replaced on a real, nested tree -
+    /// for every combination of expanded folders, not just the one a hand-written case picks.
+    #[test]
     fn span_based_visibility_matches_the_depth_scan_for_every_expansion() {
         let dir = TempDir::new().expect("tempdir");
         fs::create_dir_all(dir.path().join("a/b/c")).expect("mkdir -p");
@@ -467,7 +555,7 @@ mod tests {
         fs::write(dir.path().join("e/leaf.txt"), "x").expect("write");
         fs::write(dir.path().join("root.txt"), "x").expect("write");
 
-        let tree = tree_of(dir.path());
+        let tree = build_file_tree(dir.path()).expect("build_file_tree").tree;
         let dirs: Vec<PathBuf> = tree
             .iter()
             .filter(|entry| entry.is_dir)
@@ -489,169 +577,43 @@ mod tests {
             );
         }
     }
+}
+
+#[cfg(test)]
+mod lang_chip_tests {
+    use crate::sidebar::file_tree::lang_chip_for_name;
+    use crate::theme;
+    use gpui::Rgba;
 
     fn same(a: Rgba, b: Rgba) -> bool {
         a.r == b.r && a.g == b.g && a.b == b.b && a.a == b.a
     }
 
+    /// One table over the whole mapping: each documented extension's own chip, the neutral
+    /// fallback for an unrecognized one and for a name with no extension at all, and the
+    /// case-insensitive match.
     #[test]
-    fn each_documented_extension_gets_its_own_chip() {
-        let rs = lang_chip_for_name("main.rs");
-        assert_eq!(rs.label, "rs");
-        assert!(same(rs.fg, theme::lang::RS.0.into()));
-        assert!(same(rs.bg, theme::lang::RS.1.into()));
-
-        let toml = lang_chip_for_name("Cargo.toml");
-        assert_eq!(toml.label, "to");
-        assert!(same(toml.fg, theme::lang::TOML.0.into()));
-
-        let md = lang_chip_for_name("README.md");
-        assert_eq!(md.label, "md");
-        assert!(same(md.fg, theme::lang::MD.0.into()));
-
-        let sql = lang_chip_for_name("schema.sql");
-        assert_eq!(sql.label, "sq");
-        assert!(same(sql.fg, theme::lang::SQL.0.into()));
-    }
-
-    #[test]
-    fn an_unrecognized_extension_gets_the_neutral_fallback_chip() {
-        let chip = lang_chip_for_name("image.png");
-        assert_eq!(chip.label, ".");
-        assert!(same(chip.fg, theme::lang::UNKNOWN.0.into()));
-        assert!(same(chip.bg, theme::lang::UNKNOWN.1.into()));
-    }
-
-    #[test]
-    fn extension_matching_is_case_insensitive() {
-        let upper = lang_chip_for_name("Notes.MD");
-        assert_eq!(upper.label, "md");
-    }
-
-    #[test]
-    fn a_name_with_no_extension_gets_the_fallback_chip() {
-        let chip = lang_chip_for_name("Makefile");
-        assert_eq!(chip.label, ".");
-    }
-
-    fn entry(name: &str, depth: usize, is_dir: bool) -> FileTreeEntry {
-        FileTreeEntry {
-            path: PathBuf::from(name),
-            name: name.to_string(),
-            depth,
-            is_dir,
+    fn every_name_gets_its_documented_chip_or_the_neutral_fallback() {
+        for (name, label, colors) in [
+            ("main.rs", "rs", theme::lang::RS),
+            ("Cargo.toml", "to", theme::lang::TOML),
+            ("README.md", "md", theme::lang::MD),
+            ("schema.sql", "sq", theme::lang::SQL),
+            ("Notes.MD", "md", theme::lang::MD),
+            ("image.png", ".", theme::lang::UNKNOWN),
+            ("Makefile", ".", theme::lang::UNKNOWN),
+        ] {
+            let chip = lang_chip_for_name(name);
+            assert_eq!(chip.label, label, "{name}");
+            assert!(same(chip.fg, colors.0.into()), "{name} foreground");
+            assert!(same(chip.bg, colors.1.into()), "{name} background");
         }
     }
+}
 
-    /// Hand-built fixtures go through the same [`FileTree::new`] every real walk does, so the
-    /// subtree spans under test are always the derived ones - there is deliberately no way to
-    /// hand-write a span.
-    fn tree(entries: Vec<FileTreeEntry>) -> FileTree {
-        FileTree::new(entries)
-    }
-
-    #[test]
-    fn nothing_expanded_shows_only_root_level_entries() {
-        let entries = tree(vec![
-            entry("sub", 0, true),
-            entry("nested.txt", 1, false),
-            entry("a.txt", 0, false),
-        ]);
-        let visible = entries.visible_entries(&HashSet::new());
-        let names: Vec<&str> = visible.iter().map(|e| e.name.as_str()).collect();
-        assert_eq!(names, vec!["sub", "a.txt"]);
-    }
-
-    #[test]
-    fn expanding_a_directory_reveals_only_its_own_immediate_subtree() {
-        let entries = tree(vec![
-            entry("sub", 0, true),
-            entry("nested.txt", 1, false),
-            entry("deeper", 1, true),
-            entry("deepest.txt", 2, false),
-            entry("a.txt", 0, false),
-        ]);
-        let mut expanded = HashSet::new();
-        expanded.insert(PathBuf::from("sub"));
-
-        let visible = entries.visible_entries(&expanded);
-        let names: Vec<&str> = visible.iter().map(|e| e.name.as_str()).collect();
-        // "deeper" shows because its parent is expanded, but its own children stay hidden until
-        // it is expanded too.
-        assert_eq!(names, vec!["sub", "nested.txt", "deeper", "a.txt"]);
-    }
-
-    #[test]
-    fn expanding_a_whole_chain_reveals_the_deepest_entry() {
-        let entries = tree(vec![
-            entry("sub", 0, true),
-            entry("deeper", 1, true),
-            entry("deepest.txt", 2, false),
-        ]);
-        let mut expanded = HashSet::new();
-        expanded.insert(PathBuf::from("sub"));
-        expanded.insert(PathBuf::from("deeper"));
-
-        let visible = entries.visible_entries(&expanded);
-        let names: Vec<&str> = visible.iter().map(|e| e.name.as_str()).collect();
-        assert_eq!(names, vec!["sub", "deeper", "deepest.txt"]);
-    }
-
-    #[test]
-    fn an_expanded_directory_under_a_collapsed_ancestor_stays_hidden() {
-        let entries = tree(vec![
-            entry("sub", 0, true),
-            entry("deeper", 1, true),
-            entry("deepest.txt", 2, false),
-            entry("a.txt", 0, false),
-        ]);
-        let mut expanded = HashSet::new();
-        expanded.insert(PathBuf::from("deeper"));
-
-        let visible = entries.visible_entries(&expanded);
-        let names: Vec<&str> = visible.iter().map(|e| e.name.as_str()).collect();
-        assert_eq!(names, vec!["sub", "a.txt"]);
-    }
-
-    #[test]
-    fn expanding_a_directory_with_no_children_reveals_nothing_extra() {
-        let entries = tree(vec![entry("empty-dir", 0, true), entry("a.txt", 0, false)]);
-        let mut expanded = HashSet::new();
-        expanded.insert(PathBuf::from("empty-dir"));
-
-        let visible = entries.visible_entries(&expanded);
-        assert_eq!(visible.len(), 2);
-    }
-
-    #[test]
-    fn visible_entries_on_a_real_tree_matches_manual_filtering() {
-        let dir = TempDir::new().expect("tempdir");
-        fs::create_dir(dir.path().join("sub")).expect("mkdir");
-        fs::write(dir.path().join("sub/nested.txt"), "n").expect("write");
-        fs::write(dir.path().join("a.txt"), "a").expect("write");
-
-        let entries = tree_of(dir.path());
-        let mut expanded = HashSet::new();
-        expanded.insert(dir.path().join("sub"));
-
-        let visible = entries.visible_entries(&expanded);
-        let names: Vec<&str> = visible.iter().map(|e| e.name.as_str()).collect();
-        assert_eq!(names, vec!["sub", "nested.txt", "a.txt"]);
-    }
-
-    #[test]
-    fn directory_paths_collects_every_directory_and_no_files() {
-        let dir = TempDir::new().expect("tempdir");
-        fs::create_dir(dir.path().join("sub")).expect("mkdir");
-        fs::create_dir(dir.path().join("sub/deeper")).expect("mkdir");
-        fs::write(dir.path().join("sub/nested.txt"), "n").expect("write");
-
-        let dirs = directory_paths(&tree_of(dir.path()));
-
-        assert_eq!(dirs.len(), 2);
-        assert!(dirs.contains(&dir.path().join("sub")));
-        assert!(dirs.contains(&dir.path().join("sub/deeper")));
-    }
+#[cfg(test)]
+mod indent_geometry_tests {
+    use crate::sidebar::file_tree::indent_guide_x;
 
     #[test]
     fn indent_guides_line_up_with_each_levels_expand_chevron() {

--- a/crates/app/src/sidebar/file_tree_watch.rs
+++ b/crates/app/src/sidebar/file_tree_watch.rs
@@ -23,7 +23,12 @@ pub fn spawn_file_tree_watcher(
         return None;
     }
     wt_core::git_common_dir(worktree_root).ok()?;
-    let git_dir: PathBuf = worktree_root.join(".git");
+    // The OS reports every event path resolved (macOS `FSEvents` hands back `/private/var/...` for
+    // a watch armed on `/var/...`), so a `.git` prefix built from an unresolved root would match
+    // nothing and every one of git's own internal writes would mark the tree dirty.
+    let resolved =
+        std::fs::canonicalize(worktree_root).unwrap_or_else(|_| worktree_root.to_path_buf());
+    let git_dir: PathBuf = resolved.join(".git");
 
     let mut watcher = notify::recommended_watcher(move |result: notify::Result<notify::Event>| {
         let Ok(event) = result else {
@@ -45,123 +50,63 @@ pub fn spawn_file_tree_watcher(
 }
 
 #[cfg(test)]
-mod tests {
+mod file_tree_watcher_tests {
     use super::*;
     use std::fs;
-    use std::process::Command;
     use std::sync::atomic::AtomicBool;
     use std::sync::Arc;
-    use std::time::{Duration, Instant};
+    use std::time::Duration;
     use tempfile::TempDir;
+    use test_support::{git, seed_repo, stays_false, wait_until};
 
-    fn git(dir: &Path, args: &[&str]) {
-        let output = Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {:?} failed in {:?}",
-            args,
-            dir
-        );
-    }
-
-    /// A real git repository - see [`spawn_file_tree_watcher`]'s own docs on why its
-    /// `wt_core::git_common_dir` gate means every one of this module's tests needs a real repo,
-    /// not just a plain temp directory.
-    fn init_repo() -> TempDir {
-        let dir = TempDir::new().expect("tempdir");
-        git(dir.path(), &["init", "-b", "main"]);
-        git(dir.path(), &["config", "user.email", "test@example.com"]);
-        git(dir.path(), &["config", "user.name", "Test User"]);
-        fs::write(dir.path().join("base.txt"), "base\n").expect("write");
-        git(dir.path(), &["add", "base.txt"]);
-        git(dir.path(), &["commit", "-m", "initial"]);
-        dir
-    }
-
-    /// Real-time bounded wait for the watcher's async, OS-thread-delivered callback to fire - see
-    /// `crate::rail::worktree_watch::tests::wait_until_dirty`'s identical own docs for why this
-    /// can't be a simulated/deterministic clock.
+    /// The watcher's callback is delivered by an OS thread, not by a GPUI executor, so there is
+    /// no deterministic clock to park - a real-time bounded wait is the only option.
     fn wait_until_dirty(dirty: &DirtyFlag) -> bool {
-        let deadline = Instant::now() + Duration::from_secs(3);
-        while Instant::now() < deadline {
-            if dirty.swap(false, Ordering::SeqCst) {
-                return true;
-            }
-            std::thread::sleep(Duration::from_millis(10));
-        }
-        false
+        wait_until(Duration::from_secs(3), || {
+            dirty.swap(false, Ordering::SeqCst)
+        })
     }
 
-    /// The inverse of [`wait_until_dirty`]: asserts the flag stays clear for a real, bounded
-    /// window - used to prove `.git/` churn is genuinely filtered out, not just "usually" missed
-    /// by a race.
+    /// The inverse of [`wait_until_dirty`]: proves `.git/` churn is genuinely filtered out
+    /// rather than just slow to arrive.
     fn assert_stays_clean(dirty: &DirtyFlag) {
-        std::thread::sleep(Duration::from_millis(500));
         assert!(
-            !dirty.load(Ordering::SeqCst),
+            stays_false(Duration::from_millis(500), || dirty.load(Ordering::SeqCst)),
             "a change confined to .git/ must never mark the file tree dirty"
         );
     }
 
+    /// Creation, a nested edit and a deletion are the three real working-tree changes the Files
+    /// tab has to notice, and one recursive watch is what notices all three - so they are one
+    /// test over one watcher rather than three that differ only in which `fs` call they make.
     #[test]
-    fn a_real_new_file_is_noticed() {
-        let dir = init_repo();
-        let dirty: DirtyFlag = Arc::new(AtomicBool::new(false));
-        let _watcher =
-            spawn_file_tree_watcher(dir.path(), dirty.clone()).expect("spawn_file_tree_watcher");
-
-        fs::write(dir.path().join("new.txt"), "content").expect("write");
-
-        assert!(
-            wait_until_dirty(&dirty),
-            "creating a real file must be observed within the real-time budget"
-        );
-    }
-
-    #[test]
-    fn a_real_file_edit_in_a_nested_directory_is_noticed() {
-        let dir = init_repo();
+    fn every_real_working_tree_change_marks_the_tree_dirty() {
+        let dir = seed_repo();
         fs::create_dir_all(dir.path().join("src/nested")).expect("mkdir");
-        let file = dir.path().join("src/nested/a.rs");
-        fs::write(&file, "fn main() {}").expect("write");
+        let nested = dir.path().join("src/nested/a.rs");
+        fs::write(&nested, "fn main() {}").expect("write");
 
         let dirty: DirtyFlag = Arc::new(AtomicBool::new(false));
         let _watcher =
             spawn_file_tree_watcher(dir.path(), dirty.clone()).expect("spawn_file_tree_watcher");
 
-        fs::write(&file, "fn main() { println!(\"hi\"); }").expect("write");
+        let created = dir.path().join("new.txt");
+        fs::write(&created, "content").expect("write");
+        assert!(wait_until_dirty(&dirty), "a created file must be observed");
 
+        fs::write(&nested, "fn main() { println!(\"hi\"); }").expect("write");
         assert!(
             wait_until_dirty(&dirty),
-            "editing a real file nested several directories deep must be observed"
+            "an edit several directories deep must be observed - the watch is recursive"
         );
-    }
 
-    #[test]
-    fn a_real_deletion_is_noticed() {
-        let dir = init_repo();
-        let file = dir.path().join("gone.txt");
-        fs::write(&file, "content").expect("write");
-
-        let dirty: DirtyFlag = Arc::new(AtomicBool::new(false));
-        let _watcher =
-            spawn_file_tree_watcher(dir.path(), dirty.clone()).expect("spawn_file_tree_watcher");
-
-        fs::remove_file(&file).expect("remove");
-
-        assert!(
-            wait_until_dirty(&dirty),
-            "deleting a real file must be observed"
-        );
+        fs::remove_file(&created).expect("remove");
+        assert!(wait_until_dirty(&dirty), "a deletion must be observed");
     }
 
     #[test]
     fn a_change_confined_to_dot_git_is_filtered_out() {
-        let dir = init_repo();
+        let dir = seed_repo();
 
         let dirty: DirtyFlag = Arc::new(AtomicBool::new(false));
         let _watcher =
@@ -178,7 +123,7 @@ mod tests {
 
     #[test]
     fn a_real_change_alongside_dot_git_churn_is_still_noticed() {
-        let dir = init_repo();
+        let dir = seed_repo();
 
         let dirty: DirtyFlag = Arc::new(AtomicBool::new(false));
         let _watcher =
@@ -195,7 +140,7 @@ mod tests {
 
     #[test]
     fn a_missing_directory_yields_no_watcher_rather_than_panicking() {
-        let dir = init_repo();
+        let dir = seed_repo();
         let missing = dir.path().join("does-not-exist");
         let dirty: DirtyFlag = Arc::new(AtomicBool::new(false));
         assert!(spawn_file_tree_watcher(&missing, dirty).is_none());

--- a/crates/app/src/sidebar/mod.rs
+++ b/crates/app/src/sidebar/mod.rs
@@ -24,3 +24,22 @@ pub mod sections;
 
 pub(crate) mod render;
 pub(crate) mod tree_ops;
+
+/// Fixtures shared by this folder's own test modules.
+#[cfg(test)]
+pub(in crate::sidebar) mod fixtures {
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+
+    /// A scratch directory, plus the path every assertion about it must be written against.
+    ///
+    /// `AdeApp` resolves each repository path it is handed (`crate::rail::repo::canonical_repo_path`),
+    /// so on macOS - where `TMPDIR` lives under `/var/folders`, a symlink to `/private/var/folders` -
+    /// a test that builds expectations out of `TempDir::path()` is comparing unresolved paths
+    /// against the resolved ones the app actually holds, and matches nothing.
+    pub(in crate::sidebar) fn temp_root() -> (TempDir, PathBuf) {
+        let dir = TempDir::new().expect("tempdir");
+        let root = std::fs::canonicalize(dir.path()).expect("canonicalize tempdir");
+        (dir, root)
+    }
+}

--- a/crates/app/src/sidebar/render.rs
+++ b/crates/app/src/sidebar/render.rs
@@ -4135,58 +4135,25 @@ mod virtualization_tests {
     use crate::root::focus::palette_focus_tests;
     use gpui::TestAppContext;
     use std::fs;
-    use std::process::Command;
-    use tempfile::TempDir;
+    use test_support::{git, seed_empty_repo_at};
 
-    /// `.output()`, not `.status()`: `status()` inherits stdout/stderr, so seeding a 40-file
-    /// repository below dumped forty `create mode 100644 f-NN.txt` lines into the test output.
-    fn git(dir: &std::path::Path, args: &[&str]) {
-        let output = Command::new("git")
-            .args(args)
-            .current_dir(dir)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {args:?} failed: {}",
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
-    #[gpui::test]
-    fn a_file_tree_row_far_below_the_viewport_is_never_painted(cx: &mut TestAppContext) {
-        let repo = TempDir::new().expect("tempdir");
-        // Deliberately more rows than any plausible test viewport can show at
-        // `theme::band::TREE_ROW` (22px) each, but fewer than
-        // the since-removed `MAX_RENDERED_FILE_ENTRIES` cap, so this measured virtualization
-        // alone even back when that cap still existed.
-        for index in 0..300 {
-            fs::write(repo.path().join(format!("file-{index:03}.txt")), "x\n").expect("write");
-        }
-        let (_app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
-        cx.run_until_parked();
-
-        assert!(
-            cx.debug_bounds("file-tree-row-file-000.txt").is_some(),
-            "the first file-tree row must really paint - if it doesn't, this test proves \
-             nothing about virtualization, only that the tree is empty"
-        );
-        assert!(
-            cx.debug_bounds("file-tree-row-file-299.txt").is_none(),
-            "the 300th file-tree row is far below any plausible viewport, so a virtualized \
-             list must never build it as an element at all"
-        );
-    }
-
+    /// Both halves of "is it really virtualized": a row far below the viewport is never built as
+    /// an element at all (before this revision's fix every one of the first 500 visible rows was
+    /// built, laid out and painted on *every* frame, which measured as ~145ms of a ~200ms
+    /// `Window::draw` against real `gpui::FrameTiming` data on this repository's own tree), and a
+    /// row that legitimately isn't painted yet must still be reachable. The scroll uses a real
+    /// `gpui::ScrollWheelEvent`, which simultaneously proves the list still scrolls at all after
+    /// `Self::render_right_sidebar` stopped wrapping it in its own `overflow_y_scroll()`
+    /// container, the one behaviour that change could plausibly have broken.
     #[gpui::test]
     fn scrolling_the_virtualized_file_tree_materializes_a_row_that_was_not_painted(
         cx: &mut TestAppContext,
     ) {
-        let repo = TempDir::new().expect("tempdir");
+        let (_repo_dir, repo) = fixtures::temp_root();
         for index in 0..300 {
-            fs::write(repo.path().join(format!("file-{index:03}.txt")), "x\n").expect("write");
+            fs::write(repo.join(format!("file-{index:03}.txt")), "x\n").expect("write");
         }
-        let (_app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (_app, cx) = palette_focus_tests::open_test_app(cx, repo.clone());
         cx.run_until_parked();
 
         let first_row = cx
@@ -4218,10 +4185,10 @@ mod virtualization_tests {
 
     #[gpui::test]
     fn expanding_and_collapsing_a_directory_adds_and_removes_its_children(cx: &mut TestAppContext) {
-        let repo = TempDir::new().expect("tempdir");
-        fs::create_dir(repo.path().join("src")).expect("mkdir");
-        fs::write(repo.path().join("src/only.rs"), "fn main() {}\n").expect("write");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (_repo_dir, repo) = fixtures::temp_root();
+        fs::create_dir(repo.join("src")).expect("mkdir");
+        fs::write(repo.join("src/only.rs"), "fn main() {}\n").expect("write");
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.clone());
         cx.run_until_parked();
 
         assert!(
@@ -4233,7 +4200,7 @@ mod virtualization_tests {
             "nothing is expanded on first open, so a nested child must not paint"
         );
 
-        let src_dir = repo.path().join("src");
+        let src_dir = repo.join("src");
         app.update(cx, |app, cx| {
             app.toggle_dir_expanded(src_dir.clone(), cx);
         });
@@ -4256,29 +4223,23 @@ mod virtualization_tests {
 
     #[gpui::test]
     fn a_changes_row_far_below_the_viewport_is_never_painted(cx: &mut TestAppContext) {
-        let repo = TempDir::new().expect("tempdir");
-        git(repo.path(), &["init", "-b", "main"]);
-        git(repo.path(), &["config", "user.email", "test@example.com"]);
-        git(repo.path(), &["config", "user.name", "Test User"]);
+        let (_repo_dir, repo) = fixtures::temp_root();
+        seed_empty_repo_at(&repo);
         for index in 0..40 {
-            fs::write(repo.path().join(format!("f-{index:02}.txt")), "base\n").expect("write");
+            fs::write(repo.join(format!("f-{index:02}.txt")), "base\n").expect("write");
         }
-        git(repo.path(), &["add", "."]);
-        git(repo.path(), &["commit", "-m", "initial"]);
+        git(&repo, &["add", "."]);
+        git(&repo, &["commit", "-m", "initial"]);
         // A real feature branch, so this hits `wt_core::diff::DiffBase::Diff` against a real
         // merge-base rather than `DiffBase::NoBase`'s uncommitted-vs-HEAD fallback (GitHub issue
         // #108) - the same setup this crate's existing real-diff tests use, and the shape this
         // test's 40 changed rows need to exercise virtualization against.
-        git(repo.path(), &["checkout", "-b", "feature"]);
+        git(&repo, &["checkout", "-b", "feature"]);
         for index in 0..40 {
-            fs::write(
-                repo.path().join(format!("f-{index:02}.txt")),
-                "base\nchanged\n",
-            )
-            .expect("write");
+            fs::write(repo.join(format!("f-{index:02}.txt")), "base\nchanged\n").expect("write");
         }
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.clone());
         app.update_in(cx, |app, window, cx| {
             app.set_right_sidebar_view(RightSidebarView::Changes, window, cx);
         });
@@ -4304,17 +4265,17 @@ mod virtualization_tests {
 
     #[gpui::test]
     fn file_tree_row_and_header_actions_clear_the_real_scrollbar(cx: &mut TestAppContext) {
-        let repo = TempDir::new().expect("tempdir");
-        fs::create_dir(repo.path().join("src")).expect("mkdir");
-        fs::write(repo.path().join("src/main.rs"), "//\n").expect("write");
+        let (_repo_dir, repo) = fixtures::temp_root();
+        fs::create_dir(repo.join("src")).expect("mkdir");
+        fs::write(repo.join("src/main.rs"), "//\n").expect("write");
         // Enough flat files that the tree genuinely overflows its viewport and the real overlay
         // scrollbar actually renders - `render_vertical_scrollbar` returns `None`, painting
         // nothing at all, when the list doesn't overflow (see that function's own early return
         // on `max_offset <= 0.5`).
         for index in 0..300 {
-            fs::write(repo.path().join(format!("file-{index:03}.txt")), "x\n").expect("write");
+            fs::write(repo.join(format!("file-{index:03}.txt")), "x\n").expect("write");
         }
-        let (_app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (_app, cx) = palette_focus_tests::open_test_app(cx, repo.clone());
         cx.run_until_parked();
 
         let scrollbar = cx.debug_bounds("file-tree-scrollbar").expect(
@@ -4333,7 +4294,7 @@ mod virtualization_tests {
         // a selector that must embed a real runtime path (see `crate::root::focus`'s own tests)
         // is a deliberate, test-only leak via `Box::leak`.
         let row_selector: &'static str = Box::leak(
-            format!("file-tree-new-file-{}", repo.path().join("src").display()).into_boxed_str(),
+            format!("file-tree-new-file-{}", repo.join("src").display()).into_boxed_str(),
         );
         let row_button = cx
             .debug_bounds(row_selector)
@@ -4370,37 +4331,21 @@ mod change_row_selection_tests {
     use super::*;
     use crate::root::focus::palette_focus_tests;
     use gpui::TestAppContext;
-    use std::process::Command;
-    use tempfile::TempDir;
-
-    fn git(dir: &std::path::Path, args: &[&str]) {
-        let output = Command::new("git")
-            .args(args)
-            .current_dir(dir)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {args:?} failed: {}",
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
+    use test_support::{git, seed_empty_repo_at};
 
     #[gpui::test]
     fn the_selection_edge_is_a_real_element_painted_regardless_of_selection(
         cx: &mut TestAppContext,
     ) {
-        let repo = TempDir::new().expect("tempdir");
-        git(repo.path(), &["init", "-b", "main"]);
-        git(repo.path(), &["config", "user.email", "test@example.com"]);
-        git(repo.path(), &["config", "user.name", "Test User"]);
-        std::fs::write(repo.path().join("a.txt"), "base\n").expect("write");
-        git(repo.path(), &["add", "."]);
-        git(repo.path(), &["commit", "-m", "initial"]);
-        git(repo.path(), &["checkout", "-b", "feature"]);
-        std::fs::write(repo.path().join("a.txt"), "base\nchanged\n").expect("write");
+        let (_repo_dir, repo) = fixtures::temp_root();
+        seed_empty_repo_at(&repo);
+        std::fs::write(repo.join("a.txt"), "base\n").expect("write");
+        git(&repo, &["add", "."]);
+        git(&repo, &["commit", "-m", "initial"]);
+        git(&repo, &["checkout", "-b", "feature"]);
+        std::fs::write(repo.join("a.txt"), "base\nchanged\n").expect("write");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.clone());
         app.update_in(cx, |app, window, cx| {
             app.set_right_sidebar_view(RightSidebarView::Changes, window, cx);
         });
@@ -4486,12 +4431,12 @@ mod fold_state_tests {
     }
 
     /// `src/app/` + `src/lib/` + a root-level file, the shape every test below expands into.
-    fn seed_tree(repo: &TempDir) {
-        fs::create_dir_all(repo.path().join("src/app")).expect("mkdir");
-        fs::create_dir_all(repo.path().join("src/lib")).expect("mkdir");
-        fs::write(repo.path().join("src/app/main.rs"), "fn main() {}\n").expect("write");
-        fs::write(repo.path().join("src/lib/util.rs"), "pub fn u() {}\n").expect("write");
-        fs::write(repo.path().join("README.md"), "hi\n").expect("write");
+    fn seed_tree(repo: &Path) {
+        fs::create_dir_all(repo.join("src/app")).expect("mkdir");
+        fs::create_dir_all(repo.join("src/lib")).expect("mkdir");
+        fs::write(repo.join("src/app/main.rs"), "fn main() {}\n").expect("write");
+        fs::write(repo.join("src/lib/util.rs"), "pub fn u() {}\n").expect("write");
+        fs::write(repo.join("README.md"), "hi\n").expect("write");
     }
 
     fn expanded_names(app: &AdeApp) -> Vec<String> {
@@ -4507,15 +4452,12 @@ mod fold_state_tests {
 
     #[gpui::test]
     fn a_worktree_opened_for_the_first_time_starts_fully_collapsed(cx: &mut TestAppContext) {
-        let repo = TempDir::new().expect("tempdir");
+        let (_repo_dir, repo) = fixtures::temp_root();
         let state_dir = TempDir::new().expect("tempdir");
         seed_tree(&repo);
 
-        let (app, cx) = open_app_with_state_dir(
-            cx,
-            repo.path().to_path_buf(),
-            state_dir.path().join("settings.toml"),
-        );
+        let (app, cx) =
+            open_app_with_state_dir(cx, repo.clone(), state_dir.path().join("settings.toml"));
         cx.run_until_parked();
 
         assert!(app.read_with(cx, |app, _| app.expanded_dirs.is_empty()));
@@ -4536,18 +4478,17 @@ mod fold_state_tests {
 
     #[gpui::test]
     fn expanded_folders_are_restored_exactly_after_a_simulated_reload(cx: &mut TestAppContext) {
-        let repo = TempDir::new().expect("tempdir");
+        let (_repo_dir, repo) = fixtures::temp_root();
         let state_dir = TempDir::new().expect("tempdir");
         seed_tree(&repo);
         let settings_path = state_dir.path().join("settings.toml");
         let fold_path = state_dir.path().join("file-tree-state.toml");
 
-        let (app, cx) =
-            open_app_with_state_dir(cx, repo.path().to_path_buf(), settings_path.clone());
+        let (app, cx) = open_app_with_state_dir(cx, repo.clone(), settings_path.clone());
         cx.run_until_parked();
         app.update(cx, |app, cx| {
-            app.toggle_dir_expanded(repo.path().join("src"), cx);
-            app.toggle_dir_expanded(repo.path().join("src/app"), cx);
+            app.toggle_dir_expanded(repo.join("src"), cx);
+            app.toggle_dir_expanded(repo.join("src/app"), cx);
         });
         cx.run_until_parked();
 
@@ -4556,14 +4497,10 @@ mod fold_state_tests {
             "expanding a folder must be recorded on disk immediately - not on a clean exit, \
              which is exactly what this test never performs"
         );
-        assert_eq!(
-            FoldState::load_at(&fold_path)
-                .expanded_dirs(repo.path())
-                .len(),
-            2
-        );
+        assert_eq!(FoldState::load_at(&fold_path).expanded_dirs(&repo).len(), 2);
 
-        let (reloaded, cx) = open_app_with_state_dir(cx, repo.path().to_path_buf(), settings_path);
+        // The "relaunch": a brand-new `AdeApp` reading that same real file.
+        let (reloaded, cx) = open_app_with_state_dir(cx, repo.clone(), settings_path);
         cx.run_until_parked();
 
         assert_eq!(
@@ -4584,23 +4521,21 @@ mod fold_state_tests {
 
     #[gpui::test]
     fn fold_state_from_one_worktree_never_leaks_into_another(cx: &mut TestAppContext) {
-        let worktree_a = TempDir::new().expect("tempdir");
-        let worktree_b = TempDir::new().expect("tempdir");
+        let (_worktree_a_dir, worktree_a) = fixtures::temp_root();
+        let (_worktree_b_dir, worktree_b) = fixtures::temp_root();
         let state_dir = TempDir::new().expect("tempdir");
         seed_tree(&worktree_a);
         seed_tree(&worktree_b);
         let settings_path = state_dir.path().join("settings.toml");
 
-        let (app_a, cx) =
-            open_app_with_state_dir(cx, worktree_a.path().to_path_buf(), settings_path.clone());
+        let (app_a, cx) = open_app_with_state_dir(cx, worktree_a.clone(), settings_path.clone());
         cx.run_until_parked();
         app_a.update(cx, |app, cx| {
-            app.toggle_dir_expanded(worktree_a.path().join("src"), cx);
+            app.toggle_dir_expanded(worktree_a.join("src"), cx);
         });
         cx.run_until_parked();
 
-        let (app_b, cx) =
-            open_app_with_state_dir(cx, worktree_b.path().to_path_buf(), settings_path);
+        let (app_b, cx) = open_app_with_state_dir(cx, worktree_b.clone(), settings_path);
         cx.run_until_parked();
 
         assert!(
@@ -4613,7 +4548,7 @@ mod fold_state_tests {
         let fold_path = state_dir.path().join("file-tree-state.toml");
         assert_eq!(
             FoldState::load_at(&fold_path)
-                .expanded_dirs(worktree_a.path())
+                .expanded_dirs(&worktree_a)
                 .len(),
             1
         );
@@ -4621,42 +4556,41 @@ mod fold_state_tests {
 
     #[gpui::test]
     fn a_second_instances_saves_never_erase_the_first_instances_worktree(cx: &mut TestAppContext) {
-        let repo_a = TempDir::new().expect("tempdir");
-        let repo_b = TempDir::new().expect("tempdir");
+        let (_repo_a_dir, repo_a) = fixtures::temp_root();
+        let (_repo_b_dir, repo_b) = fixtures::temp_root();
         let state_dir = TempDir::new().expect("tempdir");
         seed_tree(&repo_a);
         seed_tree(&repo_b);
         let settings_path = state_dir.path().join("settings.toml");
         let fold_path = state_dir.path().join("file-tree-state.toml");
 
-        let (app_a, cx) =
-            open_app_with_state_dir(cx, repo_a.path().to_path_buf(), settings_path.clone());
+        let (app_a, cx) = open_app_with_state_dir(cx, repo_a.clone(), settings_path.clone());
         cx.run_until_parked();
 
-        let (app_b, cx) =
-            open_app_with_state_dir(cx, repo_b.path().to_path_buf(), settings_path.clone());
+        // Instance B starts here, snapshotting a file that knows nothing about A yet.
+        let (app_b, cx) = open_app_with_state_dir(cx, repo_b.clone(), settings_path.clone());
         cx.run_until_parked();
 
         app_a.update(cx, |app, cx| {
-            app.toggle_dir_expanded(repo_a.path().join("src"), cx);
+            app.toggle_dir_expanded(repo_a.join("src"), cx);
         });
         cx.run_until_parked();
         app_b.update(cx, |app, cx| {
-            app.toggle_dir_expanded(repo_b.path().join("src"), cx);
+            app.toggle_dir_expanded(repo_b.join("src"), cx);
         });
         cx.run_until_parked();
 
         let on_disk = FoldState::load_at(&fold_path);
         assert_eq!(
-            on_disk.expanded_dirs(repo_a.path()).len(),
+            on_disk.expanded_dirs(&repo_a).len(),
             1,
             "the second instance's save must merge, not clobber - repository A's fold state is \
              gone here if the write is a plain whole-file one"
         );
-        assert_eq!(on_disk.expanded_dirs(repo_b.path()).len(), 1);
+        assert_eq!(on_disk.expanded_dirs(&repo_b).len(), 1);
 
-        let (reloaded_a, cx) =
-            open_app_with_state_dir(cx, repo_a.path().to_path_buf(), settings_path);
+        // And a real relaunch of A sees its own state, which is what the user actually notices.
+        let (reloaded_a, cx) = open_app_with_state_dir(cx, repo_a.clone(), settings_path);
         cx.run_until_parked();
         assert_eq!(
             reloaded_a.read_with(cx, |app, _| expanded_names(app)),
@@ -4666,27 +4600,27 @@ mod fold_state_tests {
 
     #[gpui::test]
     fn a_stale_entry_for_a_deleted_folder_is_pruned_silently(cx: &mut TestAppContext) {
-        let repo = TempDir::new().expect("tempdir");
+        let (_repo_dir, repo) = fixtures::temp_root();
         let state_dir = TempDir::new().expect("tempdir");
         seed_tree(&repo);
         let settings_path = state_dir.path().join("settings.toml");
         let fold_path = state_dir.path().join("file-tree-state.toml");
 
-        let (app, cx) =
-            open_app_with_state_dir(cx, repo.path().to_path_buf(), settings_path.clone());
+        let (app, cx) = open_app_with_state_dir(cx, repo.clone(), settings_path.clone());
         cx.run_until_parked();
         app.update(cx, |app, cx| {
-            app.toggle_dir_expanded(repo.path().join("src"), cx);
-            app.toggle_dir_expanded(repo.path().join("src/app"), cx);
-            app.toggle_dir_expanded(repo.path().join("src/lib"), cx);
+            app.toggle_dir_expanded(repo.join("src"), cx);
+            app.toggle_dir_expanded(repo.join("src/app"), cx);
+            app.toggle_dir_expanded(repo.join("src/lib"), cx);
         });
         cx.run_until_parked();
 
-        fs::remove_dir_all(repo.path().join("src/lib")).expect("remove");
+        // An agent deletes one of them from underneath the running app.
+        fs::remove_dir_all(repo.join("src/lib")).expect("remove");
 
         // The "relaunch" - which is also where the prune happens, against the freshly walked
         // tree.
-        let (reloaded, cx) = open_app_with_state_dir(cx, repo.path().to_path_buf(), settings_path);
+        let (reloaded, cx) = open_app_with_state_dir(cx, repo.clone(), settings_path);
         cx.run_until_parked();
 
         assert_eq!(
@@ -4700,7 +4634,7 @@ mod fold_state_tests {
         );
         let on_disk = FoldState::load_at(&fold_path);
         assert_eq!(
-            on_disk.expanded_dirs(repo.path()).len(),
+            on_disk.expanded_dirs(&repo).len(),
             2,
             "the prune must be written back to the file, not just applied in memory"
         );
@@ -4708,26 +4642,23 @@ mod fold_state_tests {
 
     #[gpui::test]
     fn reloading_the_same_worktrees_tree_keeps_the_fold_state(cx: &mut TestAppContext) {
-        let repo = TempDir::new().expect("tempdir");
+        let (_repo_dir, repo) = fixtures::temp_root();
         let state_dir = TempDir::new().expect("tempdir");
         seed_tree(&repo);
 
-        let (app, cx) = open_app_with_state_dir(
-            cx,
-            repo.path().to_path_buf(),
-            state_dir.path().join("settings.toml"),
-        );
+        let (app, cx) =
+            open_app_with_state_dir(cx, repo.clone(), state_dir.path().join("settings.toml"));
         cx.run_until_parked();
         app.update(cx, |app, cx| {
-            app.toggle_dir_expanded(repo.path().join("src"), cx);
-            app.toggle_dir_expanded(repo.path().join("src/app"), cx);
+            app.toggle_dir_expanded(repo.join("src"), cx);
+            app.toggle_dir_expanded(repo.join("src/app"), cx);
         });
         cx.run_until_parked();
 
         // A file appears and another disappears underneath the running app, then the tree is
         // re-walked - neither touches any directory that was expanded.
-        fs::write(repo.path().join("src/app/new.rs"), "//\n").expect("write");
-        fs::remove_file(repo.path().join("README.md")).expect("remove");
+        fs::write(repo.join("src/app/new.rs"), "//\n").expect("write");
+        fs::remove_file(repo.join("README.md")).expect("remove");
         app.update(cx, |app, cx| {
             let root = app.file_tree_root.clone();
             app.load_file_tree(root, cx);
@@ -4747,17 +4678,16 @@ mod fold_state_tests {
 
     #[gpui::test]
     fn collapse_all_clears_both_the_tree_and_the_saved_state(cx: &mut TestAppContext) {
-        let repo = TempDir::new().expect("tempdir");
+        let (_repo_dir, repo) = fixtures::temp_root();
         let state_dir = TempDir::new().expect("tempdir");
         seed_tree(&repo);
         let settings_path = state_dir.path().join("settings.toml");
 
-        let (app, cx) =
-            open_app_with_state_dir(cx, repo.path().to_path_buf(), settings_path.clone());
+        let (app, cx) = open_app_with_state_dir(cx, repo.clone(), settings_path.clone());
         cx.run_until_parked();
         app.update(cx, |app, cx| {
-            app.toggle_dir_expanded(repo.path().join("src"), cx);
-            app.toggle_dir_expanded(repo.path().join("src/app"), cx);
+            app.toggle_dir_expanded(repo.join("src"), cx);
+            app.toggle_dir_expanded(repo.join("src/app"), cx);
         });
         cx.run_until_parked();
         assert!(cx.debug_bounds("file-tree-row-main.rs").is_some());
@@ -4772,7 +4702,7 @@ mod fold_state_tests {
         assert!(app.read_with(cx, |app, _| app.expanded_dirs.is_empty()));
         assert!(cx.debug_bounds("file-tree-row-main.rs").is_none());
 
-        let (reloaded, cx) = open_app_with_state_dir(cx, repo.path().to_path_buf(), settings_path);
+        let (reloaded, cx) = open_app_with_state_dir(cx, repo.clone(), settings_path);
         cx.run_until_parked();
         assert!(
             reloaded.read_with(cx, |app, _| app.expanded_dirs.is_empty()),
@@ -4783,14 +4713,13 @@ mod fold_state_tests {
 
     #[gpui::test]
     fn revealing_a_file_expands_its_ancestors_and_records_them(cx: &mut TestAppContext) {
-        let repo = TempDir::new().expect("tempdir");
+        let (_repo_dir, repo) = fixtures::temp_root();
         let state_dir = TempDir::new().expect("tempdir");
         seed_tree(&repo);
         let settings_path = state_dir.path().join("settings.toml");
-        let target = repo.path().join("src/app/main.rs");
+        let target = repo.join("src/app/main.rs");
 
-        let (app, cx) =
-            open_app_with_state_dir(cx, repo.path().to_path_buf(), settings_path.clone());
+        let (app, cx) = open_app_with_state_dir(cx, repo.clone(), settings_path.clone());
         cx.run_until_parked();
         assert!(
             cx.debug_bounds("file-tree-row-main.rs").is_none(),
@@ -4828,7 +4757,7 @@ mod fold_state_tests {
             );
         });
 
-        let (reloaded, cx) = open_app_with_state_dir(cx, repo.path().to_path_buf(), settings_path);
+        let (reloaded, cx) = open_app_with_state_dir(cx, repo.clone(), settings_path);
         cx.run_until_parked();
         assert_eq!(
             reloaded.read_with(cx, |app, _| expanded_names(app)),
@@ -4839,16 +4768,13 @@ mod fold_state_tests {
 
     #[gpui::test]
     fn opening_a_file_directly_reveals_it_in_the_tree(cx: &mut TestAppContext) {
-        let repo = TempDir::new().expect("tempdir");
+        let (_repo_dir, repo) = fixtures::temp_root();
         let state_dir = TempDir::new().expect("tempdir");
         seed_tree(&repo);
-        let target = repo.path().join("src/app/main.rs");
+        let target = repo.join("src/app/main.rs");
 
-        let (app, cx) = open_app_with_state_dir(
-            cx,
-            repo.path().to_path_buf(),
-            state_dir.path().join("settings.toml"),
-        );
+        let (app, cx) =
+            open_app_with_state_dir(cx, repo.clone(), state_dir.path().join("settings.toml"));
         cx.run_until_parked();
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(target.clone(), window, cx);
@@ -4867,21 +4793,18 @@ mod fold_state_tests {
 
     #[gpui::test]
     fn a_large_directory_renders_completely_with_no_truncation_row(cx: &mut TestAppContext) {
-        let repo = TempDir::new().expect("tempdir");
+        let (_repo_dir, repo) = fixtures::temp_root();
         let state_dir = TempDir::new().expect("tempdir");
-        fs::create_dir(repo.path().join("big")).expect("mkdir");
+        fs::create_dir(repo.join("big")).expect("mkdir");
         for index in 0..800 {
-            fs::write(repo.path().join(format!("big/f-{index:03}.txt")), "x\n").expect("write");
+            fs::write(repo.join(format!("big/f-{index:03}.txt")), "x\n").expect("write");
         }
 
-        let (app, cx) = open_app_with_state_dir(
-            cx,
-            repo.path().to_path_buf(),
-            state_dir.path().join("settings.toml"),
-        );
+        let (app, cx) =
+            open_app_with_state_dir(cx, repo.clone(), state_dir.path().join("settings.toml"));
         cx.run_until_parked();
         app.update(cx, |app, cx| {
-            app.toggle_dir_expanded(repo.path().join("big"), cx);
+            app.toggle_dir_expanded(repo.join("big"), cx);
         });
         cx.run_until_parked();
 
@@ -4929,79 +4852,31 @@ mod fold_state_tests {
         );
     }
 
-    #[gpui::test]
-    fn a_tree_past_the_removed_cap_loads_every_entry_with_no_load_more_row(
-        cx: &mut TestAppContext,
-    ) {
-        const DIRS: usize = 200;
-        const FILES_PER_DIR: usize = 105;
-        const EXPECTED: usize = DIRS + DIRS * FILES_PER_DIR;
-
-        let repo = TempDir::new().expect("tempdir");
-        let state_dir = TempDir::new().expect("tempdir");
-        for d in 0..DIRS {
-            let sub = repo.path().join(format!("d-{d:03}"));
-            fs::create_dir(&sub).expect("mkdir");
-            for f in 0..FILES_PER_DIR {
-                fs::write(sub.join(format!("f-{f:03}.txt")), "x\n").expect("write");
-            }
-        }
-
-        let (app, cx) = open_app_with_state_dir(
-            cx,
-            repo.path().to_path_buf(),
-            state_dir.path().join("settings.toml"),
-        );
-        cx.run_until_parked();
-
-        assert_eq!(
-            app.read_with(cx, |app, _| app.file_tree.len()),
-            EXPECTED,
-            "the walk used to stop at 20,000 entries - every folder and file must now load"
-        );
-        assert!(
-            app.read_with(cx, |app, _| app.file_tree_complete),
-            "and a walk that reached everything is a complete inventory, so fold-state pruning \
-             may trust it"
-        );
-        assert!(
-            cx.debug_bounds("file-tree-show-all").is_none(),
-            "the 'Stopped at N entries - load more' row must not exist any more"
-        );
-
-        // The palette's own candidate list is derived from the same walk, on the background
-        // executor now that it is unbounded - it must cover the whole tree, not the first 20,000.
-        assert_eq!(
-            app.read_with(cx, |app, _| app.palette_file_candidates.len()),
-            DIRS * FILES_PER_DIR,
-            "one candidate per file (directories are not candidates), across the whole tree"
-        );
-
-        // A folder well past the old cut-off must expand and render for real, not just be
-        // counted: `d-199` starts at entry ~21,000.
-        let last_dir = repo.path().join(format!("d-{:03}", DIRS - 1));
-        app.update(cx, |app, cx| app.toggle_dir_expanded(last_dir.clone(), cx));
-        cx.run_until_parked();
-        assert!(
-            app.read_with(cx, |app, _| {
-                app.file_tree
-                    .visible_entries(&app.expanded_dirs)
-                    .iter()
-                    .any(|entry| entry.path == last_dir.join("f-104.txt"))
-            }),
-            "the last file of the last directory is ~1,200 entries past the removed cap and must \
-             be a real, visible row"
-        );
-    }
-
+    /// CRITICAL 2: the canonicalized worktree key is resolved once per real root change and
+    /// cached, because `worktree_key` calls the blocking `std::fs::canonicalize` and the callers
+    /// are clicks and per-ancestor reveals. What's asserted here is the part that would actually
+    /// break if the cache were wrong: reaching a worktree through a symlink must record against
+    /// the *canonical* path, so opening it through the symlink and opening it directly share one
+    /// fold-state entry rather than silently keeping two.
+    ///
+    /// The reveal below goes through the **real** path, not the symlink, and that is the honest
+    /// shape of this now: `crate::rail::repo::canonical_repo_path` resolves the repo path where it
+    /// enters the app (the CLI argument, `AdeApp::add_repo`, `AdeApp::open_repo_in_current_
+    /// window`), so `AdeApp::file_tree_root` is already the real path here even though the app was
+    /// opened through the link - and every path the file tree/palette hands back to a reveal is
+    /// walked from that root, so no real UI path produces a symlinked one anymore. That
+    /// normalization exists for a separate, reproduced bug (an agent spawned against an unresolved
+    /// repo path matched no rail worktree row at all - see that function's docs); this test's own
+    /// property is unaffected by it, and the extra `file_tree_root` assertion below pins the new
+    /// behavior down rather than leaving it implied.
     #[cfg(unix)]
     #[gpui::test]
     fn the_cached_worktree_key_is_canonical_and_records_through_a_symlink(cx: &mut TestAppContext) {
-        let real = TempDir::new().expect("tempdir");
+        let (_real_dir, real) = fixtures::temp_root();
         let link_parent = TempDir::new().expect("tempdir");
         seed_tree(&real);
         let link = link_parent.path().join("linked-worktree");
-        std::os::unix::fs::symlink(real.path(), &link).expect("symlink");
+        std::os::unix::fs::symlink(&real, &link).expect("symlink");
         let state_dir = TempDir::new().expect("tempdir");
 
         let (app, cx) =
@@ -5016,21 +4891,19 @@ mod fold_state_tests {
         );
         assert_eq!(
             app.read_with(cx, |app, _| app.file_tree_root.clone()),
-            real.path(),
+            real,
             "opening through a symlink must root the tree at the resolved path, so nothing this \
              app walks or spawns from it carries the unresolved one"
         );
 
         app.update_in(cx, |app, window, cx| {
-            app.open_palette_file_result(real.path().join("src/app/main.rs"), window, cx);
+            app.open_palette_file_result(real.join("src/app/main.rs"), window, cx);
         });
         cx.run_until_parked();
 
-        let (reloaded, cx) = open_app_with_state_dir(
-            cx,
-            real.path().to_path_buf(),
-            state_dir.path().join("settings.toml"),
-        );
+        // Reopening against the *real* path must see what was recorded through the symlink.
+        let (reloaded, cx) =
+            open_app_with_state_dir(cx, real.clone(), state_dir.path().join("settings.toml"));
         cx.run_until_parked();
         assert_eq!(
             reloaded.read_with(cx, |app, _| expanded_names(app)),
@@ -5041,7 +4914,7 @@ mod fold_state_tests {
 
     #[gpui::test]
     fn a_failed_fold_state_write_is_requeued_rather_than_dropped(cx: &mut TestAppContext) {
-        let repo = TempDir::new().expect("tempdir");
+        let (_repo_dir, repo) = fixtures::temp_root();
         let state_dir = TempDir::new().expect("tempdir");
         seed_tree(&repo);
         let blocker = state_dir.path().join("not-a-directory");
@@ -5051,12 +4924,11 @@ mod fold_state_tests {
         )
         .expect("write");
 
-        let (app, cx) =
-            open_app_with_state_dir(cx, repo.path().to_path_buf(), blocker.join("settings.toml"));
+        let (app, cx) = open_app_with_state_dir(cx, repo.clone(), blocker.join("settings.toml"));
         cx.run_until_parked();
 
         app.update(cx, |app, cx| {
-            app.toggle_dir_expanded(repo.path().join("src"), cx);
+            app.toggle_dir_expanded(repo.join("src"), cx);
         });
         cx.run_until_parked();
 
@@ -5081,28 +4953,22 @@ mod fold_state_tests {
     fn an_incomplete_walk_never_prunes_fold_state(cx: &mut TestAppContext) {
         use std::os::unix::fs::PermissionsExt;
 
-        let repo = TempDir::new().expect("tempdir");
+        let (_repo_dir, repo) = fixtures::temp_root();
         let state_dir = TempDir::new().expect("tempdir");
-        let outer = repo.path().join("outer");
+        let outer = repo.join("outer");
         fs::create_dir(&outer).expect("mkdir");
         fs::create_dir(outer.join("zzz")).expect("mkdir");
         fs::write(outer.join("zzz/inside.txt"), "x\n").expect("write");
         let settings_path = state_dir.path().join("settings.toml");
         let fold_path = state_dir.path().join("file-tree-state.toml");
 
-        let (app, cx) =
-            open_app_with_state_dir(cx, repo.path().to_path_buf(), settings_path.clone());
+        let (app, cx) = open_app_with_state_dir(cx, repo.clone(), settings_path.clone());
         cx.run_until_parked();
         app.update(cx, |app, cx| {
             app.toggle_dir_expanded(outer.join("zzz"), cx);
         });
         cx.run_until_parked();
-        assert_eq!(
-            FoldState::load_at(&fold_path)
-                .expanded_dirs(repo.path())
-                .len(),
-            1
-        );
+        assert_eq!(FoldState::load_at(&fold_path).expanded_dirs(&repo).len(), 1);
 
         fs::set_permissions(&outer, fs::Permissions::from_mode(0o000)).expect("chmod");
         if fs::read_dir(&outer).is_ok() {
@@ -5112,7 +4978,7 @@ mod fold_state_tests {
             return;
         }
 
-        let (reloaded, cx) = open_app_with_state_dir(cx, repo.path().to_path_buf(), settings_path);
+        let (reloaded, cx) = open_app_with_state_dir(cx, repo.clone(), settings_path);
         cx.run_until_parked();
 
         let complete = reloaded.read_with(cx, |app, _| app.file_tree_complete);
@@ -5132,9 +4998,7 @@ mod fold_state_tests {
         );
 
         assert_eq!(
-            FoldState::load_at(&fold_path)
-                .expanded_dirs(repo.path())
-                .len(),
+            FoldState::load_at(&fold_path).expanded_dirs(&repo).len(),
             1,
             "an incomplete listing is not evidence that a folder is gone"
         );
@@ -5150,7 +5014,6 @@ mod indent_guide_tests {
     use crate::root::focus::palette_focus_tests;
     use gpui::TestAppContext;
     use std::fs;
-    use tempfile::TempDir;
 
     fn close_enough(a: f32, b: f32) -> bool {
         (a - b).abs() < 1.0
@@ -5159,81 +5022,31 @@ mod indent_guide_tests {
     /// `a/b/c/deep.txt`, with the whole chain expanded, plus a sibling file at each level.
     fn open_deep_tree<'a>(
         cx: &'a mut TestAppContext,
-        repo: &TempDir,
+        repo: &Path,
     ) -> (gpui::Entity<AdeApp>, &'a mut gpui::VisualTestContext) {
-        fs::create_dir_all(repo.path().join("a/b/c")).expect("mkdir");
-        fs::write(repo.path().join("a/b/c/deep.txt"), "x\n").expect("write");
-        fs::write(repo.path().join("a/b/mid.txt"), "x\n").expect("write");
-        fs::write(repo.path().join("a/top.txt"), "x\n").expect("write");
+        fs::create_dir_all(repo.join("a/b/c")).expect("mkdir");
+        fs::write(repo.join("a/b/c/deep.txt"), "x\n").expect("write");
+        fs::write(repo.join("a/b/mid.txt"), "x\n").expect("write");
+        fs::write(repo.join("a/top.txt"), "x\n").expect("write");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.to_path_buf());
         cx.run_until_parked();
         app.update(cx, |app, cx| {
-            app.toggle_dir_expanded(repo.path().join("a"), cx);
-            app.toggle_dir_expanded(repo.path().join("a/b"), cx);
-            app.toggle_dir_expanded(repo.path().join("a/b/c"), cx);
+            app.toggle_dir_expanded(repo.join("a"), cx);
+            app.toggle_dir_expanded(repo.join("a/b"), cx);
+            app.toggle_dir_expanded(repo.join("a/b/c"), cx);
         });
         cx.run_until_parked();
         (app, cx)
     }
 
-    #[gpui::test]
-    fn indent_guides_stay_neutral_even_when_a_descendant_file_is_open_and_focus_leaves_the_tree(
-        cx: &mut TestAppContext,
-    ) {
-        let repo = TempDir::new().expect("tempdir");
-        let (app, cx) = open_deep_tree(cx, &repo);
-
-        app.update_in(cx, |app, window, cx| {
-            app.open_file_view(repo.path().join("a/b/c/deep.txt"), window, cx);
-        });
-        cx.run_until_parked();
-        app.update_in(cx, |app, window, _cx| {
-            assert!(
-                !app.tree_focus_handle.is_focused(window),
-                "premise: opening a file via the normal path focuses the editor, not the tree"
-            );
-        });
-        for level in 0..3 {
-            assert!(
-                cx.debug_bounds(match level {
-                    0 => "file-tree-guide-deep.txt-0",
-                    1 => "file-tree-guide-deep.txt-1",
-                    _ => "file-tree-guide-deep.txt-2",
-                })
-                .is_some(),
-                "the open file's own ancestor guides must still render at level {level} - just \
-                 never in a distinct colour"
-            );
-        }
-        assert!(
-            cx.debug_bounds("file-tree-guide-active-deep.txt-0")
-                .is_none(),
-            "no guide may ever render under the old accent-colour selector, even for the open \
-             file's own chain, with focus on the editor"
-        );
-
-        app.update_in(cx, |app, window, cx| {
-            app.focus_file_tree(window, cx);
-        });
-        cx.run_until_parked();
-        assert!(
-            cx.debug_bounds("file-tree-guide-active-deep.txt-0")
-                .is_none(),
-            "and still none once the tree regains focus - selecting/focusing the open file's own \
-             row must not recolour its ancestor guides either"
-        );
-        assert!(
-            cx.debug_bounds("file-tree-guide-deep.txt-0").is_some(),
-            "the guide itself must still be there, just neutral"
-        );
-    }
-
+    /// One guide per nesting level, each at exactly its level's chevron offset from the row's
+    /// own left edge, and none at all for a root-level row.
     #[gpui::test]
     fn each_row_draws_one_guide_per_level_aligned_with_that_levels_chevron(
         cx: &mut TestAppContext,
     ) {
-        let repo = TempDir::new().expect("tempdir");
+        let (_repo_dir, repo) = fixtures::temp_root();
         let (_app, cx) = open_deep_tree(cx, &repo);
 
         assert!(
@@ -5271,7 +5084,7 @@ mod indent_guide_tests {
 
     #[gpui::test]
     fn guides_on_consecutive_rows_join_with_no_gap(cx: &mut TestAppContext) {
-        let repo = TempDir::new().expect("tempdir");
+        let (_repo_dir, repo) = fixtures::temp_root();
         let (_app, cx) = open_deep_tree(cx, &repo);
 
         // The three consecutive rows `c`, `deep.txt`, `mid.txt` (in that render order - `c`'s
@@ -5316,23 +5129,19 @@ mod indent_guide_tests {
 
     #[gpui::test]
     fn guides_stay_aligned_with_their_own_rows_after_the_list_recycles(cx: &mut TestAppContext) {
-        let repo = TempDir::new().expect("tempdir");
-        fs::create_dir_all(repo.path().join("nested/inner")).expect("mkdir");
+        let (_repo_dir, repo) = fixtures::temp_root();
+        fs::create_dir_all(repo.join("nested/inner")).expect("mkdir");
         // Enough rows inside the nested folder to fill several viewports, so scrolling genuinely
         // recycles row elements rather than merely translating them.
         for index in 0..300 {
-            fs::write(
-                repo.path().join(format!("nested/inner/f-{index:03}.txt")),
-                "x\n",
-            )
-            .expect("write");
+            fs::write(repo.join(format!("nested/inner/f-{index:03}.txt")), "x\n").expect("write");
         }
         let (_app, cx) = {
-            let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+            let (app, cx) = palette_focus_tests::open_test_app(cx, repo.to_path_buf());
             cx.run_until_parked();
             app.update(cx, |app, cx| {
-                app.toggle_dir_expanded(repo.path().join("nested"), cx);
-                app.toggle_dir_expanded(repo.path().join("nested/inner"), cx);
+                app.toggle_dir_expanded(repo.join("nested"), cx);
+                app.toggle_dir_expanded(repo.join("nested/inner"), cx);
             });
             cx.run_until_parked();
             (app, cx)
@@ -5393,14 +5202,14 @@ mod indent_guide_tests {
 
     #[gpui::test]
     fn no_rows_guides_are_ever_recoloured_by_a_sibling_subtrees_open_file(cx: &mut TestAppContext) {
-        let repo = TempDir::new().expect("tempdir");
+        let (_repo_dir, repo) = fixtures::temp_root();
         // A second branch at the same depth as `a/b`, so there is a row that shares only a
         // partial ancestor chain with the file that ends up open.
-        fs::create_dir_all(repo.path().join("a/other")).expect("mkdir");
-        fs::write(repo.path().join("a/other/elsewhere.txt"), "x\n").expect("write");
+        fs::create_dir_all(repo.join("a/other")).expect("mkdir");
+        fs::write(repo.join("a/other/elsewhere.txt"), "x\n").expect("write");
         let (app, cx) = open_deep_tree(cx, &repo);
         app.update(cx, |app, cx| {
-            app.toggle_dir_expanded(repo.path().join("a/other"), cx);
+            app.toggle_dir_expanded(repo.join("a/other"), cx);
         });
         cx.run_until_parked();
 
@@ -5410,7 +5219,27 @@ mod indent_guide_tests {
         );
 
         app.update_in(cx, |app, window, cx| {
-            app.open_file_view(repo.path().join("a/b/c/deep.txt"), window, cx);
+            app.open_file_view(repo.join("a/b/c/deep.txt"), window, cx);
+        });
+        cx.run_until_parked();
+        app.update_in(cx, |app, window, _cx| {
+            assert!(
+                !app.tree_focus_handle.is_focused(window),
+                "premise: opening a file via the normal path focuses the editor, not the tree"
+            );
+        });
+        assert!(
+            cx.debug_bounds("file-tree-guide-deep.txt-0").is_some(),
+            "the open file's own ancestor guides still render with focus on the editor"
+        );
+        assert!(
+            cx.debug_bounds("file-tree-guide-active-deep.txt-0")
+                .is_none(),
+            "and none of them under the old accent-colour selector, focus on the editor being \
+             exactly the state a user typing in a file sits in"
+        );
+
+        app.update_in(cx, |app, window, cx| {
             app.focus_file_tree(window, cx);
         });
         cx.run_until_parked();
@@ -5443,12 +5272,12 @@ mod indent_guide_tests {
 
     #[gpui::test]
     fn collapsing_removes_the_hidden_rows_guides_too(cx: &mut TestAppContext) {
-        let repo = TempDir::new().expect("tempdir");
+        let (_repo_dir, repo) = fixtures::temp_root();
         let (app, cx) = open_deep_tree(cx, &repo);
         assert!(cx.debug_bounds("file-tree-guide-deep.txt-2").is_some());
 
         app.update(cx, |app, cx| {
-            app.toggle_dir_expanded(repo.path().join("a/b"), cx);
+            app.toggle_dir_expanded(repo.join("a/b"), cx);
         });
         cx.run_until_parked();
 
@@ -5474,38 +5303,10 @@ mod commit_composer_tests {
     use super::*;
     use crate::root::focus::palette_focus_tests;
     use gpui::TestAppContext;
-    use std::process::Command;
     use tempfile::TempDir;
+    use test_support::{git, git_output, seed_empty_repo_at};
 
-    /// `.output()`, not `.status()` - see `virtualization_tests::git`'s own comment for why.
-    fn git(dir: &std::path::Path, args: &[&str]) {
-        let output = Command::new("git")
-            .args(args)
-            .current_dir(dir)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {args:?} failed: {}",
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
-    fn git_output(dir: &std::path::Path, args: &[&str]) -> String {
-        let output = Command::new("git")
-            .args(args)
-            .current_dir(dir)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {args:?} failed: {}",
-            String::from_utf8_lossy(&output.stderr)
-        );
-        String::from_utf8_lossy(&output.stdout).trim().to_string()
-    }
-
-    fn commit_count(dir: &std::path::Path) -> usize {
+    fn commit_count(dir: &Path) -> usize {
         git_output(dir, &["rev-list", "--count", "HEAD"])
             .parse()
             .expect("git rev-list --count must print a real integer")
@@ -5516,19 +5317,17 @@ mod commit_composer_tests {
     /// `virtualization_tests::a_changes_row_far_below_the_viewport_is_never_painted` already
     /// establishes, so this hits `wt_core::diff::DiffBase::Diff` against a real merge-base
     /// rather than `DiffBase::NoBase`'s uncommitted-vs-HEAD fallback (GitHub issue #108).
-    fn changes_test_repo() -> TempDir {
-        let repo = TempDir::new().expect("tempdir");
-        git(repo.path(), &["init", "-b", "main"]);
-        git(repo.path(), &["config", "user.email", "test@example.com"]);
-        git(repo.path(), &["config", "user.name", "Test User"]);
-        std::fs::write(repo.path().join("a.txt"), "one\ntwo\nthree\n").expect("write a.txt");
-        std::fs::write(repo.path().join("b.txt"), "uno\ndos\ntres\n").expect("write b.txt");
-        git(repo.path(), &["add", "."]);
-        git(repo.path(), &["commit", "-m", "initial"]);
-        git(repo.path(), &["checkout", "-b", "feature"]);
-        std::fs::write(repo.path().join("a.txt"), "one\ntwo\nthree\nfour\n").expect("write a.txt");
-        std::fs::write(repo.path().join("b.txt"), "uno\ndos\ntres\ncuatro\n").expect("write b.txt");
-        repo
+    fn changes_test_repo() -> (TempDir, PathBuf) {
+        let (dir, repo) = fixtures::temp_root();
+        seed_empty_repo_at(&repo);
+        std::fs::write(repo.join("a.txt"), "one\ntwo\nthree\n").expect("write a.txt");
+        std::fs::write(repo.join("b.txt"), "uno\ndos\ntres\n").expect("write b.txt");
+        git(&repo, &["add", "."]);
+        git(&repo, &["commit", "-m", "initial"]);
+        git(&repo, &["checkout", "-b", "feature"]);
+        std::fs::write(repo.join("a.txt"), "one\ntwo\nthree\nfour\n").expect("write a.txt");
+        std::fs::write(repo.join("b.txt"), "uno\ndos\ntres\ncuatro\n").expect("write b.txt");
+        (dir, repo)
     }
 
     /// GitHub issue #220's exact shape: a feature branch carrying **one real commit** since its
@@ -5537,32 +5336,29 @@ mod commit_composer_tests {
     /// against that merge-base, so it lists *both* files and `DiffFile` alone cannot tell them
     /// apart - which is precisely what used to make the committed one render an actionable,
     /// unchecked "stage me" checkbox.
-    fn repo_with_a_committed_and_a_dirty_file() -> TempDir {
-        let repo = TempDir::new().expect("tempdir");
-        git(repo.path(), &["init", "-b", "main"]);
-        git(repo.path(), &["config", "user.email", "test@example.com"]);
-        git(repo.path(), &["config", "user.name", "Test User"]);
-        std::fs::write(repo.path().join("dirty.txt"), "one\ntwo\n").expect("write dirty.txt");
-        git(repo.path(), &["add", "."]);
-        git(repo.path(), &["commit", "-m", "initial"]);
-        git(repo.path(), &["checkout", "-b", "feature"]);
-        std::fs::write(repo.path().join("committed.txt"), "committed\n")
-            .expect("write committed.txt");
-        git(repo.path(), &["add", "committed.txt"]);
+    fn repo_with_a_committed_and_a_dirty_file() -> (TempDir, PathBuf) {
+        let (dir, repo) = fixtures::temp_root();
+        seed_empty_repo_at(&repo);
+        std::fs::write(repo.join("dirty.txt"), "one\ntwo\n").expect("write dirty.txt");
+        git(&repo, &["add", "."]);
+        git(&repo, &["commit", "-m", "initial"]);
+        git(&repo, &["checkout", "-b", "feature"]);
+        std::fs::write(repo.join("committed.txt"), "committed\n").expect("write committed.txt");
+        git(&repo, &["add", "committed.txt"]);
         git(
-            repo.path(),
+            &repo,
             &["commit", "-m", "a real commit on the feature branch"],
         );
-        std::fs::write(repo.path().join("dirty.txt"), "one\ntwo\nthree\n")
-            .expect("modify dirty.txt");
-        repo
+        // ...and only now a real, still-uncommitted edit to the other file.
+        std::fs::write(repo.join("dirty.txt"), "one\ntwo\nthree\n").expect("modify dirty.txt");
+        (dir, repo)
     }
 
     fn open_changes_view<'a>(
         cx: &'a mut TestAppContext,
-        repo: &TempDir,
+        repo: &Path,
     ) -> (gpui::Entity<AdeApp>, &'a mut gpui::VisualTestContext) {
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.set_right_sidebar_view(RightSidebarView::Changes, window, cx);
         });
@@ -5585,7 +5381,7 @@ mod commit_composer_tests {
 
     #[gpui::test]
     fn message_caret_hugs_the_real_text_and_is_vertically_centered(cx: &mut TestAppContext) {
-        let repo = changes_test_repo();
+        let (_repo_dir, repo) = changes_test_repo();
         let (_app, cx) = open_changes_view(cx, &repo);
 
         let field = cx
@@ -5651,7 +5447,7 @@ mod commit_composer_tests {
     fn the_composer_reflects_real_staged_count_diffstat_branch_and_message(
         cx: &mut TestAppContext,
     ) {
-        let repo = changes_test_repo();
+        let (_repo_dir, repo) = changes_test_repo();
         let (app, cx) = open_changes_view(cx, &repo);
 
         assert_eq!(
@@ -5722,12 +5518,16 @@ mod commit_composer_tests {
         );
     }
 
+    /// A commit needs both halves - something staged *and* a message the user typed ("a normal
+    /// message input that the user has to fill", not an optional one with a fallback) - so the
+    /// primary button is a genuine no-op with either one missing.
     #[gpui::test]
-    fn the_primary_button_is_a_genuine_no_op_with_nothing_staged(cx: &mut TestAppContext) {
-        let repo = changes_test_repo();
+    fn the_primary_button_is_a_genuine_no_op_until_something_is_staged_and_typed(
+        cx: &mut TestAppContext,
+    ) {
+        let (_repo_dir, repo) = changes_test_repo();
         let (app, cx) = open_changes_view(cx, &repo);
-
-        let commits_before = commit_count(repo.path());
+        let commits_before = commit_count(&repo);
 
         let bounds = cx
             .debug_bounds("commit-composer-primary")
@@ -5736,7 +5536,7 @@ mod commit_composer_tests {
         cx.run_until_parked();
 
         assert_eq!(
-            commit_count(repo.path()),
+            commit_count(&repo),
             commits_before,
             "a real click on the primary button with nothing staged must never create a real \
              commit"
@@ -5756,13 +5556,8 @@ mod commit_composer_tests {
             "a disabled click must never even set the real \"committing…\" status - proof the \
              operation truly never started, not just that it already finished"
         );
-    }
 
-    #[gpui::test]
-    fn the_primary_button_is_a_genuine_no_op_with_nothing_typed(cx: &mut TestAppContext) {
-        let repo = changes_test_repo();
-        let (app, cx) = open_changes_view(cx, &repo);
-
+        // Now the other half: something really staged, still nothing typed.
         app.update(cx, |app, cx| {
             app.toggle_staged(PathBuf::from("a.txt"), cx);
         });
@@ -5772,7 +5567,6 @@ mod commit_composer_tests {
             "premise: something is staged, but no message has been typed"
         );
 
-        let commits_before = commit_count(repo.path());
         let bounds = cx
             .debug_bounds("commit-composer-primary")
             .expect("the primary button must really paint even with no message");
@@ -5780,20 +5574,20 @@ mod commit_composer_tests {
         cx.run_until_parked();
 
         assert_eq!(
-            commit_count(repo.path()),
+            commit_count(&repo),
             commits_before,
             "a real click on the primary button with something staged but no message must never \
              create a real commit"
         );
         assert!(
             app.read_with(cx, |app, _| app.worktree_history_status.is_none()),
-            "a disabled click must never even set the real \"committing…\" status"
+            "and still never sets the real \"committing…\" status"
         );
     }
 
     #[gpui::test]
     fn clicking_the_message_box_and_typing_really_edits_it(cx: &mut TestAppContext) {
-        let repo = changes_test_repo();
+        let (_repo_dir, repo) = changes_test_repo();
         let (app, cx) = open_changes_view(cx, &repo);
 
         app.update(cx, |app, cx| {
@@ -5843,7 +5637,7 @@ mod commit_composer_tests {
 
     #[gpui::test]
     fn typing_before_staging_survives_a_later_stage(cx: &mut TestAppContext) {
-        let repo = changes_test_repo();
+        let (_repo_dir, repo) = changes_test_repo();
         let (app, cx) = open_changes_view(cx, &repo);
 
         assert!(
@@ -5919,7 +5713,7 @@ mod commit_composer_tests {
 
     #[gpui::test]
     fn focusing_the_commit_message_starts_the_real_shared_blink_loop(cx: &mut TestAppContext) {
-        let repo = changes_test_repo();
+        let (_repo_dir, repo) = changes_test_repo();
         let (app, cx) = open_changes_view(cx, &repo);
         // `on_focus`/`on_blur` only fire while GPUI considers the window itself "active" - see
         // `focusing_the_rail_filter_starts_the_real_shared_blink_loop`'s own docs.
@@ -5951,7 +5745,7 @@ mod commit_composer_tests {
 
     #[gpui::test]
     fn a_real_commit_writes_the_users_own_edited_message(cx: &mut TestAppContext) {
-        let repo = changes_test_repo();
+        let (_repo_dir, repo) = changes_test_repo();
         let (app, cx) = open_changes_view(cx, &repo);
 
         app.update(cx, |app, cx| {
@@ -5973,13 +5767,8 @@ mod commit_composer_tests {
         cx.simulate_click(primary.center(), gpui::Modifiers::none());
         cx.run_until_parked();
 
-        let log = std::process::Command::new("git")
-            .args(["log", "-1", "--format=%s"])
-            .current_dir(repo.path())
-            .output()
-            .expect("real git log");
         assert_eq!(
-            String::from_utf8_lossy(&log.stdout).trim(),
+            git_output(&repo, &["log", "-1", "--format=%s"]),
             "REWRITTEN",
             "the real commit on disk must carry the user's own typed message verbatim"
         );
@@ -5987,7 +5776,7 @@ mod commit_composer_tests {
 
     #[gpui::test]
     fn focusing_the_message_field_is_not_itself_an_undoable_step(cx: &mut TestAppContext) {
-        let repo = changes_test_repo();
+        let (_repo_dir, repo) = changes_test_repo();
         let (app, cx) = open_changes_view(cx, &repo);
 
         app.update(cx, |app, cx| {
@@ -6016,7 +5805,7 @@ mod commit_composer_tests {
 
     #[gpui::test]
     fn staging_never_writes_anything_into_the_message_box(cx: &mut TestAppContext) {
-        let repo = changes_test_repo();
+        let (_repo_dir, repo) = changes_test_repo();
         let (app, cx) = open_changes_view(cx, &repo);
 
         assert_eq!(
@@ -6057,7 +5846,7 @@ mod commit_composer_tests {
     fn clicking_the_primary_button_reaches_the_real_commit_staged_files_action(
         cx: &mut TestAppContext,
     ) {
-        let repo = changes_test_repo();
+        let (_repo_dir, repo) = changes_test_repo();
         let (app, cx) = open_changes_view(cx, &repo);
 
         let a_path = PathBuf::from("a.txt");
@@ -6067,7 +5856,7 @@ mod commit_composer_tests {
         cx.run_until_parked();
         type_commit_message(cx, "update a.txt");
 
-        let commits_before = commit_count(repo.path());
+        let commits_before = commit_count(&repo);
 
         let bounds = cx
             .debug_bounds("commit-composer-primary")
@@ -6076,7 +5865,7 @@ mod commit_composer_tests {
         cx.run_until_parked();
 
         assert_eq!(
-            commit_count(repo.path()),
+            commit_count(&repo),
             commits_before + 1,
             "a real click on the wired primary button must create exactly one real git commit \
              via wt_core::undo::commit_paths"
@@ -6103,7 +5892,7 @@ mod commit_composer_tests {
     fn clicking_the_menu_toggle_genuinely_opens_and_closes_the_commit_menu(
         cx: &mut TestAppContext,
     ) {
-        let repo = changes_test_repo();
+        let (_repo_dir, repo) = changes_test_repo();
         let (app, cx) = open_changes_view(cx, &repo);
 
         assert!(
@@ -6152,7 +5941,7 @@ mod commit_composer_tests {
         // No `origin` in this fixture, deliberately: the commit half must really happen and the
         // push half must fail *loudly*, with git's own words on the status line. A row that
         // silently swallowed an unreachable remote would be the worst of both worlds.
-        let repo = changes_test_repo();
+        let (_repo_dir, repo) = changes_test_repo();
         let (app, cx) = open_changes_view(cx, &repo);
         app.update(cx, |app, cx| {
             app.toggle_staged(PathBuf::from("a.txt"), cx);
@@ -6160,19 +5949,19 @@ mod commit_composer_tests {
         cx.run_until_parked();
         type_commit_message(cx, "update a.txt");
 
-        let commits_before = commit_count(repo.path());
+        let commits_before = commit_count(&repo);
         app.update(cx, |app, cx| {
             app.run_commit_menu_action(CommitMenuAction::CommitAndPush, cx);
         });
         cx.run_until_parked();
 
         assert_eq!(
-            commit_count(repo.path()),
+            commit_count(&repo),
             commits_before + 1,
             "the commit half of `Commit and push` must really create a commit object"
         );
         assert_eq!(
-            git_output(repo.path(), &["show", "--format=", "--name-only", "HEAD"]),
+            git_output(&repo, &["show", "--format=", "--name-only", "HEAD"]),
             "a.txt",
             "and it must contain exactly the staged path, not the whole worktree"
         );
@@ -6188,7 +5977,7 @@ mod commit_composer_tests {
 
     #[gpui::test]
     fn commit_all_files_really_commits_the_unstaged_ones_too(cx: &mut TestAppContext) {
-        let repo = changes_test_repo();
+        let (_repo_dir, repo) = changes_test_repo();
         let (app, cx) = open_changes_view(cx, &repo);
 
         assert!(
@@ -6196,20 +5985,20 @@ mod commit_composer_tests {
             "premise: nothing is staged, so a plain `Commit` could not do this"
         );
         type_commit_message(cx, "commit everything");
-        let commits_before = commit_count(repo.path());
+        let commits_before = commit_count(&repo);
         app.update(cx, |app, cx| {
             app.run_commit_menu_action(CommitMenuAction::CommitAllFiles, cx);
         });
         cx.run_until_parked();
 
-        assert_eq!(commit_count(repo.path()), commits_before + 1);
-        let committed = git_output(repo.path(), &["show", "--format=", "--name-only", "HEAD"]);
+        assert_eq!(commit_count(&repo), commits_before + 1);
+        let committed = git_output(&repo, &["show", "--format=", "--name-only", "HEAD"]);
         assert!(
             committed.contains("a.txt") && committed.contains("b.txt"),
             "both changed files must be in the commit - got {committed:?}"
         );
         assert_eq!(
-            git_output(repo.path(), &["status", "--porcelain"]),
+            git_output(&repo, &["status", "--porcelain"]),
             "",
             "and the worktree must really be clean afterwards"
         );
@@ -6217,9 +6006,9 @@ mod commit_composer_tests {
 
     #[gpui::test]
     fn amend_last_commit_really_rewrites_the_tip_without_adding_a_commit(cx: &mut TestAppContext) {
-        let repo = changes_test_repo();
-        git(repo.path(), &["add", "b.txt"]);
-        git(repo.path(), &["commit", "-m", "a commit worth amending"]);
+        let (_repo_dir, repo) = changes_test_repo();
+        git(&repo, &["add", "b.txt"]);
+        git(&repo, &["commit", "-m", "a commit worth amending"]);
         let (app, cx) = open_changes_view(cx, &repo);
 
         app.update(cx, |app, cx| {
@@ -6227,38 +6016,37 @@ mod commit_composer_tests {
         });
         cx.run_until_parked();
 
-        let commits_before = commit_count(repo.path());
-        let tip_before = git_output(repo.path(), &["rev-parse", "HEAD"]);
+        let commits_before = commit_count(&repo);
+        let tip_before = git_output(&repo, &["rev-parse", "HEAD"]);
         app.update(cx, |app, cx| {
             app.run_commit_menu_action(CommitMenuAction::AmendLastCommit, cx);
         });
         cx.run_until_parked();
 
         assert_eq!(
-            commit_count(repo.path()),
+            commit_count(&repo),
             commits_before,
             "an amend must not add a commit - that would be a plain commit wearing the wrong name"
         );
         assert_ne!(
-            git_output(repo.path(), &["rev-parse", "HEAD"]),
+            git_output(&repo, &["rev-parse", "HEAD"]),
             tip_before,
             "but it must really rewrite the tip object"
         );
         assert_eq!(
-            git_output(repo.path(), &["log", "-1", "--format=%s"]),
+            git_output(&repo, &["log", "-1", "--format=%s"]),
             "a commit worth amending",
             "keeping the tip's own message: this row amends, it does not reword"
         );
         assert!(
-            git_output(repo.path(), &["show", "--format=", "--name-only", "HEAD"])
-                .contains("a.txt"),
+            git_output(&repo, &["show", "--format=", "--name-only", "HEAD"]).contains("a.txt"),
             "and the staged file must really be inside the amended tip now"
         );
     }
 
     #[gpui::test]
     fn stash_staged_files_really_stashes_the_staged_half_only(cx: &mut TestAppContext) {
-        let repo = changes_test_repo();
+        let (_repo_dir, repo) = changes_test_repo();
         let (app, cx) = open_changes_view(cx, &repo);
         app.update(cx, |app, cx| {
             app.toggle_staged(PathBuf::from("a.txt"), cx);
@@ -6266,28 +6054,28 @@ mod commit_composer_tests {
         cx.run_until_parked();
         type_commit_message(cx, "stash this");
 
-        let commits_before = commit_count(repo.path());
+        let commits_before = commit_count(&repo);
         app.update(cx, |app, cx| {
             app.run_commit_menu_action(CommitMenuAction::StashStaged, cx);
         });
         cx.run_until_parked();
 
         assert_eq!(
-            commit_count(repo.path()),
+            commit_count(&repo),
             commits_before,
             "stashing is not committing"
         );
         assert!(
-            !git_output(repo.path(), &["stash", "list"]).is_empty(),
+            !git_output(&repo, &["stash", "list"]).is_empty(),
             "a real stash entry must exist"
         );
         assert_eq!(
-            std::fs::read_to_string(repo.path().join("a.txt")).expect("read a.txt"),
+            std::fs::read_to_string(repo.join("a.txt")).expect("read a.txt"),
             "one\ntwo\nthree\n",
             "the staged edit must be gone from the working tree"
         );
         assert_eq!(
-            std::fs::read_to_string(repo.path().join("b.txt")).expect("read b.txt"),
+            std::fs::read_to_string(repo.join("b.txt")).expect("read b.txt"),
             "uno\ndos\ntres\ncuatro\n",
             "and the unstaged edit must be untouched - the row's hint says `keeps the worktree \
              clean`, not `throws away everything`"
@@ -6298,7 +6086,7 @@ mod commit_composer_tests {
     fn a_commit_menu_row_with_nothing_staged_is_disabled_and_does_nothing_when_clicked(
         cx: &mut TestAppContext,
     ) {
-        let repo = changes_test_repo();
+        let (_repo_dir, repo) = changes_test_repo();
         let (app, cx) = open_changes_view(cx, &repo);
         assert!(
             app.read_with(cx, |app, _| app.staged_files.is_empty()),
@@ -6329,7 +6117,7 @@ mod commit_composer_tests {
              with nothing staged - and there really are changed files here"
         );
 
-        let commits_before = commit_count(repo.path());
+        let commits_before = commit_count(&repo);
         let disabled = cx
             .debug_bounds("commit-menu-row-stash-staged-files-disabled")
             .expect("the disabled row must really paint");
@@ -6337,19 +6125,19 @@ mod commit_composer_tests {
         cx.run_until_parked();
 
         assert_eq!(
-            commit_count(repo.path()),
+            commit_count(&repo),
             commits_before,
             "a disabled row must really be a no-op, not merely look like one"
         );
         assert!(
-            git_output(repo.path(), &["stash", "list"]).is_empty(),
+            git_output(&repo, &["stash", "list"]).is_empty(),
             "and it must certainly not have stashed anything"
         );
     }
 
     #[gpui::test]
     fn a_real_click_far_outside_the_composer_closes_the_commit_menu(cx: &mut TestAppContext) {
-        let repo = changes_test_repo();
+        let (_repo_dir, repo) = changes_test_repo();
         let (app, cx) = open_changes_view(cx, &repo);
 
         let composer = cx
@@ -6396,7 +6184,7 @@ mod commit_composer_tests {
 
     #[gpui::test]
     fn the_commit_menu_popover_really_paints_anchored_to_the_composer(cx: &mut TestAppContext) {
-        let repo = changes_test_repo();
+        let (_repo_dir, repo) = changes_test_repo();
         let (app, cx) = open_changes_view(cx, &repo);
 
         let toggle = cx
@@ -6445,7 +6233,7 @@ mod commit_composer_tests {
 
     #[gpui::test]
     fn leaving_the_changes_view_really_closes_the_commit_menu(cx: &mut TestAppContext) {
-        let repo = changes_test_repo();
+        let (_repo_dir, repo) = changes_test_repo();
         let (app, cx) = open_changes_view(cx, &repo);
 
         let toggle = cx
@@ -6479,7 +6267,7 @@ mod commit_composer_tests {
 
     #[gpui::test]
     fn returning_to_an_already_loaded_changes_view_never_blanks_it(cx: &mut TestAppContext) {
-        let repo = changes_test_repo();
+        let (_repo_dir, repo) = changes_test_repo();
         let (app, cx) = open_changes_view(cx, &repo);
 
         app.read_with(cx, |app, _| {
@@ -6549,8 +6337,8 @@ mod commit_composer_tests {
 
     #[gpui::test]
     fn switching_worktrees_still_blanks_the_changes_view_synchronously(cx: &mut TestAppContext) {
-        let repo_a = changes_test_repo();
-        let repo_b = changes_test_repo();
+        let (_repo_a_dir, repo_a) = changes_test_repo();
+        let (_repo_b_dir, repo_b) = changes_test_repo();
         let (app, cx) = open_changes_view(cx, &repo_a);
 
         app.read_with(cx, |app, _| {
@@ -6561,7 +6349,7 @@ mod commit_composer_tests {
         });
 
         app.update_in(cx, |app, window, cx| {
-            app.load_diff(repo_b.path().to_path_buf(), cx);
+            app.load_diff(repo_b.clone(), cx);
             let _ = window;
         });
 
@@ -6580,7 +6368,7 @@ mod commit_composer_tests {
 
     #[gpui::test]
     fn opening_the_commit_menu_closes_an_already_open_plus_menu(cx: &mut TestAppContext) {
-        let repo = changes_test_repo();
+        let (_repo_dir, repo) = changes_test_repo();
         let (app, cx) = open_changes_view(cx, &repo);
 
         app.update(cx, |app, cx| {
@@ -6619,7 +6407,7 @@ mod commit_composer_tests {
     fn opening_the_commit_menu_blocks_a_real_click_on_the_primary_button_underneath(
         cx: &mut TestAppContext,
     ) {
-        let repo = changes_test_repo();
+        let (_repo_dir, repo) = changes_test_repo();
         let (app, cx) = open_changes_view(cx, &repo);
 
         let a_path = PathBuf::from("a.txt");
@@ -6642,7 +6430,7 @@ mod commit_composer_tests {
              scrim's own click-blocking, not a no-op"
         );
 
-        let commits_before = commit_count(repo.path());
+        let commits_before = commit_count(&repo);
 
         // The scrim spans the composer's full bounds (`top(0)/left(0)/right(0)/bottom(0)` on a
         // `.relative()` parent) - including the still-visible primary-button row underneath the
@@ -6656,7 +6444,7 @@ mod commit_composer_tests {
         cx.run_until_parked();
 
         assert_eq!(
-            commit_count(repo.path()),
+            commit_count(&repo),
             commits_before,
             "a click on the primary button's own screen position, while the scrim covers it, \
              must not reach the real commit action painted underneath"
@@ -6667,7 +6455,7 @@ mod commit_composer_tests {
     fn the_popover_blocks_a_click_even_where_it_paints_above_the_composers_own_bounds(
         cx: &mut TestAppContext,
     ) {
-        let repo = changes_test_repo();
+        let (_repo_dir, repo) = changes_test_repo();
         let (app, cx) = open_changes_view(cx, &repo);
 
         let a_path = PathBuf::from("a.txt");
@@ -6717,12 +6505,12 @@ mod commit_composer_tests {
 
     #[gpui::test]
     fn toggle_staged_really_stages_and_unstages_the_real_git_index(cx: &mut TestAppContext) {
-        let repo = changes_test_repo();
+        let (_repo_dir, repo) = changes_test_repo();
         let (app, cx) = open_changes_view(cx, &repo);
         let a_path = PathBuf::from("a.txt");
 
         assert_eq!(
-            git_output(repo.path(), &["status", "--porcelain", "a.txt"]),
+            git_output(&repo, &["status", "--porcelain", "a.txt"]),
             "M a.txt",
             "sanity check: a.txt must start out modified but genuinely unstaged"
         );
@@ -6733,7 +6521,7 @@ mod commit_composer_tests {
         cx.run_until_parked();
 
         assert_eq!(
-            git_output(repo.path(), &["status", "--porcelain", "a.txt"]),
+            git_output(&repo, &["status", "--porcelain", "a.txt"]),
             "M  a.txt",
             "checking the box must really stage a.txt in the real git index (two-space \
              porcelain form), not just flip an in-memory flag"
@@ -6749,7 +6537,7 @@ mod commit_composer_tests {
         cx.run_until_parked();
 
         assert_eq!(
-            git_output(repo.path(), &["status", "--porcelain", "a.txt"]),
+            git_output(&repo, &["status", "--porcelain", "a.txt"]),
             "M a.txt",
             "unchecking the box must really unstage a.txt in the real git index - back to the \
              one-space, working-tree-only porcelain form - not merely forget about it in memory \
@@ -6765,10 +6553,10 @@ mod commit_composer_tests {
     fn a_file_already_staged_in_real_git_before_the_worktree_is_ever_loaded_reads_as_staged(
         cx: &mut TestAppContext,
     ) {
-        let repo = changes_test_repo();
+        let (_repo_dir, repo) = changes_test_repo();
         // Stages a.txt with a real, direct `git add` *before* the app ever opens this worktree -
         // standing in for a user's own shell or an agent CLI having staged it first.
-        git(repo.path(), &["add", "a.txt"]);
+        git(&repo, &["add", "a.txt"]);
 
         let (app, cx) = open_changes_view(cx, &repo);
 
@@ -6790,10 +6578,10 @@ mod commit_composer_tests {
     fn switching_to_a_worktree_with_something_already_staged_in_real_git_shows_it_as_staged(
         cx: &mut TestAppContext,
     ) {
-        let repo = changes_test_repo();
-        let second_wt = repo.path().join("second-wt");
+        let (_repo_dir, repo) = changes_test_repo();
+        let second_wt = &repo.join("second-wt");
         git(
-            repo.path(),
+            &repo,
             &[
                 "worktree",
                 "add",
@@ -6803,7 +6591,8 @@ mod commit_composer_tests {
             ],
         );
         std::fs::write(second_wt.join("c.txt"), "real change\n").expect("write c.txt");
-        git(&second_wt, &["add", "c.txt"]);
+        // Staged in the *second* worktree's own real index, before Jerry ever selects it.
+        git(second_wt.as_path(), &["add", "c.txt"]);
 
         let (app, cx) = open_changes_view(cx, &repo);
         assert!(
@@ -6814,7 +6603,7 @@ mod commit_composer_tests {
         let index = app.read_with(cx, |app, _| {
             app.worktrees
                 .iter()
-                .position(|item| item.path == second_wt)
+                .position(|item| item.path == *second_wt)
                 .expect("the newly created second worktree must be in the real worktree list")
         });
         app.update_in(cx, |app, window, cx| {
@@ -6835,7 +6624,7 @@ mod commit_composer_tests {
     fn a_committed_file_is_in_the_against_main_section_not_the_uncommitted_one(
         cx: &mut TestAppContext,
     ) {
-        let repo = repo_with_a_committed_and_a_dirty_file();
+        let (_repo_dir, repo) = repo_with_a_committed_and_a_dirty_file();
         let (app, cx) = open_changes_view(cx, &repo);
 
         assert!(
@@ -6896,7 +6685,7 @@ mod commit_composer_tests {
 
     #[gpui::test]
     fn the_composer_counts_only_the_uncommitted_scope_in_its_denominator(cx: &mut TestAppContext) {
-        let repo = repo_with_a_committed_and_a_dirty_file();
+        let (_repo_dir, repo) = repo_with_a_committed_and_a_dirty_file();
         let (app, cx) = open_changes_view(cx, &repo);
 
         assert!(
@@ -6920,7 +6709,7 @@ mod commit_composer_tests {
         cx.run_until_parked();
 
         assert_eq!(
-            git_output(repo.path(), &["status", "--porcelain", "dirty.txt"]),
+            git_output(&repo, &["status", "--porcelain", "dirty.txt"]),
             "M  dirty.txt",
             "sanity check: that really staged it in the real git index"
         );
@@ -6934,7 +6723,7 @@ mod commit_composer_tests {
     fn committing_a_staged_file_moves_it_out_of_uncommitted_and_into_against_main(
         cx: &mut TestAppContext,
     ) {
-        let repo = repo_with_a_committed_and_a_dirty_file();
+        let (_repo_dir, repo) = repo_with_a_committed_and_a_dirty_file();
         let (app, cx) = open_changes_view(cx, &repo);
 
         app.update(cx, |app, cx| {
@@ -6947,13 +6736,13 @@ mod commit_composer_tests {
         );
         type_commit_message(cx, "commit the dirty file");
 
-        let commits_before = commit_count(repo.path());
+        let commits_before = commit_count(&repo);
         app.update(cx, |app, cx| {
             app.commit_staged_files(cx);
         });
         cx.run_until_parked();
         assert_eq!(
-            commit_count(repo.path()),
+            commit_count(&repo),
             commits_before + 1,
             "sanity check: a real commit must actually have happened"
         );
@@ -7000,17 +6789,15 @@ mod commit_composer_tests {
 
     #[gpui::test]
     fn a_deeply_nested_path_does_not_overflow_the_change_row(cx: &mut TestAppContext) {
-        let repo = TempDir::new().expect("tempdir");
-        git(repo.path(), &["init", "-b", "main"]);
-        git(repo.path(), &["config", "user.email", "test@example.com"]);
-        git(repo.path(), &["config", "user.name", "Test User"]);
-        std::fs::write(repo.path().join("base.txt"), "base\n").expect("write base.txt");
-        git(repo.path(), &["add", "."]);
-        git(repo.path(), &["commit", "-m", "initial"]);
+        let (_repo_dir, repo) = fixtures::temp_root();
+        seed_empty_repo_at(&repo);
+        std::fs::write(repo.join("base.txt"), "base\n").expect("write base.txt");
+        git(&repo, &["add", "."]);
+        git(&repo, &["commit", "-m", "initial"]);
 
         // Twelve real nested directories, each with a long, realistic segment name - the exact
         // shape of path this issue was filed against, not a contrived worst case.
-        let nested_dir = repo.path().join(
+        let nested_dir = repo.join(
             [
                 "crates",
                 "app",
@@ -7035,7 +6822,7 @@ mod commit_composer_tests {
         let (_app, cx) = open_changes_view(cx, &repo);
 
         let relative = nested_file
-            .strip_prefix(repo.path())
+            .strip_prefix(&repo)
             .expect("nested file is under the repo root")
             .display()
             .to_string();
@@ -7080,53 +6867,38 @@ mod changes_sections_tests {
     use crate::root::focus::palette_focus_tests;
     use crate::sidebar::sections::{ChangesSection, SectionRow};
     use gpui::TestAppContext;
-    use std::process::Command;
     use tempfile::TempDir;
-
-    fn git(dir: &std::path::Path, args: &[&str]) {
-        let output = Command::new("git")
-            .args(args)
-            .current_dir(dir)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {args:?} failed: {}",
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
+    use test_support::{git, seed_empty_repo_at};
 
     /// A feature branch that genuinely populates all four scopes at once: two commits of its own
     /// (Commits), two still-uncommitted edits (Uncommitted), and therefore four paths that differ
     /// from `main` (Against main).
-    fn four_scope_repo() -> TempDir {
-        let repo = TempDir::new().expect("tempdir");
-        git(repo.path(), &["init", "-b", "main"]);
-        git(repo.path(), &["config", "user.email", "test@example.com"]);
-        git(repo.path(), &["config", "user.name", "Test User"]);
-        std::fs::write(repo.path().join("dirty-a.txt"), "one\n").expect("write");
-        std::fs::write(repo.path().join("dirty-b.txt"), "one\n").expect("write");
-        git(repo.path(), &["add", "."]);
-        git(repo.path(), &["commit", "-m", "initial"]);
-        git(repo.path(), &["checkout", "-b", "feature"]);
+    fn four_scope_repo() -> (TempDir, PathBuf) {
+        let (dir, repo) = fixtures::temp_root();
+        seed_empty_repo_at(&repo);
+        std::fs::write(repo.join("dirty-a.txt"), "one\n").expect("write");
+        std::fs::write(repo.join("dirty-b.txt"), "one\n").expect("write");
+        git(&repo, &["add", "."]);
+        git(&repo, &["commit", "-m", "initial"]);
+        git(&repo, &["checkout", "-b", "feature"]);
 
-        std::fs::write(repo.path().join("done-a.txt"), "committed a\n").expect("write");
-        git(repo.path(), &["add", "done-a.txt"]);
-        git(repo.path(), &["commit", "-m", "first branch commit"]);
-        std::fs::write(repo.path().join("done-b.txt"), "committed b\n").expect("write");
-        git(repo.path(), &["add", "done-b.txt"]);
-        git(repo.path(), &["commit", "-m", "second branch commit"]);
+        std::fs::write(repo.join("done-a.txt"), "committed a\n").expect("write");
+        git(&repo, &["add", "done-a.txt"]);
+        git(&repo, &["commit", "-m", "first branch commit"]);
+        std::fs::write(repo.join("done-b.txt"), "committed b\n").expect("write");
+        git(&repo, &["add", "done-b.txt"]);
+        git(&repo, &["commit", "-m", "second branch commit"]);
 
-        std::fs::write(repo.path().join("dirty-a.txt"), "one\ntwo\n").expect("write");
-        std::fs::write(repo.path().join("dirty-b.txt"), "one\ntwo\n").expect("write");
-        repo
+        std::fs::write(repo.join("dirty-a.txt"), "one\ntwo\n").expect("write");
+        std::fs::write(repo.join("dirty-b.txt"), "one\ntwo\n").expect("write");
+        (dir, repo)
     }
 
     fn open_changes_view<'a>(
         cx: &'a mut TestAppContext,
-        repo: &TempDir,
+        repo: &Path,
     ) -> (gpui::Entity<AdeApp>, &'a mut gpui::VisualTestContext) {
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.set_right_sidebar_view(RightSidebarView::Changes, window, cx);
         });
@@ -7149,7 +6921,7 @@ mod changes_sections_tests {
     fn the_panel_is_four_sections_with_runs_and_uncommitted_open_by_default(
         cx: &mut TestAppContext,
     ) {
-        let repo = four_scope_repo();
+        let (_repo_dir, repo) = four_scope_repo();
         let (_app, cx) = open_changes_view(cx, &repo);
 
         assert!(
@@ -7191,7 +6963,7 @@ mod changes_sections_tests {
     fn the_tab_is_called_changes_and_uncommitted_is_one_of_its_four_sections(
         cx: &mut TestAppContext,
     ) {
-        let repo = four_scope_repo();
+        let (_repo_dir, repo) = four_scope_repo();
         let (app, cx) = open_changes_view(cx, &repo);
 
         // Index 1 of the right sidebar's own two-segment toggle - the segment the panel is
@@ -7231,7 +7003,7 @@ mod changes_sections_tests {
 
     #[gpui::test]
     fn every_section_header_count_equals_the_number_of_rows_it_renders(cx: &mut TestAppContext) {
-        let repo = four_scope_repo();
+        let (_repo_dir, repo) = four_scope_repo();
         let (app, cx) = open_changes_view(cx, &repo);
         open_every_section(&app, cx);
 
@@ -7296,7 +7068,8 @@ mod changes_sections_tests {
 
     #[gpui::test]
     fn checkboxes_exist_only_in_the_uncommitted_section(cx: &mut TestAppContext) {
-        let repo = four_scope_repo();
+        // `REVISION-2026-08-14.md` §9, box 1.
+        let (_repo_dir, repo) = four_scope_repo();
         let (app, cx) = open_changes_view(cx, &repo);
         open_every_section(&app, cx);
 
@@ -7337,7 +7110,7 @@ mod changes_sections_tests {
 
     #[gpui::test]
     fn collapsing_a_section_unpaints_its_rows_and_keeps_its_count(cx: &mut TestAppContext) {
-        let repo = four_scope_repo();
+        let (_repo_dir, repo) = four_scope_repo();
         let (app, cx) = open_changes_view(cx, &repo);
         assert!(cx.debug_bounds("change-row-dirty-a.txt").is_some());
 
@@ -7375,7 +7148,7 @@ mod changes_sections_tests {
         // should not appear on the changes tab under against master") and confirmed against
         // `Jerry.dc.html` line 1422's own `baseRows` - a synthetic one-entry array, never a
         // per-file loop. Against main's only real body row is its context card.
-        let repo = four_scope_repo();
+        let (_repo_dir, repo) = four_scope_repo();
         let (app, cx) = open_changes_view(cx, &repo);
         open_every_section(&app, cx);
 
@@ -7421,13 +7194,11 @@ mod changes_sections_tests {
         // `+319 −145` and Uncommitted `+319 −145` agree exactly." The provenance is recorded
         // through the store's real `PreToolUse`/write/`PostToolUse` door, exactly as the hook
         // layer drives it - no fabricated attribution.
-        let repo = TempDir::new().expect("tempdir");
-        git(repo.path(), &["init", "-b", "main"]);
-        git(repo.path(), &["config", "user.email", "test@example.com"]);
-        git(repo.path(), &["config", "user.name", "Test User"]);
-        std::fs::write(repo.path().join("agent.txt"), "one\n").expect("write");
-        git(repo.path(), &["add", "."]);
-        git(repo.path(), &["commit", "-m", "initial"]);
+        let (_repo_dir, repo) = fixtures::temp_root();
+        seed_empty_repo_at(&repo);
+        std::fs::write(repo.join("agent.txt"), "one\n").expect("write");
+        git(&repo, &["add", "."]);
+        git(&repo, &["commit", "-m", "initial"]);
 
         let (app, cx) = open_changes_view(cx, &repo);
         let agent_id = app
@@ -7450,15 +7221,14 @@ mod changes_sections_tests {
                 agent.spawned_at_unix,
             ))
         });
-        let file = repo.path().join("agent.txt");
+        let file = repo.join("agent.txt");
         app.update(cx, |app, _cx| {
-            app.line_provenance.begin_agent_edit(repo.path(), &file);
+            app.line_provenance.begin_agent_edit(&repo, &file);
         });
         std::fs::write(&file, "one\ntwo\nthree\n").expect("agent writes");
         app.update_in(cx, |app, window, cx| {
-            app.line_provenance
-                .record_agent_edit(repo.path(), &file, &key);
-            app.load_diff(repo.path().to_path_buf(), cx);
+            app.line_provenance.record_agent_edit(&repo, &file, &key);
+            app.load_diff(repo.clone(), cx);
             let _ = window;
         });
         cx.run_until_parked();
@@ -7505,6 +7275,10 @@ mod changes_sections_tests {
         );
     }
 
+    // Asserts both run rows report `live` and read `running`, which requires the spawned `claude`
+    // CLI to be a real live process - without that binary the child exits immediately and the row
+    // honestly reports an ended run. The `external` tier.
+    #[ignore = "external: claude; see docs/testing.md"]
     #[gpui::test]
     fn a_live_runs_row_states_that_it_is_running_and_switching_focus_changes_no_count(
         cx: &mut TestAppContext,
@@ -7512,7 +7286,7 @@ mod changes_sections_tests {
         // Audit I2: the header count equals the rendered row count, and switching agent focus
         // changes neither. Before the union, the header read one agent's set while the rows read
         // another's - two sources able to disagree on screen.
-        let repo = four_scope_repo();
+        let (_repo_dir, repo) = four_scope_repo();
         let (app, cx) = open_changes_view(cx, &repo);
         let first = app
             .read_with(cx, |app, _| app.agents.active_id())
@@ -7523,7 +7297,7 @@ mod changes_sections_tests {
         let second = app.update_in(cx, |app, window, cx| {
             app.agents.spawn(
                 ProcessKind::claude(),
-                repo.path().to_path_buf(),
+                repo.clone(),
                 12.0,
                 None,
                 None,
@@ -7586,12 +7360,14 @@ mod changes_sections_tests {
         assert!(cx.debug_bounds("changes-section-runs-2-open").is_some());
     }
 
+    /// `#[cfg(unix)]`: the ended run below is a real `/bin/false` child, which needs a `/bin`.
+    #[cfg(unix)]
     #[gpui::test]
     fn a_live_run_and_an_ended_run_render_side_by_side(cx: &mut TestAppContext) {
         // The mock's sad path (`STAGE-A-SELFCHECK.md`): "a live run and a frozen run render side
         // by side in the Runs section […] both rows verifiable in one screen." The ended run here
         // is a genuinely exited process, not a flag.
-        let repo = four_scope_repo();
+        let (_repo_dir, repo) = four_scope_repo();
         let (app, cx) = open_changes_view(cx, &repo);
         let live = app
             .read_with(cx, |app, _| app.agents.active_id())
@@ -7607,7 +7383,7 @@ mod changes_sections_tests {
         let ended = app.update_in(cx, |app, window, cx| {
             app.agents.spawn(
                 ProcessKind::Shell,
-                repo.path().to_path_buf(),
+                repo.clone(),
                 12.0,
                 Some("/bin/false"),
                 None,
@@ -7621,27 +7397,22 @@ mod changes_sections_tests {
         cx.run_until_parked();
         // A real OS process really has to exit, which takes real wall-clock time - so this waits
         // on the genuine `is_running()` transition rather than assuming it, and gives up loudly
-        // rather than asserting against a process that never died.
-        let mut exited = false;
-        for _ in 0..200 {
+        // rather than asserting against a process that never died. The pane notices its child's
+        // real pty EOF on its own poll timer, and this context's executor is deterministic - so
+        // each poll has to advance the clock as well as let real time pass, which is why the
+        // condition drives the executor rather than merely reading a flag.
+        let exited = test_support::wait_until(std::time::Duration::from_secs(4), || {
             app.update(cx, |_app, cx| cx.notify());
             cx.run_until_parked();
-            if app.read_with(cx, |app, cx| {
+            cx.executor()
+                .advance_clock(std::time::Duration::from_millis(50));
+            app.read_with(cx, |app, cx| {
                 app.agents
                     .iter()
                     .find(|agent| agent.id == ended)
                     .is_some_and(|agent| !agent.pane.read(cx).is_running())
-            }) {
-                exited = true;
-                break;
-            }
-            std::thread::sleep(std::time::Duration::from_millis(20));
-            // The pane notices its child's real pty EOF on its own poll timer, and this context's
-            // executor is deterministic - so real time has to be given to the child *and* the
-            // clock has to be advanced for the poll that observes it.
-            cx.executor()
-                .advance_clock(std::time::Duration::from_millis(50));
-        }
+            })
+        });
         assert!(
             exited,
             "premise: the `/bin/false` agent must really have exited, or this test would be \
@@ -7693,46 +7464,31 @@ mod change_row_tests {
     use crate::root::focus::palette_focus_tests;
     use crate::sidebar::changes::StatusLetter;
     use gpui::TestAppContext;
-    use std::process::Command;
     use tempfile::TempDir;
-
-    fn git(dir: &std::path::Path, args: &[&str]) {
-        let output = Command::new("git")
-            .args(args)
-            .current_dir(dir)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {args:?} failed: {}",
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
+    use test_support::{git, seed_empty_repo_at};
 
     /// One worktree holding one of each real git status at once: `added.txt` is brand new,
     /// `modified.txt` has an edit, `deleted.txt` is gone. §4j's whole point is that all three -
     /// not only the two exceptions - carry a mark.
-    fn mixed_status_repo() -> TempDir {
-        let repo = TempDir::new().expect("tempdir");
-        git(repo.path(), &["init", "-b", "main"]);
-        git(repo.path(), &["config", "user.email", "test@example.com"]);
-        git(repo.path(), &["config", "user.name", "Test User"]);
-        std::fs::write(repo.path().join("modified.txt"), "one\n").expect("write");
-        std::fs::write(repo.path().join("deleted.txt"), "gone\n").expect("write");
-        git(repo.path(), &["add", "."]);
-        git(repo.path(), &["commit", "-m", "initial"]);
+    fn mixed_status_repo() -> (TempDir, PathBuf) {
+        let (dir, repo) = fixtures::temp_root();
+        seed_empty_repo_at(&repo);
+        std::fs::write(repo.join("modified.txt"), "one\n").expect("write");
+        std::fs::write(repo.join("deleted.txt"), "gone\n").expect("write");
+        git(&repo, &["add", "."]);
+        git(&repo, &["commit", "-m", "initial"]);
 
-        std::fs::write(repo.path().join("modified.txt"), "one\ntwo\n").expect("write");
-        std::fs::remove_file(repo.path().join("deleted.txt")).expect("delete");
-        std::fs::write(repo.path().join("added.txt"), "brand new\n").expect("write");
-        repo
+        std::fs::write(repo.join("modified.txt"), "one\ntwo\n").expect("write");
+        std::fs::remove_file(repo.join("deleted.txt")).expect("delete");
+        std::fs::write(repo.join("added.txt"), "brand new\n").expect("write");
+        (dir, repo)
     }
 
     fn open_changes_view<'a>(
         cx: &'a mut TestAppContext,
-        repo: &TempDir,
+        repo: &Path,
     ) -> (gpui::Entity<AdeApp>, &'a mut gpui::VisualTestContext) {
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.set_right_sidebar_view(RightSidebarView::Changes, window, cx);
         });
@@ -7744,7 +7500,7 @@ mod change_row_tests {
     fn every_row_carries_gits_own_status_letter_including_the_modified_one(
         cx: &mut TestAppContext,
     ) {
-        let repo = mixed_status_repo();
+        let (_repo_dir, repo) = mixed_status_repo();
         let (_app, cx) = open_changes_view(cx, &repo);
 
         assert!(
@@ -7764,7 +7520,7 @@ mod change_row_tests {
 
     #[gpui::test]
     fn the_letter_column_is_fixed_width_and_ahead_of_the_name(cx: &mut TestAppContext) {
-        let repo = mixed_status_repo();
+        let (_repo_dir, repo) = mixed_status_repo();
         let (_app, cx) = open_changes_view(cx, &repo);
 
         let added = cx
@@ -7796,7 +7552,7 @@ mod change_row_tests {
 
     #[gpui::test]
     fn the_file_header_above_the_diff_carries_the_same_letter(cx: &mut TestAppContext) {
-        let repo = mixed_status_repo();
+        let (_repo_dir, repo) = mixed_status_repo();
         let (app, cx) = open_changes_view(cx, &repo);
 
         let row = cx
@@ -7819,7 +7575,7 @@ mod change_row_tests {
 
     #[gpui::test]
     fn opening_a_file_moves_its_name_from_unseen_to_seen(cx: &mut TestAppContext) {
-        let repo = mixed_status_repo();
+        let (_repo_dir, repo) = mixed_status_repo();
         let (_app, cx) = open_changes_view(cx, &repo);
 
         assert!(
@@ -7848,7 +7604,7 @@ mod change_row_tests {
 
     #[gpui::test]
     fn seen_and_staged_are_two_independent_maps(cx: &mut TestAppContext) {
-        let repo = mixed_status_repo();
+        let (_repo_dir, repo) = mixed_status_repo();
         let (app, cx) = open_changes_view(cx, &repo);
 
         let row = cx
@@ -7884,7 +7640,7 @@ mod change_row_tests {
 
     #[gpui::test]
     fn v_unmarks_a_seen_file_and_marks_an_unseen_one(cx: &mut TestAppContext) {
-        let repo = mixed_status_repo();
+        let (_repo_dir, repo) = mixed_status_repo();
         let (app, cx) = open_changes_view(cx, &repo);
 
         let row = cx
@@ -7921,33 +7677,11 @@ mod change_row_tests {
         );
     }
 
-    #[test]
-    fn the_changes_footer_only_advertises_a_really_registered_binding() {
-        let bindings = crate::default_key_bindings();
-        let binding = bindings
-            .iter()
-            .find(|binding| binding.action().name() == "app::ToggleChangeSeen")
-            .expect("`ToggleChangeSeen` must have a real registered binding");
-        let keystrokes = binding.keystrokes();
-        assert_eq!(keystrokes.len(), 1, "one plain keystroke, no chord");
-        let keystroke = &keystrokes[0];
-        assert_eq!(
-            keystroke.key(),
-            CHANGES_SEEN_SPEC,
-            "the footer prints the keycap for {CHANGES_SEEN_SPEC:?}, so that is what has to be \
-             bound"
-        );
-        let modifiers = keystroke.modifiers();
-        assert!(
-            !modifiers.control && !modifiers.alt && !modifiers.platform && !modifiers.shift,
-            "a bare `V`, exactly as §4i's legend prints it - a binding that silently gained a \
-             modifier would leave the keycap advertising a keystroke nobody can trigger"
-        );
-    }
-
+    /// §4i: the bar is "revealed by row state (`hov`), so nothing shifts and nothing is
+    /// permanently occluded" - so it must genuinely not exist at rest.
     #[gpui::test]
     fn the_hover_bar_is_absent_until_the_row_is_hovered(cx: &mut TestAppContext) {
-        let repo = mixed_status_repo();
+        let (_repo_dir, repo) = mixed_status_repo();
         let (_app, cx) = open_changes_view(cx, &repo);
 
         assert!(
@@ -7973,7 +7707,7 @@ mod change_row_tests {
 
     #[gpui::test]
     fn the_hover_bar_is_two_icons_floating_above_the_rows_top_edge(cx: &mut TestAppContext) {
-        let repo = mixed_status_repo();
+        let (_repo_dir, repo) = mixed_status_repo();
         let (_app, cx) = open_changes_view(cx, &repo);
 
         let row = cx
@@ -8004,8 +7738,8 @@ mod change_row_tests {
 
     #[gpui::test]
     fn the_first_discard_click_only_arms_the_confirm_and_changes_nothing(cx: &mut TestAppContext) {
-        let repo = mixed_status_repo();
-        let before = std::fs::read_to_string(repo.path().join("modified.txt")).expect("read");
+        let (_repo_dir, repo) = mixed_status_repo();
+        let before = std::fs::read_to_string(repo.join("modified.txt")).expect("read");
         let (app, cx) = open_changes_view(cx, &repo);
 
         let row = cx
@@ -8030,7 +7764,7 @@ mod change_row_tests {
             "and the plain icon is gone - one control, one state, not both at once"
         );
         assert_eq!(
-            std::fs::read_to_string(repo.path().join("modified.txt")).expect("read"),
+            std::fs::read_to_string(repo.join("modified.txt")).expect("read"),
             before,
             "arming must not touch the file: this is the one irreversible action in the panel"
         );
@@ -8042,7 +7776,7 @@ mod change_row_tests {
 
     #[gpui::test]
     fn the_second_discard_click_really_throws_the_files_changes_away(cx: &mut TestAppContext) {
-        let repo = mixed_status_repo();
+        let (_repo_dir, repo) = mixed_status_repo();
         let (_app, cx) = open_changes_view(cx, &repo);
 
         let row = cx
@@ -8063,20 +7797,20 @@ mod change_row_tests {
         cx.run_until_parked();
 
         assert_eq!(
-            std::fs::read_to_string(repo.path().join("modified.txt")).expect("read"),
+            std::fs::read_to_string(repo.join("modified.txt")).expect("read"),
             "one\n",
             "the file is back to exactly what HEAD has - a real `git checkout HEAD -- <path>`, \
              not a UI-only flag"
         );
         assert!(
-            std::fs::read_to_string(repo.path().join("added.txt")).is_ok(),
+            std::fs::read_to_string(repo.join("added.txt")).is_ok(),
             "and every other dirty path is untouched"
         );
     }
 
     #[gpui::test]
     fn leaving_the_row_cancels_an_armed_discard(cx: &mut TestAppContext) {
-        let repo = mixed_status_repo();
+        let (_repo_dir, repo) = mixed_status_repo();
         let (app, cx) = open_changes_view(cx, &repo);
 
         let row = cx
@@ -8111,7 +7845,7 @@ mod change_row_tests {
 
     #[gpui::test]
     fn moving_onto_the_bars_overhang_keeps_it_open(cx: &mut TestAppContext) {
-        let repo = mixed_status_repo();
+        let (_repo_dir, repo) = mixed_status_repo();
         let (_app, cx) = open_changes_view(cx, &repo);
 
         let row = cx
@@ -8140,7 +7874,7 @@ mod change_row_tests {
 
     #[gpui::test]
     fn the_section_header_counts_seen_off_the_same_map_the_rows_read(cx: &mut TestAppContext) {
-        let repo = mixed_status_repo();
+        let (_repo_dir, repo) = mixed_status_repo();
         let (_app, cx) = open_changes_view(cx, &repo);
 
         assert!(
@@ -8163,14 +7897,17 @@ mod change_row_tests {
     }
 
     #[gpui::test]
-    fn the_footer_shows_the_v_keycap_only_while_the_binding_is_live(cx: &mut TestAppContext) {
-        let repo = mixed_status_repo();
+    fn the_footer_shows_a_keycap_only_while_its_binding_is_live(cx: &mut TestAppContext) {
+        let (_repo_dir, repo) = mixed_status_repo();
         let (_app, cx) = open_changes_view(cx, &repo);
 
-        assert!(
-            cx.debug_bounds("changes-footer-seen-hint").is_none(),
-            "with no file open, `V` would do nothing - so the strip advertises nothing"
-        );
+        for hint in ["changes-footer-seen-hint", "changes-footer-stage-hint"] {
+            assert!(
+                cx.debug_bounds(hint).is_none(),
+                "{hint}: with no file open the keystroke would do nothing, so the strip \
+                 advertises nothing"
+            );
+        }
 
         let row = cx
             .debug_bounds("change-row-modified.txt")
@@ -8178,39 +7915,20 @@ mod change_row_tests {
         cx.simulate_click(row.center(), gpui::Modifiers::none());
         cx.run_until_parked();
 
-        assert!(
-            cx.debug_bounds("changes-footer-seen-hint").is_some(),
-            "with a real file open, the keycap appears and really does something"
-        );
-    }
-
-    #[gpui::test]
-    fn the_footer_shows_the_space_keycap_only_while_the_binding_is_live(cx: &mut TestAppContext) {
-        let repo = mixed_status_repo();
-        let (_app, cx) = open_changes_view(cx, &repo);
-
-        assert!(
-            cx.debug_bounds("changes-footer-stage-hint").is_none(),
-            "with no file open, `space` would do nothing - so the strip advertises nothing"
-        );
-
-        let row = cx
-            .debug_bounds("change-row-modified.txt")
-            .expect("the modified row");
-        cx.simulate_click(row.center(), gpui::Modifiers::none());
-        cx.run_until_parked();
-
-        assert!(
-            cx.debug_bounds("changes-footer-stage-hint").is_some(),
-            "with a real uncommitted file open, the keycap appears and really does something"
-        );
+        for hint in ["changes-footer-seen-hint", "changes-footer-stage-hint"] {
+            assert!(
+                cx.debug_bounds(hint).is_some(),
+                "{hint}: with a real uncommitted file open, the keycap appears and really does \
+                 something"
+            );
+        }
     }
 
     #[gpui::test]
     fn the_footers_first_child_is_the_stage_keycap_at_the_bands_own_left_padding(
         cx: &mut TestAppContext,
     ) {
-        let repo = mixed_status_repo();
+        let (_repo_dir, repo) = mixed_status_repo();
         let (_app, cx) = open_changes_view(cx, &repo);
 
         let row = cx
@@ -8244,7 +7962,7 @@ mod change_row_tests {
     fn space_stages_and_unstages_the_open_change_through_the_real_key_binding(
         cx: &mut TestAppContext,
     ) {
-        let repo = mixed_status_repo();
+        let (_repo_dir, repo) = mixed_status_repo();
         let (app, cx) = open_changes_view(cx, &repo);
         cx.update(|_window, cx| cx.bind_keys(crate::default_key_bindings()));
 
@@ -8293,21 +8011,19 @@ mod change_row_tests {
 
     #[gpui::test]
     fn space_does_nothing_for_a_file_with_no_uncommitted_row(cx: &mut TestAppContext) {
-        let repo = TempDir::new().expect("tempdir");
-        git(repo.path(), &["init", "-b", "main"]);
-        git(repo.path(), &["config", "user.email", "test@example.com"]);
-        git(repo.path(), &["config", "user.name", "Test User"]);
-        std::fs::write(repo.path().join("dirty.txt"), "one\n").expect("write");
-        git(repo.path(), &["add", "."]);
-        git(repo.path(), &["commit", "-m", "initial"]);
-        git(repo.path(), &["checkout", "-b", "feature"]);
-        std::fs::write(repo.path().join("committed.txt"), "committed\n").expect("write");
-        git(repo.path(), &["add", "committed.txt"]);
+        let (_repo_dir, repo) = fixtures::temp_root();
+        seed_empty_repo_at(&repo);
+        std::fs::write(repo.join("dirty.txt"), "one\n").expect("write");
+        git(&repo, &["add", "."]);
+        git(&repo, &["commit", "-m", "initial"]);
+        git(&repo, &["checkout", "-b", "feature"]);
+        std::fs::write(repo.join("committed.txt"), "committed\n").expect("write");
+        git(&repo, &["add", "committed.txt"]);
         git(
-            repo.path(),
+            &repo,
             &["commit", "-m", "a real commit on the feature branch"],
         );
-        std::fs::write(repo.path().join("dirty.txt"), "one\ntwo\n").expect("modify");
+        std::fs::write(repo.join("dirty.txt"), "one\ntwo\n").expect("modify");
 
         let (app, cx) = open_changes_view(cx, &repo);
         assert!(
@@ -8344,7 +8060,7 @@ mod change_row_tests {
     }
 
     #[test]
-    fn the_changes_footers_space_hint_only_advertises_a_really_registered_binding() {
+    fn the_changes_footers_hints_only_advertise_really_registered_bindings() {
         let bindings = crate::default_key_bindings();
         let find = |name: &str| {
             bindings
@@ -8355,20 +8071,28 @@ mod change_row_tests {
         let stage = find("app::ToggleChangeStaged");
         let seen = find("app::ToggleChangeSeen");
 
-        let keystrokes = stage.keystrokes();
-        assert_eq!(keystrokes.len(), 1, "one plain keystroke, no chord");
-        let keystroke = &keystrokes[0];
-        assert_eq!(
-            keystroke.key(),
-            CHANGES_STAGE_SPEC,
-            "the footer prints the keycap for {CHANGES_STAGE_SPEC:?}, so that is what has to be \
-             bound"
-        );
-        let modifiers = keystroke.modifiers();
-        assert!(
-            !modifiers.control && !modifiers.alt && !modifiers.platform && !modifiers.shift,
-            "a bare `space`, exactly as `Jerry.dc.html`'s `changesHints` prints it"
-        );
+        for (binding, spec) in [(stage, CHANGES_STAGE_SPEC), (seen, CHANGES_SEEN_SPEC)] {
+            let keystrokes = binding.keystrokes();
+            assert_eq!(
+                keystrokes.len(),
+                1,
+                "{spec:?}: one plain keystroke, no chord"
+            );
+            let keystroke = &keystrokes[0];
+            assert_eq!(
+                keystroke.key(),
+                spec,
+                "the footer prints the keycap for {spec:?}, so that is what has to be bound"
+            );
+            let modifiers = keystroke.modifiers();
+            assert!(
+                !modifiers.control && !modifiers.alt && !modifiers.platform && !modifiers.shift,
+                "{spec:?} is printed bare in `Jerry.dc.html`'s `changesHints`, so a binding that \
+                 silently gained a modifier would leave the keycap advertising a keystroke nobody \
+                 can trigger"
+            );
+        }
+
         let predicate = |binding: &gpui::KeyBinding| {
             binding
                 .predicate()
@@ -8392,7 +8116,7 @@ mod change_row_tests {
 
     #[gpui::test]
     fn the_rows_letter_is_the_status_the_real_diff_reports(cx: &mut TestAppContext) {
-        let repo = mixed_status_repo();
+        let (_repo_dir, repo) = mixed_status_repo();
         let (app, cx) = open_changes_view(cx, &repo);
 
         let letters = app.read_with(cx, |app, _| {

--- a/crates/app/src/sidebar/sections.rs
+++ b/crates/app/src/sidebar/sections.rs
@@ -408,25 +408,12 @@ impl NoteEmphasis {
 }
 
 #[cfg(test)]
-mod tests {
+mod changes_section_tests {
     use super::*;
     use crate::provenance::change_set::build_change_set;
     use crate::provenance::store::ProvenanceStore;
-    use std::process::Command;
+    use test_support::{git, seed_empty_repo_at};
     use wt_core::diff::diff_against_head;
-
-    fn git(dir: &Path, args: &[&str]) {
-        let output = Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {args:?} failed: {}",
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
 
     fn agent_writes(
         store: &mut ProvenanceStore,
@@ -455,9 +442,7 @@ mod tests {
         fn two_agents_wrote_everything() -> Fixture {
             let dir = tempfile::tempdir().expect("tempdir");
             let repo = dir.path();
-            git(repo, &["init", "-b", "main"]);
-            git(repo, &["config", "user.email", "test@example.com"]);
-            git(repo, &["config", "user.name", "Test User"]);
+            seed_empty_repo_at(repo);
             std::fs::write(repo.join("shared.rs"), "one\ntwo\nthree\n").expect("seed shared");
             std::fs::write(repo.join("solo.rs"), "alpha\n").expect("seed solo");
             git(repo, &["add", "-A"]);
@@ -604,24 +589,6 @@ mod tests {
         assert_eq!(
             rows[1].files_label, "2 files",
             "s10 wrote in the shared file and its own"
-        );
-    }
-
-    #[test]
-    fn the_order_matches_the_mock_not_the_issue_sketch() {
-        // `Jerry.dc.html` paints `onSecUnc`, `onSecCommits`, `onSecBase`, then `onSecRuns` last,
-        // and says so in its own comment - "Runs is not on [the git-state] ladder ... so it sits
-        // after it rather than inside it, which also keeps Uncommitted's top edge fixed however
-        // many agents have run." `REVISION-2026-08-14.md` §1's sketch lists Runs first; the mock
-        // wins the disagreement.
-        assert_eq!(
-            ChangesSection::ORDER,
-            [
-                ChangesSection::Uncommitted,
-                ChangesSection::Commits,
-                ChangesSection::AgainstMain,
-                ChangesSection::Runs,
-            ]
         );
     }
 

--- a/crates/app/src/sidebar/tree_ops.rs
+++ b/crates/app/src/sidebar/tree_ops.rs
@@ -1676,23 +1676,23 @@ mod tree_ops_regression_tests {
     }
 
     /// `src/main.rs` + `src/util.rs` + a root-level `README.md`.
-    fn seed(repo: &TempDir) {
-        fs::create_dir_all(repo.path().join("src")).expect("mkdir");
-        fs::write(repo.path().join("src/main.rs"), "fn main() {}\n").expect("write");
-        fs::write(repo.path().join("src/util.rs"), "pub fn u() {}\n").expect("write");
-        fs::write(repo.path().join("README.md"), "hi\n").expect("write");
+    fn seed(repo: &Path) {
+        fs::create_dir_all(repo.join("src")).expect("mkdir");
+        fs::write(repo.join("src/main.rs"), "fn main() {}\n").expect("write");
+        fs::write(repo.join("src/util.rs"), "pub fn u() {}\n").expect("write");
+        fs::write(repo.join("README.md"), "hi\n").expect("write");
     }
 
     #[gpui::test]
     fn renaming_an_open_file_carries_its_tab_and_buffer_with_no_orphan_left_behind(
         cx: &mut TestAppContext,
     ) {
-        let repo = TempDir::new().expect("tempdir");
+        let (_repo_dir, repo) = crate::sidebar::fixtures::temp_root();
         seed(&repo);
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.clone());
         cx.run_until_parked();
 
-        let old = repo.path().join("src/main.rs");
+        let old = repo.join("src/main.rs");
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(old.clone(), window, cx);
         });
@@ -1714,7 +1714,7 @@ mod tree_ops_regression_tests {
         cx.run_until_parked();
 
         assert!(!old.exists(), "the old path must be gone from disk");
-        assert!(repo.path().join("src/renamed.rs").exists());
+        assert!(repo.join("src/renamed.rs").exists());
 
         app.read_with(cx, |app, _| {
             assert_eq!(
@@ -1736,40 +1736,40 @@ mod tree_ops_regression_tests {
                 .expect("the buffer must be re-keyed, not dropped");
             assert_eq!(
                 buffer.path,
-                repo.path().join("src/renamed.rs"),
+                repo.join("src/renamed.rs"),
                 "the buffer's own absolute save path must move too - otherwise the next save \
                  would recreate the file under its old name"
             );
             assert_eq!(
                 app.selected_tree_path.as_deref(),
-                Some(repo.path().join("src/renamed.rs").as_path())
+                Some(repo.join("src/renamed.rs").as_path())
             );
         });
     }
 
     #[gpui::test]
     fn renaming_a_folder_carries_every_open_tab_underneath_it(cx: &mut TestAppContext) {
-        let repo = TempDir::new().expect("tempdir");
+        let (_repo_dir, repo) = crate::sidebar::fixtures::temp_root();
         seed(&repo);
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.clone());
         cx.run_until_parked();
 
         app.update_in(cx, |app, window, cx| {
-            app.open_file_view(repo.path().join("src/main.rs"), window, cx);
-            app.open_file_view(repo.path().join("src/util.rs"), window, cx);
-            app.set_dir_expanded(repo.path().join("src"), true, cx);
+            app.open_file_view(repo.join("src/main.rs"), window, cx);
+            app.open_file_view(repo.join("src/util.rs"), window, cx);
+            app.set_dir_expanded(repo.join("src"), true, cx);
         });
         cx.run_until_parked();
 
         app.update_in(cx, |app, window, cx| {
-            app.start_tree_rename(repo.path().join("src"), true, window, cx);
+            app.start_tree_rename(repo.join("src"), true, window, cx);
             app.tree_inline_edit.as_mut().expect("editor").name =
                 text_history::TextField::seeded("lib");
             app.commit_tree_inline_edit(window, cx);
         });
         cx.run_until_parked();
 
-        assert!(repo.path().join("lib/main.rs").exists());
+        assert!(repo.join("lib/main.rs").exists());
         app.read_with(cx, |app, _| {
             assert_eq!(
                 app.open_files().to_vec(),
@@ -1779,8 +1779,8 @@ mod tree_ops_regression_tests {
             assert!(app.edit_buffer_contains(Path::new("lib/util.rs")));
             assert!(!app.edit_buffer_contains(Path::new("src/util.rs")));
             assert!(
-                app.expanded_dirs.contains(&repo.path().join("lib"))
-                    && !app.expanded_dirs.contains(&repo.path().join("src")),
+                app.expanded_dirs.contains(&repo.join("lib"))
+                    && !app.expanded_dirs.contains(&repo.join("src")),
                 "the folder's own expanded state must move with it, or the renamed folder would \
                  silently snap shut"
             );
@@ -1791,12 +1791,12 @@ mod tree_ops_regression_tests {
     fn deleting_a_file_removes_it_immediately_and_records_a_real_undo_entry(
         cx: &mut TestAppContext,
     ) {
-        let repo = TempDir::new().expect("tempdir");
+        let (_repo_dir, repo) = crate::sidebar::fixtures::temp_root();
         seed(&repo);
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.clone());
         cx.run_until_parked();
 
-        let victim = repo.path().join("src/util.rs");
+        let victim = repo.join("src/util.rs");
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(victim.clone(), window, cx);
             app.request_tree_delete_with_mechanism_for_test(
@@ -1843,12 +1843,12 @@ mod tree_ops_regression_tests {
 
     #[gpui::test]
     fn undoing_then_redoing_a_delete_restores_then_removes_the_file_again(cx: &mut TestAppContext) {
-        let repo = TempDir::new().expect("tempdir");
+        let (_repo_dir, repo) = crate::sidebar::fixtures::temp_root();
         seed(&repo);
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.clone());
         cx.run_until_parked();
 
-        let victim = repo.path().join("src/util.rs");
+        let victim = repo.join("src/util.rs");
         let original_content = fs::read_to_string(&victim).expect("read fixture");
         app.update(cx, |app, cx| {
             app.request_tree_delete_with_mechanism_for_test(
@@ -1890,14 +1890,14 @@ mod tree_ops_regression_tests {
     fn two_app_instances_deleting_a_same_named_file_never_collide_on_their_backup_paths(
         cx: &mut TestAppContext,
     ) {
-        let repo_a = TempDir::new().expect("tempdir a");
+        let (_repo_a_dir, repo_a) = crate::sidebar::fixtures::temp_root();
         seed(&repo_a);
-        let repo_b = TempDir::new().expect("tempdir b");
+        let (_repo_b_dir, repo_b) = crate::sidebar::fixtures::temp_root();
         seed(&repo_b);
 
-        let (app_a, cx) = palette_focus_tests::open_test_app(cx, repo_a.path().to_path_buf());
+        let (app_a, cx) = palette_focus_tests::open_test_app(cx, repo_a.clone());
         cx.run_until_parked();
-        let (app_b, cx) = palette_focus_tests::open_test_app(cx, repo_b.path().to_path_buf());
+        let (app_b, cx) = palette_focus_tests::open_test_app(cx, repo_b.clone());
         cx.run_until_parked();
 
         app_a.read_with(cx, |a, _| {
@@ -1909,8 +1909,8 @@ mod tree_ops_regression_tests {
             })
         });
 
-        let victim_a = repo_a.path().join("src/util.rs");
-        let victim_b = repo_b.path().join("src/util.rs");
+        let victim_a = repo_a.join("src/util.rs");
+        let victim_b = repo_b.join("src/util.rs");
         app_a.update(cx, |a, cx| {
             a.request_tree_delete_with_mechanism_for_test(
                 victim_a.clone(),
@@ -1938,12 +1938,12 @@ mod tree_ops_regression_tests {
 
     #[gpui::test]
     fn undoing_then_redoing_a_rename_restores_then_reapplies_it(cx: &mut TestAppContext) {
-        let repo = TempDir::new().expect("tempdir");
+        let (_repo_dir, repo) = crate::sidebar::fixtures::temp_root();
         seed(&repo);
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.clone());
         cx.run_until_parked();
 
-        let old = repo.path().join("src/main.rs");
+        let old = repo.join("src/main.rs");
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(old.clone(), window, cx);
             app.start_tree_rename(old.clone(), false, window, cx);
@@ -1952,7 +1952,7 @@ mod tree_ops_regression_tests {
             app.commit_tree_inline_edit(window, cx);
         });
         cx.run_until_parked();
-        let renamed = repo.path().join("src/renamed.rs");
+        let renamed = repo.join("src/renamed.rs");
         assert!(renamed.exists());
         assert!(!old.exists());
         app.read_with(cx, |app, _| {
@@ -1983,18 +1983,18 @@ mod tree_ops_regression_tests {
 
     #[gpui::test]
     fn undoing_a_cut_and_paste_move_restores_the_original_location(cx: &mut TestAppContext) {
-        let repo = TempDir::new().expect("tempdir");
+        let (_repo_dir, repo) = crate::sidebar::fixtures::temp_root();
         seed(&repo);
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.clone());
         cx.run_until_parked();
 
-        let original = repo.path().join("README.md");
+        let original = repo.join("README.md");
         app.update(cx, |app, cx| {
             app.set_tree_clipboard(original.clone(), ClipboardMode::Cut, cx);
-            app.paste_into_dir(&repo.path().join("src"), cx);
+            app.paste_into_dir(&repo.join("src"), cx);
         });
         cx.run_until_parked();
-        let moved = repo.path().join("src/README.md");
+        let moved = repo.join("src/README.md");
         assert!(moved.exists());
         assert!(!original.exists());
 
@@ -2011,12 +2011,12 @@ mod tree_ops_regression_tests {
 
     #[gpui::test]
     fn a_fresh_edit_after_an_undo_clears_the_redo_stack(cx: &mut TestAppContext) {
-        let repo = TempDir::new().expect("tempdir");
+        let (_repo_dir, repo) = crate::sidebar::fixtures::temp_root();
         seed(&repo);
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.clone());
         cx.run_until_parked();
 
-        let victim = repo.path().join("src/util.rs");
+        let victim = repo.join("src/util.rs");
         app.update(cx, |app, cx| {
             app.request_tree_delete_with_mechanism_for_test(
                 victim.clone(),
@@ -2039,7 +2039,7 @@ mod tree_ops_regression_tests {
         });
 
         app.update_in(cx, |app, window, cx| {
-            app.start_tree_rename(repo.path().join("README.md"), false, window, cx);
+            app.start_tree_rename(repo.join("README.md"), false, window, cx);
             app.tree_inline_edit.as_mut().expect("editor").name =
                 text_history::TextField::seeded("renamed.md");
             app.commit_tree_inline_edit(window, cx);
@@ -2061,10 +2061,10 @@ mod tree_ops_regression_tests {
 
     #[gpui::test]
     fn deleting_something_outside_the_worktree_is_refused_outright(cx: &mut TestAppContext) {
-        let repo = TempDir::new().expect("tempdir");
+        let (_repo_dir, repo) = crate::sidebar::fixtures::temp_root();
         let outside = TempDir::new().expect("tempdir");
         fs::write(outside.path().join("precious.txt"), "keep me").expect("write");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.clone());
         cx.run_until_parked();
 
         app.update(cx, |app, cx| {
@@ -2084,19 +2084,19 @@ mod tree_ops_regression_tests {
 
     #[gpui::test]
     fn pasting_into_the_source_folder_creates_a_real_suffixed_copy(cx: &mut TestAppContext) {
-        let repo = TempDir::new().expect("tempdir");
+        let (_repo_dir, repo) = crate::sidebar::fixtures::temp_root();
         seed(&repo);
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.clone());
         cx.run_until_parked();
 
-        let source = repo.path().join("src/main.rs");
+        let source = repo.join("src/main.rs");
         app.update(cx, |app, cx| {
             app.set_tree_clipboard(source.clone(), ClipboardMode::Copy, cx);
-            app.paste_into_dir(&repo.path().join("src"), cx);
+            app.paste_into_dir(&repo.join("src"), cx);
         });
         cx.run_until_parked();
 
-        let copy = repo.path().join("src/main copy.rs");
+        let copy = repo.join("src/main copy.rs");
         assert!(
             copy.exists(),
             "the paste must produce a real, suffixed file"
@@ -2121,30 +2121,30 @@ mod tree_ops_regression_tests {
         });
 
         app.update(cx, |app, cx| {
-            app.paste_into_dir(&repo.path().join("src"), cx);
+            app.paste_into_dir(&repo.join("src"), cx);
         });
         cx.run_until_parked();
-        assert!(repo.path().join("src/main copy 2.rs").exists());
+        assert!(repo.join("src/main copy 2.rs").exists());
     }
 
     #[gpui::test]
     fn cutting_and_pasting_moves_the_entry_and_its_open_tab(cx: &mut TestAppContext) {
-        let repo = TempDir::new().expect("tempdir");
+        let (_repo_dir, repo) = crate::sidebar::fixtures::temp_root();
         seed(&repo);
-        fs::create_dir(repo.path().join("dest")).expect("mkdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        fs::create_dir(repo.join("dest")).expect("mkdir");
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.clone());
         cx.run_until_parked();
 
-        let source = repo.path().join("src/util.rs");
+        let source = repo.join("src/util.rs");
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(source.clone(), window, cx);
             app.set_tree_clipboard(source.clone(), ClipboardMode::Cut, cx);
-            app.paste_into_dir(&repo.path().join("dest"), cx);
+            app.paste_into_dir(&repo.join("dest"), cx);
         });
         cx.run_until_parked();
 
         assert!(!source.exists());
-        assert!(repo.path().join("dest/util.rs").exists());
+        assert!(repo.join("dest/util.rs").exists());
         app.read_with(cx, |app, _| {
             assert!(app.open_files().contains(&PathBuf::from("dest/util.rs")));
             assert!(!app.edit_buffer_contains(Path::new("src/util.rs")));
@@ -2158,14 +2158,14 @@ mod tree_ops_regression_tests {
 
     #[gpui::test]
     fn a_tree_reload_during_an_inline_rename_keeps_the_typed_text(cx: &mut TestAppContext) {
-        let repo = TempDir::new().expect("tempdir");
+        let (_repo_dir, repo) = crate::sidebar::fixtures::temp_root();
         seed(&repo);
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.clone());
         cx.run_until_parked();
 
         app.update_in(cx, |app, window, cx| {
-            app.set_dir_expanded(repo.path().join("src"), true, cx);
-            app.start_tree_rename(repo.path().join("src/main.rs"), false, window, cx);
+            app.set_dir_expanded(repo.join("src"), true, cx);
+            app.start_tree_rename(repo.join("src/main.rs"), false, window, cx);
             app.tree_inline_edit.as_mut().expect("editor").name =
                 text_history::TextField::seeded("half-typed");
         });
@@ -2175,7 +2175,8 @@ mod tree_ops_regression_tests {
             "premise: the editor must be a real painted row before the reload"
         );
 
-        fs::write(repo.path().join("src/agent-made.rs"), "// new\n").expect("write");
+        // An agent CLI creating a file mid-agent, followed by the real re-walk.
+        fs::write(repo.join("src/agent-made.rs"), "// new\n").expect("write");
         app.update(cx, |app, cx| {
             let root = app.file_tree_root.clone();
             app.load_file_tree(root, cx);
@@ -2203,14 +2204,14 @@ mod tree_ops_regression_tests {
 
     #[gpui::test]
     fn the_empty_area_collapse_all_clears_the_persisted_fold_state_too(cx: &mut TestAppContext) {
-        let repo = TempDir::new().expect("tempdir");
+        let (_repo_dir, repo) = crate::sidebar::fixtures::temp_root();
         seed(&repo);
         let state_dir = TempDir::new().expect("tempdir");
         let settings_path = state_dir.path().join("settings.toml");
         let fold_path = crate::sidebar::fold_state::fold_state_path_for(&settings_path);
         let (app, cx) = cx.add_window_view(|window, cx| {
             AdeApp::new_with_settings(
-                Some(repo.path().to_path_buf()),
+                Some(repo.clone()),
                 true,
                 settings_store::Settings::default(),
                 Some(settings_path),
@@ -2221,7 +2222,7 @@ mod tree_ops_regression_tests {
         cx.run_until_parked();
 
         app.update(cx, |app, cx| {
-            app.set_dir_expanded(repo.path().join("src"), true, cx);
+            app.set_dir_expanded(repo.join("src"), true, cx);
         });
         cx.run_until_parked();
         assert!(
@@ -2252,14 +2253,14 @@ mod tree_ops_regression_tests {
 
     #[gpui::test]
     fn ctrl_z_while_typing_a_name_in_the_tree_undoes_the_name(cx: &mut TestAppContext) {
-        let repo = TempDir::new().expect("tempdir");
+        let (_repo_dir, repo) = crate::sidebar::fixtures::temp_root();
         seed(&repo);
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.clone());
         cx.update(|_window, cx| cx.bind_keys(crate::default_key_bindings()));
         cx.run_until_parked();
 
         app.update_in(cx, |app, window, cx| {
-            app.start_tree_new_entry(repo.path().to_path_buf(), false, window, cx);
+            app.start_tree_new_entry(repo.clone(), false, window, cx);
         });
         cx.run_until_parked();
 
@@ -2297,14 +2298,14 @@ mod tree_ops_regression_tests {
     fn the_first_ctrl_z_in_a_rename_editor_does_not_blank_the_prefilled_name(
         cx: &mut TestAppContext,
     ) {
-        let repo = TempDir::new().expect("tempdir");
+        let (_repo_dir, repo) = crate::sidebar::fixtures::temp_root();
         seed(&repo);
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.clone());
         cx.update(|_window, cx| cx.bind_keys(crate::default_key_bindings()));
         cx.run_until_parked();
 
         app.update_in(cx, |app, window, cx| {
-            app.start_tree_rename(repo.path().join("README.md"), false, window, cx);
+            app.start_tree_rename(repo.join("README.md"), false, window, cx);
         });
         cx.run_until_parked();
         app.read_with(cx, |app, _| {
@@ -2338,14 +2339,14 @@ mod tree_ops_regression_tests {
 
     #[gpui::test]
     fn redo_in_the_tree_inline_editor_restores_the_undone_name(cx: &mut TestAppContext) {
-        let repo = TempDir::new().expect("tempdir");
+        let (_repo_dir, repo) = crate::sidebar::fixtures::temp_root();
         seed(&repo);
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.clone());
         cx.update(|_window, cx| cx.bind_keys(crate::default_key_bindings()));
         cx.run_until_parked();
 
         app.update_in(cx, |app, window, cx| {
-            app.start_tree_new_entry(repo.path().to_path_buf(), true, window, cx);
+            app.start_tree_new_entry(repo.clone(), true, window, cx);
         });
         cx.run_until_parked();
         cx.simulate_input("assets");
@@ -2389,13 +2390,13 @@ mod tree_ops_regression_tests {
 
     #[gpui::test]
     fn opening_the_context_menu_cancels_an_open_inline_editor(cx: &mut TestAppContext) {
-        let repo = TempDir::new().expect("tempdir");
+        let (_repo_dir, repo) = crate::sidebar::fixtures::temp_root();
         seed(&repo);
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.clone());
         cx.run_until_parked();
 
         app.update_in(cx, |app, window, cx| {
-            app.start_tree_rename(repo.path().join("README.md"), false, window, cx);
+            app.start_tree_rename(repo.join("README.md"), false, window, cx);
         });
         cx.run_until_parked();
         app.read_with(cx, |app, _| {
@@ -2404,7 +2405,7 @@ mod tree_ops_regression_tests {
 
         app.update_in(cx, |app, window, cx| {
             app.open_tree_context_menu(
-                ContextTarget::File(repo.path().join("README.md")),
+                ContextTarget::File(repo.join("README.md")),
                 10.0,
                 10.0,
                 window,
@@ -2423,16 +2424,16 @@ mod tree_ops_regression_tests {
 
     #[gpui::test]
     fn ctrl_c_with_a_focused_terminal_never_reaches_the_trees_clipboard(cx: &mut TestAppContext) {
-        let repo = TempDir::new().expect("tempdir");
+        let (_repo_dir, repo) = crate::sidebar::fixtures::temp_root();
         seed(&repo);
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.clone());
         cx.update(|_window, cx| cx.bind_keys(crate::default_key_bindings()));
         cx.run_until_parked();
 
         app.update_in(cx, |app, window, cx| {
             // A real selection, so the tree binding would genuinely have something to copy if it
             // fired - otherwise this test could pass for the wrong reason.
-            app.selected_tree_path = Some(repo.path().join("README.md"));
+            app.selected_tree_path = Some(repo.join("README.md"));
             app.agents.focus_active(window, cx);
         });
         cx.run_until_parked();
@@ -2451,14 +2452,14 @@ mod tree_ops_regression_tests {
 
     #[gpui::test]
     fn ctrl_c_with_the_tree_focused_copies_the_selected_entry(cx: &mut TestAppContext) {
-        let repo = TempDir::new().expect("tempdir");
+        let (_repo_dir, repo) = crate::sidebar::fixtures::temp_root();
         seed(&repo);
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.clone());
         cx.update(|_window, cx| cx.bind_keys(crate::default_key_bindings()));
         cx.run_until_parked();
 
         app.update_in(cx, |app, window, cx| {
-            app.selected_tree_path = Some(repo.path().join("README.md"));
+            app.selected_tree_path = Some(repo.join("README.md"));
             app.focus_file_tree(window, cx);
         });
         cx.run_until_parked();
@@ -2469,7 +2470,7 @@ mod tree_ops_regression_tests {
                 .tree_clipboard
                 .as_ref()
                 .expect("ctrl-c with the tree focused must copy the selection");
-            assert_eq!(entry.path, repo.path().join("README.md"));
+            assert_eq!(entry.path, repo.join("README.md"));
             assert_eq!(entry.mode, ClipboardMode::Copy);
         });
     }
@@ -2516,9 +2517,9 @@ mod tree_ops_regression_tests {
     fn right_clicking_a_folder_row_opens_the_folder_menu_at_a_clamped_origin(
         cx: &mut TestAppContext,
     ) {
-        let repo = TempDir::new().expect("tempdir");
+        let (_repo_dir, repo) = crate::sidebar::fixtures::temp_root();
         seed(&repo);
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.clone());
         cx.run_until_parked();
 
         let row = cx
@@ -2541,7 +2542,7 @@ mod tree_ops_regression_tests {
                 .expect("a real right-click on a folder row must open a menu");
             assert_eq!(
                 menu.target,
-                ContextTarget::Folder(repo.path().join("src")),
+                ContextTarget::Folder(repo.join("src")),
                 "the row's own handler must win over the container's empty-area one"
             );
             let rows = context_menu::menu_rows(&menu.target, false);
@@ -2577,9 +2578,9 @@ mod tree_ops_regression_tests {
 
     #[gpui::test]
     fn escape_dismisses_the_context_menu(cx: &mut TestAppContext) {
-        let repo = TempDir::new().expect("tempdir");
+        let (_repo_dir, repo) = crate::sidebar::fixtures::temp_root();
         seed(&repo);
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.clone());
         cx.update(|_window, cx| cx.bind_keys(crate::default_key_bindings()));
         cx.run_until_parked();
 
@@ -2593,14 +2594,14 @@ mod tree_ops_regression_tests {
 
     #[gpui::test]
     fn the_new_folder_editor_creates_a_real_directory(cx: &mut TestAppContext) {
-        let repo = TempDir::new().expect("tempdir");
+        let (_repo_dir, repo) = crate::sidebar::fixtures::temp_root();
         seed(&repo);
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.clone());
         cx.run_until_parked();
 
         app.update_in(cx, |app, window, cx| {
             app.open_tree_context_menu(
-                ContextTarget::Folder(repo.path().join("src")),
+                ContextTarget::Folder(repo.join("src")),
                 20.0,
                 20.0,
                 window,
@@ -2613,11 +2614,11 @@ mod tree_ops_regression_tests {
         });
         cx.run_until_parked();
 
-        assert!(repo.path().join("src/nested").is_dir());
+        assert!(repo.join("src/nested").is_dir());
         app.read_with(cx, |app, _| {
             assert!(app.tree_inline_edit.is_none(), "the editor must close");
             assert!(
-                app.expanded_dirs.contains(&repo.path().join("src")),
+                app.expanded_dirs.contains(&repo.join("src")),
                 "the parent must have been expanded so the editor was visible in the first place"
             );
         });
@@ -2627,14 +2628,14 @@ mod tree_ops_regression_tests {
     fn an_invalid_name_is_refused_with_a_real_hint_and_the_editor_stays_open(
         cx: &mut TestAppContext,
     ) {
-        let repo = TempDir::new().expect("tempdir");
+        let (_repo_dir, repo) = crate::sidebar::fixtures::temp_root();
         seed(&repo);
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.clone());
         cx.run_until_parked();
 
         for bad in ["", "  ", "a/b", ".."] {
             app.update_in(cx, |app, window, cx| {
-                app.start_tree_new_entry(repo.path().to_path_buf(), true, window, cx);
+                app.start_tree_new_entry(repo.clone(), true, window, cx);
                 app.tree_inline_edit.as_mut().expect("editor").name =
                     text_history::TextField::seeded(bad);
                 app.commit_tree_inline_edit(window, cx);
@@ -2653,7 +2654,7 @@ mod tree_ops_regression_tests {
         }
 
         app.update_in(cx, |app, window, cx| {
-            app.start_tree_new_entry(repo.path().to_path_buf(), true, window, cx);
+            app.start_tree_new_entry(repo.clone(), true, window, cx);
             app.tree_inline_edit.as_mut().expect("editor").name =
                 text_history::TextField::seeded("src");
             app.commit_tree_inline_edit(window, cx);
@@ -2669,40 +2670,40 @@ mod tree_ops_regression_tests {
                 .is_some_and(|error| error.contains("already exists")));
         });
         assert!(
-            repo.path().join("src/main.rs").exists(),
+            repo.join("src/main.rs").exists(),
             "and the existing folder must be untouched"
         );
     }
 
     #[gpui::test]
     fn collapse_subtree_collapses_only_that_folders_own_descendants(cx: &mut TestAppContext) {
-        let repo = TempDir::new().expect("tempdir");
-        fs::create_dir_all(repo.path().join("a/inner")).expect("mkdir");
-        fs::create_dir_all(repo.path().join("b")).expect("mkdir");
-        fs::write(repo.path().join("a/inner/x.rs"), "x").expect("write");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (_repo_dir, repo) = crate::sidebar::fixtures::temp_root();
+        fs::create_dir_all(repo.join("a/inner")).expect("mkdir");
+        fs::create_dir_all(repo.join("b")).expect("mkdir");
+        fs::write(repo.join("a/inner/x.rs"), "x").expect("write");
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.clone());
         cx.run_until_parked();
 
         app.update(cx, |app, cx| {
-            app.set_dir_expanded(repo.path().join("a"), true, cx);
-            app.set_dir_expanded(repo.path().join("a/inner"), true, cx);
-            app.set_dir_expanded(repo.path().join("b"), true, cx);
+            app.set_dir_expanded(repo.join("a"), true, cx);
+            app.set_dir_expanded(repo.join("a/inner"), true, cx);
+            app.set_dir_expanded(repo.join("b"), true, cx);
         });
         cx.run_until_parked();
 
         app.update(cx, |app, cx| {
-            app.collapse_subtree(&repo.path().join("a"), cx);
+            app.collapse_subtree(&repo.join("a"), cx);
         });
         cx.run_until_parked();
 
         app.read_with(cx, |app, _| {
-            assert!(!app.expanded_dirs.contains(&repo.path().join("a")));
+            assert!(!app.expanded_dirs.contains(&repo.join("a")));
             assert!(
-                !app.expanded_dirs.contains(&repo.path().join("a/inner")),
+                !app.expanded_dirs.contains(&repo.join("a/inner")),
                 "a nested expansion left behind would reappear the moment the parent reopened"
             );
             assert!(
-                app.expanded_dirs.contains(&repo.path().join("b")),
+                app.expanded_dirs.contains(&repo.join("b")),
                 "a sibling subtree must be untouched"
             );
         });
@@ -2710,30 +2711,24 @@ mod tree_ops_regression_tests {
 
     #[gpui::test]
     fn copy_relative_path_writes_the_worktree_relative_path(cx: &mut TestAppContext) {
-        let repo = TempDir::new().expect("tempdir");
+        let (_repo_dir, repo) = crate::sidebar::fixtures::temp_root();
         seed(&repo);
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.clone());
         cx.run_until_parked();
 
         app.update(cx, |app, cx| {
-            app.copy_path_to_system_clipboard(&repo.path().join("src/main.rs"), true, cx);
+            app.copy_path_to_system_clipboard(&repo.join("src/main.rs"), true, cx);
         });
         let text = cx.update(|_window, cx| cx.read_from_clipboard().and_then(|item| item.text()));
         assert_eq!(text.as_deref(), Some("src/main.rs"));
 
         app.update(cx, |app, cx| {
-            app.copy_path_to_system_clipboard(&repo.path().join("src/main.rs"), false, cx);
+            app.copy_path_to_system_clipboard(&repo.join("src/main.rs"), false, cx);
         });
         let text = cx.update(|_window, cx| cx.read_from_clipboard().and_then(|item| item.text()));
         assert_eq!(
             text.as_deref(),
-            Some(
-                repo.path()
-                    .join("src/main.rs")
-                    .display()
-                    .to_string()
-                    .as_str()
-            )
+            Some(repo.join("src/main.rs").display().to_string().as_str())
         );
     }
 
@@ -2745,16 +2740,16 @@ mod tree_ops_regression_tests {
 
         #[gpui::test]
         fn a_rename_carries_the_files_staged_checkbox_with_it(cx: &mut TestAppContext) {
-            let repo = TempDir::new().expect("tempdir");
+            let (_repo_dir, repo) = crate::sidebar::fixtures::temp_root();
             seed(&repo);
-            let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+            let (app, cx) = palette_focus_tests::open_test_app(cx, repo.clone());
             cx.run_until_parked();
 
             app.update(cx, |app, cx| {
                 app.toggle_staged(PathBuf::from("src/main.rs"), cx);
             });
             app.update_in(cx, |app, window, cx| {
-                app.start_tree_rename(repo.path().join("src/main.rs"), false, window, cx);
+                app.start_tree_rename(repo.join("src/main.rs"), false, window, cx);
                 app.tree_inline_edit.as_mut().expect("editor").name =
                     text_history::TextField::seeded("renamed.rs");
                 app.commit_tree_inline_edit(window, cx);
@@ -2775,12 +2770,12 @@ mod tree_ops_regression_tests {
         fn renaming_and_deleting_both_clear_the_lsp_per_document_bookkeeping(
             cx: &mut TestAppContext,
         ) {
-            let repo = TempDir::new().expect("tempdir");
+            let (_repo_dir, repo) = crate::sidebar::fixtures::temp_root();
             seed(&repo);
-            let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+            let (app, cx) = palette_focus_tests::open_test_app(cx, repo.clone());
             cx.run_until_parked();
 
-            let absolute = repo.path().join("src/main.rs");
+            let absolute = repo.join("src/main.rs");
             let relative = PathBuf::from("src/main.rs");
             app.update(cx, |app, _cx| {
                 app.lsp_opened_files.insert(absolute.clone());
@@ -2809,7 +2804,8 @@ mod tree_ops_regression_tests {
                 assert!(!app.lsp_synced_version.contains_key(&relative));
             });
 
-            let renamed = repo.path().join("src/renamed.rs");
+            // And the delete half, on the renamed path.
+            let renamed = repo.join("src/renamed.rs");
             let renamed_relative = PathBuf::from("src/renamed.rs");
             app.update(cx, |app, _cx| {
                 app.lsp_opened_files.insert(renamed.clone());
@@ -2835,15 +2831,15 @@ mod tree_ops_regression_tests {
         fn cutting_and_pasting_into_the_source_folder_is_a_no_op_not_a_rename(
             cx: &mut TestAppContext,
         ) {
-            let repo = TempDir::new().expect("tempdir");
+            let (_repo_dir, repo) = crate::sidebar::fixtures::temp_root();
             seed(&repo);
-            let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+            let (app, cx) = palette_focus_tests::open_test_app(cx, repo.clone());
             cx.run_until_parked();
 
-            let source = repo.path().join("src/util.rs");
+            let source = repo.join("src/util.rs");
             app.update(cx, |app, cx| {
                 app.set_tree_clipboard(source.clone(), ClipboardMode::Cut, cx);
-                app.paste_into_dir(&repo.path().join("src"), cx);
+                app.paste_into_dir(&repo.join("src"), cx);
             });
             cx.run_until_parked();
 
@@ -2852,7 +2848,7 @@ mod tree_ops_regression_tests {
                 "the file must still be exactly where it was"
             );
             assert!(
-                !repo.path().join("src/util copy.rs").exists(),
+                !repo.join("src/util copy.rs").exists(),
                 "a cut back into its own folder must never silently rename the file"
             );
             app.read_with(cx, |app, _| {
@@ -2865,15 +2861,15 @@ mod tree_ops_regression_tests {
         fn leaving_the_files_tab_does_not_leave_focus_dangling_on_the_tree(
             cx: &mut TestAppContext,
         ) {
-            let repo = TempDir::new().expect("tempdir");
+            let (_repo_dir, repo) = crate::sidebar::fixtures::temp_root();
             seed(&repo);
-            let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+            let (app, cx) = palette_focus_tests::open_test_app(cx, repo.clone());
             cx.update(|_window, cx| cx.bind_keys(crate::default_key_bindings()));
             cx.run_until_parked();
 
             app.update_in(cx, |app, window, cx| {
                 app.open_tree_context_menu(
-                    ContextTarget::File(repo.path().join("README.md")),
+                    ContextTarget::File(repo.join("README.md")),
                     30.0,
                     30.0,
                     window,
@@ -2906,11 +2902,11 @@ mod tree_ops_regression_tests {
 
     #[gpui::test]
     fn switching_worktrees_clears_every_tree_operation_in_flight(cx: &mut TestAppContext) {
-        let repo = TempDir::new().expect("tempdir");
+        let (_repo_dir, repo) = crate::sidebar::fixtures::temp_root();
         seed(&repo);
         let other = TempDir::new().expect("tempdir");
         fs::write(other.path().join("elsewhere.txt"), "x").expect("write");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.clone());
         cx.run_until_parked();
 
         // A directly-seeded `worktrees` list - the same pattern `crate::code_surface::zoom`'s own
@@ -2918,7 +2914,7 @@ mod tree_ops_regression_tests {
         app.update(cx, |app, _cx| {
             app.worktrees = vec![
                 crate::rail::worktrees::WorktreeItem {
-                    path: repo.path().to_path_buf(),
+                    path: repo.clone(),
                     label: "wt-a".to_string(),
                     branch: None,
                     is_main: true,
@@ -2949,25 +2945,25 @@ mod tree_ops_regression_tests {
         });
 
         app.update_in(cx, |app, window, cx| {
-            app.set_tree_clipboard(repo.path().join("README.md"), ClipboardMode::Cut, cx);
+            app.set_tree_clipboard(repo.join("README.md"), ClipboardMode::Cut, cx);
             // Order matters: `open_tree_context_menu` cancels an open inline editor, so opening
             // the menu *first* is the only way to have all four states live at once. An earlier
             // version of this test did it the other way round, which made the
             // `tree_inline_edit.is_none()` assertion below already true before `select_worktree`
             // ever ran - it would have passed against a reset that dropped that field entirely.
             app.open_tree_context_menu(ContextTarget::Empty, 10.0, 10.0, window, cx);
-            app.start_tree_rename(repo.path().join("README.md"), false, window, cx);
+            app.start_tree_rename(repo.join("README.md"), false, window, cx);
             // A recorded undo/redo entry - the fourth piece of in-flight tree state, replacing
             // the pre-issue-#105 armed delete confirmation. Seeded directly rather than through a
             // real delete/rename, since only the bookkeeping reset (not the real file op) is
             // under test here.
             app.tree_undo_stack.push(TreeUndoEntry::Relocate {
-                old_path: repo.path().join("a.txt"),
-                new_path: repo.path().join("b.txt"),
+                old_path: repo.join("a.txt"),
+                new_path: repo.join("b.txt"),
             });
             app.tree_redo_stack.push(TreeUndoEntry::Relocate {
-                old_path: repo.path().join("c.txt"),
-                new_path: repo.path().join("d.txt"),
+                old_path: repo.join("c.txt"),
+                new_path: repo.join("d.txt"),
             });
             assert!(
                 app.tree_clipboard.is_some()
@@ -2988,16 +2984,16 @@ mod tree_ops_regression_tests {
             assert!(app.tree_undo_stack.is_empty());
             assert!(app.tree_redo_stack.is_empty());
         });
-        assert!(repo.path().join("README.md").exists());
+        assert!(repo.join("README.md").exists());
     }
 
     #[gpui::test]
     fn a_click_on_a_tree_row_under_an_open_context_menu_does_not_reach_that_row(
         cx: &mut TestAppContext,
     ) {
-        let repo = TempDir::new().expect("tempdir");
+        let (_repo_dir, repo) = crate::sidebar::fixtures::temp_root();
         seed(&repo);
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.clone());
         cx.run_until_parked();
 
         // Open the menu from the empty area, so the menu's own panel is nowhere near the row
@@ -3036,9 +3032,9 @@ mod tree_ops_regression_tests {
 
     #[gpui::test]
     fn a_real_right_click_in_the_file_tree_closes_an_open_plus_menu(cx: &mut TestAppContext) {
-        let repo = TempDir::new().expect("tempdir");
+        let (_repo_dir, repo) = crate::sidebar::fixtures::temp_root();
         seed(&repo);
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.clone());
         cx.run_until_parked();
 
         app.update(cx, |app, cx| {
@@ -3089,9 +3085,9 @@ mod tree_ops_regression_tests {
     fn clicking_the_tab_strip_plus_under_an_open_tree_context_menu_never_leaves_both_open(
         cx: &mut TestAppContext,
     ) {
-        let repo = TempDir::new().expect("tempdir");
+        let (_repo_dir, repo) = crate::sidebar::fixtures::temp_root();
         seed(&repo);
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.clone());
         cx.run_until_parked();
 
         app.update_in(cx, |app, window, cx| {
@@ -3142,9 +3138,9 @@ mod tree_ops_regression_tests {
 
     #[gpui::test]
     fn the_same_click_with_no_menu_open_really_does_open_the_file(cx: &mut TestAppContext) {
-        let repo = TempDir::new().expect("tempdir");
+        let (_repo_dir, repo) = crate::sidebar::fixtures::temp_root();
         seed(&repo);
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.clone());
         cx.run_until_parked();
 
         let row = cx
@@ -3164,9 +3160,9 @@ mod tree_ops_regression_tests {
     fn clicking_a_file_row_keeps_the_tree_focused_so_the_next_shortcut_still_fires(
         cx: &mut TestAppContext,
     ) {
-        let repo = TempDir::new().expect("tempdir");
+        let (_repo_dir, repo) = crate::sidebar::fixtures::temp_root();
         seed(&repo);
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.clone());
         cx.update(|_window, cx| cx.bind_keys(crate::default_key_bindings()));
         cx.run_until_parked();
 
@@ -3201,9 +3197,9 @@ mod tree_ops_regression_tests {
 
     #[gpui::test]
     fn the_delete_key_reaches_the_real_delete_handler(cx: &mut TestAppContext) {
-        let repo = TempDir::new().expect("tempdir");
+        let (_repo_dir, repo) = crate::sidebar::fixtures::temp_root();
         seed(&repo);
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.clone());
         cx.update(|_window, cx| cx.bind_keys(crate::default_key_bindings()));
         cx.run_until_parked();
 
@@ -3225,14 +3221,14 @@ mod tree_ops_regression_tests {
 
     #[gpui::test]
     fn the_context_menu_paints_exactly_the_height_it_measures(cx: &mut TestAppContext) {
-        let repo = TempDir::new().expect("tempdir");
+        let (_repo_dir, repo) = crate::sidebar::fixtures::temp_root();
         seed(&repo);
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.clone());
         cx.run_until_parked();
 
         for target in [
-            ContextTarget::File(repo.path().join("README.md")),
-            ContextTarget::Folder(repo.path().join("src")),
+            ContextTarget::File(repo.join("README.md")),
+            ContextTarget::Folder(repo.join("src")),
             ContextTarget::Empty,
         ] {
             let expected =
@@ -3318,14 +3314,14 @@ mod tree_multiselect_tests {
     use crate::sidebar::context_menu::ContextTarget;
     use gpui::{Modifiers, TestAppContext};
     use std::fs;
-    use tempfile::TempDir;
+    use std::path::Path;
 
     /// Four plain root-level files, alphabetical - `visible_indices`' own display order for a
     /// worktree with no directories to expand, so a range-select test can reason about exactly
     /// which paths a Shift+click between two of them should span.
-    fn seed_flat(repo: &TempDir) {
+    fn seed_flat(repo: &Path) {
         for name in ["a.txt", "b.txt", "c.txt", "d.txt"] {
-            fs::write(repo.path().join(name), "x\n").expect("write");
+            fs::write(repo.join(name), "x\n").expect("write");
         }
     }
 
@@ -3352,13 +3348,13 @@ mod tree_multiselect_tests {
 
     #[gpui::test]
     fn secondary_click_toggles_a_row_into_and_back_out_of_the_selection(cx: &mut TestAppContext) {
-        let repo = TempDir::new().expect("tempdir");
+        let (_repo_dir, repo) = crate::sidebar::fixtures::temp_root();
         seed_flat(&repo);
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.clone());
         cx.run_until_parked();
 
-        let a = repo.path().join("a.txt");
-        let b = repo.path().join("b.txt");
+        let a = repo.join("a.txt");
+        let b = repo.join("b.txt");
         app.update(cx, |app, _cx| {
             app.selected_tree_path = Some(a.clone());
         });
@@ -3385,13 +3381,13 @@ mod tree_multiselect_tests {
     fn secondary_click_toggling_the_anchor_off_promotes_another_selected_row(
         cx: &mut TestAppContext,
     ) {
-        let repo = TempDir::new().expect("tempdir");
+        let (_repo_dir, repo) = crate::sidebar::fixtures::temp_root();
         seed_flat(&repo);
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.clone());
         cx.run_until_parked();
 
-        let a = repo.path().join("a.txt");
-        let b = repo.path().join("b.txt");
+        let a = repo.join("a.txt");
+        let b = repo.join("b.txt");
         app.update(cx, |app, _cx| {
             app.selected_tree_path = Some(a.clone());
             app.tree_click_select(b.clone(), secondary_modifiers());
@@ -3411,13 +3407,13 @@ mod tree_multiselect_tests {
 
     #[gpui::test]
     fn shift_click_range_selects_between_the_anchor_and_the_clicked_row(cx: &mut TestAppContext) {
-        let repo = TempDir::new().expect("tempdir");
+        let (_repo_dir, repo) = crate::sidebar::fixtures::temp_root();
         seed_flat(&repo);
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.clone());
         cx.run_until_parked();
 
-        let a = repo.path().join("a.txt");
-        let c = repo.path().join("c.txt");
+        let a = repo.join("a.txt");
+        let c = repo.join("c.txt");
         app.update(cx, |app, _cx| {
             app.selected_tree_path = Some(a.clone());
             app.tree_click_select(c.clone(), shift_modifiers());
@@ -3425,7 +3421,7 @@ mod tree_multiselect_tests {
         app.read_with(cx, |app, _| {
             let mut selected = app.tree_selected_paths();
             selected.sort();
-            let mut expected = vec![a.clone(), repo.path().join("b.txt"), c.clone()];
+            let mut expected = vec![a.clone(), repo.join("b.txt"), c.clone()];
             expected.sort();
             assert_eq!(
                 selected, expected,
@@ -3440,7 +3436,7 @@ mod tree_multiselect_tests {
 
         // A second Shift+click resizes the range from the same anchor - it does not extend from
         // wherever the first range left off.
-        let b = repo.path().join("b.txt");
+        let b = repo.join("b.txt");
         app.update(cx, |app, _cx| {
             app.tree_click_select(b.clone(), shift_modifiers());
         });
@@ -3455,14 +3451,14 @@ mod tree_multiselect_tests {
 
     #[gpui::test]
     fn a_plain_click_collapses_the_selection_to_just_that_row(cx: &mut TestAppContext) {
-        let repo = TempDir::new().expect("tempdir");
+        let (_repo_dir, repo) = crate::sidebar::fixtures::temp_root();
         seed_flat(&repo);
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.clone());
         cx.run_until_parked();
 
-        let a = repo.path().join("a.txt");
-        let b = repo.path().join("b.txt");
-        let c = repo.path().join("c.txt");
+        let a = repo.join("a.txt");
+        let b = repo.join("b.txt");
+        let c = repo.join("c.txt");
         app.update(cx, |app, _cx| {
             app.selected_tree_path = Some(a.clone());
             app.tree_click_select(b.clone(), secondary_modifiers());
@@ -3481,14 +3477,14 @@ mod tree_multiselect_tests {
 
     #[gpui::test]
     fn the_delete_key_removes_every_selected_file_not_just_the_anchor(cx: &mut TestAppContext) {
-        let repo = TempDir::new().expect("tempdir");
+        let (_repo_dir, repo) = crate::sidebar::fixtures::temp_root();
         seed_flat(&repo);
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.clone());
         cx.run_until_parked();
 
-        let a = repo.path().join("a.txt");
-        let b = repo.path().join("b.txt");
-        let c = repo.path().join("c.txt");
+        let a = repo.join("a.txt");
+        let b = repo.join("b.txt");
+        let c = repo.join("c.txt");
         app.update(cx, |app, _cx| {
             app.selected_tree_path = Some(a.clone());
             app.tree_click_select(b.clone(), secondary_modifiers());
@@ -3503,17 +3499,32 @@ mod tree_multiselect_tests {
         assert!(c.exists(), "an unselected row must be left alone");
     }
 
+    /// GitHub issue #145: F2 still opens the rename editor for a real single selection, and opens
+    /// nothing at all once more than one row is selected - there is no single name to rename a
+    /// multi-selection to.
     #[gpui::test]
-    fn rename_is_a_no_op_with_more_than_one_row_selected(cx: &mut TestAppContext) {
-        let repo = TempDir::new().expect("tempdir");
+    fn rename_opens_an_editor_for_one_selected_row_and_for_no_other_count(cx: &mut TestAppContext) {
+        let (_repo_dir, repo) = crate::sidebar::fixtures::temp_root();
         seed_flat(&repo);
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.clone());
         cx.run_until_parked();
 
-        let a = repo.path().join("a.txt");
-        let b = repo.path().join("b.txt");
+        let a = repo.join("a.txt");
+        let b = repo.join("b.txt");
         app.update_in(cx, |app, window, cx| {
             app.selected_tree_path = Some(a.clone());
+            app.start_tree_rename_for_selection(window, cx);
+        });
+        app.read_with(cx, |app, _| {
+            assert!(
+                app.tree_inline_edit.is_some(),
+                "a real single selection must still open the rename editor exactly as before \
+                 GitHub issue #145"
+            );
+        });
+
+        app.update_in(cx, |app, window, cx| {
+            app.cancel_tree_inline_edit(window, cx);
             app.tree_click_select(b.clone(), secondary_modifiers());
             app.start_tree_rename_for_selection(window, cx);
         });
@@ -3526,38 +3537,19 @@ mod tree_multiselect_tests {
         });
     }
 
+    /// A right-click inside the selection keeps it whole (the menu then targets every selected
+    /// row); a right-click outside it is a fresh single selection, exactly as a plain click is.
     #[gpui::test]
-    fn rename_still_works_normally_with_exactly_one_row_selected(cx: &mut TestAppContext) {
-        let repo = TempDir::new().expect("tempdir");
-        seed_flat(&repo);
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
-        cx.run_until_parked();
-
-        let a = repo.path().join("a.txt");
-        app.update_in(cx, |app, window, cx| {
-            app.selected_tree_path = Some(a.clone());
-            app.start_tree_rename_for_selection(window, cx);
-        });
-        app.read_with(cx, |app, _| {
-            assert!(
-                app.tree_inline_edit.is_some(),
-                "a real single selection must still open the rename editor exactly as before \
-                 GitHub issue #145"
-            );
-        });
-    }
-
-    #[gpui::test]
-    fn right_clicking_a_row_already_inside_a_multi_selection_preserves_the_whole_selection(
+    fn a_right_click_preserves_a_selection_it_lands_inside_and_replaces_one_it_lands_outside(
         cx: &mut TestAppContext,
     ) {
-        let repo = TempDir::new().expect("tempdir");
+        let (_repo_dir, repo) = crate::sidebar::fixtures::temp_root();
         seed_flat(&repo);
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.clone());
         cx.run_until_parked();
 
-        let a = repo.path().join("a.txt");
-        let b = repo.path().join("b.txt");
+        let a = repo.join("a.txt");
+        let b = repo.join("b.txt");
         app.update_in(cx, |app, window, cx| {
             app.selected_tree_path = Some(a.clone());
             app.tree_click_select(b.clone(), secondary_modifiers());
@@ -3584,23 +3576,10 @@ mod tree_multiselect_tests {
             );
             assert!(app.additional_tree_selection.contains(&b));
         });
-    }
 
-    #[gpui::test]
-    fn right_clicking_a_row_outside_the_selection_collapses_to_just_that_row(
-        cx: &mut TestAppContext,
-    ) {
-        let repo = TempDir::new().expect("tempdir");
-        seed_flat(&repo);
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
-        cx.run_until_parked();
-
-        let a = repo.path().join("a.txt");
-        let b = repo.path().join("b.txt");
-        let c = repo.path().join("c.txt");
+        let c = repo.join("c.txt");
         app.update_in(cx, |app, window, cx| {
-            app.selected_tree_path = Some(a.clone());
-            app.tree_click_select(b.clone(), secondary_modifiers());
+            // Right-clicking `c` - outside the {a, b} selection - must collapse to just `c`.
             app.open_tree_context_menu(ContextTarget::File(c.clone()), 10.0, 10.0, window, cx);
         });
         app.read_with(cx, |app, _| {
@@ -3613,13 +3592,13 @@ mod tree_multiselect_tests {
 
     #[gpui::test]
     fn opening_a_file_from_the_tree_collapses_a_stray_multi_selection(cx: &mut TestAppContext) {
-        let repo = TempDir::new().expect("tempdir");
+        let (_repo_dir, repo) = crate::sidebar::fixtures::temp_root();
         seed_flat(&repo);
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.clone());
         cx.run_until_parked();
 
-        let a = repo.path().join("a.txt");
-        let b = repo.path().join("b.txt");
+        let a = repo.join("a.txt");
+        let b = repo.join("b.txt");
         app.update(cx, |app, _cx| {
             app.selected_tree_path = Some(a.clone());
             app.additional_tree_selection.insert(b.clone());
@@ -3650,25 +3629,25 @@ mod tree_drag_move_tests {
     use crate::root::AdeApp;
     use gpui::TestAppContext;
     use std::fs;
-    use tempfile::TempDir;
+    use std::path::Path;
 
-    fn seed(repo: &TempDir) {
-        fs::create_dir_all(repo.path().join("dest")).expect("mkdir");
-        fs::write(repo.path().join("a.txt"), "a\n").expect("write");
-        fs::write(repo.path().join("b.txt"), "b\n").expect("write");
+    fn seed(repo: &Path) {
+        fs::create_dir_all(repo.join("dest")).expect("mkdir");
+        fs::write(repo.join("a.txt"), "a\n").expect("write");
+        fs::write(repo.join("b.txt"), "b\n").expect("write");
     }
 
     #[gpui::test]
     fn dropping_a_file_onto_a_folder_moves_it_there_with_a_real_undo_entry(
         cx: &mut TestAppContext,
     ) {
-        let repo = TempDir::new().expect("tempdir");
+        let (_repo_dir, repo) = crate::sidebar::fixtures::temp_root();
         seed(&repo);
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.clone());
         cx.run_until_parked();
 
-        let a = repo.path().join("a.txt");
-        let dest = repo.path().join("dest");
+        let a = repo.join("a.txt");
+        let dest = repo.join("dest");
         let undo_len_before = app.read_with(cx, |app, _| app.tree_undo_stack.len());
         app.update(cx, |app, cx| {
             app.move_paths_into_dir(std::slice::from_ref(&a), &dest, cx);
@@ -3696,14 +3675,14 @@ mod tree_drag_move_tests {
 
     #[gpui::test]
     fn dropping_a_multi_selection_moves_every_selected_path(cx: &mut TestAppContext) {
-        let repo = TempDir::new().expect("tempdir");
+        let (_repo_dir, repo) = crate::sidebar::fixtures::temp_root();
         seed(&repo);
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.clone());
         cx.run_until_parked();
 
-        let a = repo.path().join("a.txt");
-        let b = repo.path().join("b.txt");
-        let dest = repo.path().join("dest");
+        let a = repo.join("a.txt");
+        let b = repo.join("b.txt");
+        let dest = repo.join("dest");
         app.update(cx, |app, cx| {
             app.move_paths_into_dir(&[a.clone(), b.clone()], &dest, cx);
         });
@@ -3719,14 +3698,14 @@ mod tree_drag_move_tests {
     fn dropping_a_folder_onto_its_own_descendant_is_refused_with_a_real_error(
         cx: &mut TestAppContext,
     ) {
-        let repo = TempDir::new().expect("tempdir");
+        let (_repo_dir, repo) = crate::sidebar::fixtures::temp_root();
         seed(&repo);
-        fs::create_dir_all(repo.path().join("dest/inner")).expect("mkdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        fs::create_dir_all(repo.join("dest/inner")).expect("mkdir");
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.clone());
         cx.run_until_parked();
 
-        let dest = repo.path().join("dest");
-        let inner = repo.path().join("dest/inner");
+        let dest = repo.join("dest");
+        let inner = repo.join("dest/inner");
         app.update(cx, |app, cx| {
             app.move_paths_into_dir(std::slice::from_ref(&dest), &inner, cx);
         });
@@ -3744,13 +3723,13 @@ mod tree_drag_move_tests {
 
     #[gpui::test]
     fn dropping_onto_its_own_current_parent_is_a_real_no_op(cx: &mut TestAppContext) {
-        let repo = TempDir::new().expect("tempdir");
+        let (_repo_dir, repo) = crate::sidebar::fixtures::temp_root();
         seed(&repo);
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.clone());
         cx.run_until_parked();
 
-        let a = repo.path().join("a.txt");
-        let root = repo.path().to_path_buf();
+        let a = repo.join("a.txt");
+        let root = repo.clone();
         let undo_len_before = app.read_with(cx, |app, _| app.tree_undo_stack.len());
         app.update(cx, |app, cx| {
             app.move_paths_into_dir(std::slice::from_ref(&a), &root, cx);
@@ -3772,16 +3751,16 @@ mod tree_drag_move_tests {
     fn dropping_a_selection_back_onto_a_sibling_file_row_in_the_same_folder_is_a_real_no_op(
         cx: &mut TestAppContext,
     ) {
-        let repo = TempDir::new().expect("tempdir");
+        let (_repo_dir, repo) = crate::sidebar::fixtures::temp_root();
         seed(&repo);
-        fs::create_dir_all(repo.path().join("src")).expect("mkdir src");
-        fs::write(repo.path().join("src/util.rs"), "// util\n").expect("write util.rs");
-        fs::write(repo.path().join("src/lib.rs"), "// lib\n").expect("write lib.rs");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        fs::create_dir_all(repo.join("src")).expect("mkdir src");
+        fs::write(repo.join("src/util.rs"), "// util\n").expect("write util.rs");
+        fs::write(repo.join("src/lib.rs"), "// lib\n").expect("write lib.rs");
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.clone());
         cx.run_until_parked();
 
-        let dragged = repo.path().join("src/util.rs");
-        let sibling_row = repo.path().join("src/lib.rs");
+        let dragged = repo.join("src/util.rs");
+        let sibling_row = repo.join("src/lib.rs");
         // What `render_file_tree_row`'s file-row `on_drop` closure really resolves the drop
         // target to when the pointer released over `sibling_row` - not `sibling_row` itself,
         // which is exactly the bug: before this fix, a file row had no drop target of its own at
@@ -3790,7 +3769,7 @@ mod tree_drag_move_tests {
             AdeApp::tree_drop_target_dir(&sibling_row, false).expect("a file always has a parent");
         assert_eq!(
             drop_target,
-            repo.path().join("src"),
+            repo.join("src"),
             "premise: dropping on a sibling file row must resolve to their shared parent, not \
              the sibling's own path"
         );
@@ -3820,36 +3799,26 @@ mod tree_drag_move_tests {
 mod tree_drop_target_dir_tests {
     use super::*;
 
+    /// A drop lands in a directory, so a directory row is its own target and a file row is its
+    /// parent - including at the root, where a file's parent is the worktree itself.
     #[test]
-    fn a_directory_entry_resolves_to_its_own_path() {
-        let dir = Path::new("/repo/src");
-        assert_eq!(
-            AdeApp::tree_drop_target_dir(dir, true),
-            Some(dir.to_path_buf())
-        );
-    }
-
-    #[test]
-    fn a_file_entry_resolves_to_its_parent_not_itself() {
-        let file = Path::new("/repo/src/main.rs");
-        assert_eq!(
-            AdeApp::tree_drop_target_dir(file, false),
-            Some(Path::new("/repo/src").to_path_buf())
-        );
-    }
-
-    #[test]
-    fn a_root_level_file_resolves_to_the_worktree_root() {
-        let file = Path::new("/repo/README.md");
-        assert_eq!(
-            AdeApp::tree_drop_target_dir(file, false),
-            Some(Path::new("/repo").to_path_buf())
-        );
+    fn a_row_resolves_to_the_directory_a_drop_would_land_in() {
+        for (entry, is_dir, target) in [
+            ("/repo/src", true, "/repo/src"),
+            ("/repo/src/main.rs", false, "/repo/src"),
+            ("/repo/README.md", false, "/repo"),
+        ] {
+            assert_eq!(
+                AdeApp::tree_drop_target_dir(Path::new(entry), is_dir),
+                Some(Path::new(target).to_path_buf()),
+                "{entry} (is_dir: {is_dir})"
+            );
+        }
     }
 }
 
 #[cfg(test)]
-mod tests {
+mod path_remap_tests {
     use super::*;
 
     #[test]

--- a/crates/app/src/status_bar/process_stats/macos.rs
+++ b/crates/app/src/status_bar/process_stats/macos.rs
@@ -219,9 +219,9 @@ mod tests {
     fn a_real_busy_child_accumulates_real_cpu_time_at_a_real_rate() {
         use std::process::{Command, Stdio};
 
-        let mut child = Command::new("yes")
-            .stdout(Stdio::null())
-            .spawn()
+        // `ChildGuard`, not a manual `kill`/`wait`: `yes` pins a core, and either `expect` below
+        // firing left it doing so for the rest of the run.
+        let mut child = test_support::ChildGuard::spawn(Command::new("yes").stdout(Stdio::null()))
             .expect("spawn a real `yes` child process");
         let pid = child.id();
 
@@ -233,8 +233,7 @@ mod tests {
             .expect("still alive on the second read");
         let wall = wall_start.elapsed();
 
-        let _ = child.kill();
-        let _ = child.wait();
+        child.kill_and_wait().expect("reap the busy child");
 
         let delta = second.saturating_sub(first);
         // A quarter of wall time is a very loose floor for a process that genuinely pins a core -

--- a/crates/app/src/status_bar/process_stats/mod.rs
+++ b/crates/app/src/status_bar/process_stats/mod.rs
@@ -449,11 +449,11 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn sample_processes_reports_real_nonzero_cpu_for_a_real_busy_child() {
-        use std::process::{Child, Command, Stdio};
+        use std::process::{Command, Stdio};
 
-        let mut child: Child = Command::new("yes")
-            .stdout(Stdio::null())
-            .spawn()
+        // `ChildGuard`, not a manual `kill`/`wait` after the sampling: `yes` pins a core, and an
+        // assertion that fired before the old teardown left it doing so for the whole run.
+        let mut child = test_support::ChildGuard::spawn(Command::new("yes").stdout(Stdio::null()))
             .expect("spawn a real `yes` child process");
         let pid = child.id();
 
@@ -461,8 +461,7 @@ mod tests {
         std::thread::sleep(Duration::from_millis(500));
         let (second, _raw) = sample_processes(&[pid], raw);
 
-        let _ = child.kill();
-        let _ = child.wait();
+        child.kill_and_wait().expect("reap the busy child");
 
         let sample = second
             .get(&pid)

--- a/crates/app/src/status_bar/render.rs
+++ b/crates/app/src/status_bar/render.rs
@@ -1022,30 +1022,17 @@ mod status_bar_deletion_tests {
 #[cfg(test)]
 mod status_bar_branch_cluster_visibility_tests {
     use crate::root::focus::palette_focus_tests;
+    use crate::test_support::{temp_repo_with, TempRoot};
     use gpui::TestAppContext;
-    use std::path::Path;
-
-    fn git(dir: &Path, args: &[&str]) {
-        let output = std::process::Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(output.status.success(), "git {args:?} failed in {dir:?}");
-    }
 
     /// A real repo on a real branch, so the cluster has genuine branch text to show rather than
     /// falling through to `"(detached)"` for want of a git repository at all. Shared with
     /// `super::resources_popover_tests`, which needs the same real worktree list.
-    pub(super) fn seeded_repo() -> tempfile::TempDir {
-        let repo = tempfile::tempdir().expect("tempdir");
-        git(repo.path(), &["init", "-b", "main"]);
-        git(repo.path(), &["config", "user.email", "test@example.com"]);
-        git(repo.path(), &["config", "user.name", "Test User"]);
-        std::fs::write(repo.path().join("a.txt"), "1").expect("write a.txt");
-        git(repo.path(), &["add", "a.txt"]);
-        git(repo.path(), &["commit", "-m", "base"]);
-        repo
+    pub(super) fn seeded_repo() -> TempRoot {
+        temp_repo_with(|root| {
+            test_support::seed_empty_repo_at(root);
+            test_support::commit(root, "a.txt", "1", "base");
+        })
     }
 
     #[gpui::test]

--- a/crates/app/src/terminal/grid.rs
+++ b/crates/app/src/terminal/grid.rs
@@ -745,7 +745,7 @@ impl TerminalGrid {
 }
 
 #[cfg(test)]
-mod tests {
+mod grid_emulation_tests {
     use super::*;
 
     fn row_text(row: &[GridCell]) -> String {
@@ -870,15 +870,10 @@ mod tests {
         assert!(row_text(&rows[0]).starts_with("SECOND"));
     }
 
-    #[test]
-    fn sgr_red_foreground_resolves_to_the_named_palette_color() {
-        let mut grid = TerminalGrid::new(2, 10);
-        grid.append_bytes(b"\x1b[31mR\x1b[0m");
-        let rows = grid.visible_rows(&TerminalPalette::default());
-        assert_eq!(rows[0][0].c, 'R');
-        assert_eq!(rows[0][0].fg, TerminalPalette::default().ansi[1]);
-    }
-
+    /// GitHub issue #208's pure half. Two renders of the *same* grid state under two different
+    /// palettes must produce two different sets of colours - which is only true because every
+    /// resolution path (unstyled default fg/bg, a named ANSI colour, and `Color::Indexed(0..=15)`)
+    /// reads the passed-in palette rather than a module constant.
     #[test]
     fn every_themeable_colour_comes_from_the_supplied_palette_not_a_hardcoded_one() {
         let mut grid = TerminalGrid::new(2, 10);
@@ -953,30 +948,20 @@ mod tests {
         assert!(rows[0][0].bold);
     }
 
+    /// A resize has to change what the emulator reports *and* what it hands the renderer - a
+    /// `dimensions()` that moved without the painted rows following it would silently paint the
+    /// old geometry.
     #[test]
-    fn resize_changes_the_visible_row_and_column_count() {
+    fn a_resize_changes_both_the_reported_dimensions_and_the_visible_rows() {
         let mut grid = TerminalGrid::new(5, 20);
+        assert_eq!(grid.dimensions(), (20, 5));
+
         grid.resize(10, 40);
+
+        assert_eq!(grid.dimensions(), (40, 10));
         let rows = grid.visible_rows(&TerminalPalette::default());
         assert_eq!(rows.len(), 10);
         assert_eq!(rows[0].len(), 40);
-    }
-
-    #[test]
-    fn clear_screen_erases_previously_written_text() {
-        let mut grid = TerminalGrid::new(5, 20);
-        grid.append_bytes(b"hello");
-        grid.append_bytes(b"\x1b[2J\x1b[1;1H");
-        let rows = grid.visible_rows(&TerminalPalette::default());
-        assert_eq!(row_text(&rows[0]).trim(), "");
-    }
-
-    #[test]
-    fn dimensions_reports_the_real_current_cols_and_rows() {
-        let mut grid = TerminalGrid::new(5, 20);
-        assert_eq!(grid.dimensions(), (20, 5));
-        grid.resize(10, 40);
-        assert_eq!(grid.dimensions(), (40, 10));
     }
 
     #[test]
@@ -1001,14 +986,6 @@ mod tests {
         // not wherever the cursor happened to be before.
         grid.append_bytes(b"X");
         assert_eq!(grid.visible_rows(&TerminalPalette::default())[0][0].c, 'X');
-    }
-
-    #[test]
-    fn mark_ended_sets_the_flag() {
-        let mut grid = TerminalGrid::new(2, 10);
-        assert!(!grid.ended);
-        grid.mark_ended();
-        assert!(grid.ended);
     }
 
     /// Pushes `count` numbered lines (`"line 0\r\n"`, `"line 1\r\n"`, ...) through a real grid -
@@ -1425,56 +1402,54 @@ mod wide_char_tests {
         row.iter().map(|cell| cell.width).collect()
     }
 
+    /// The core fact this issue rests on, straight out of real parsed UTF-8: what counts as a
+    /// double-width character and what does not. CJK ideographs and emoji occupy their own cell
+    /// plus a following spacer; `é` is multi-*byte* but single-*width*, and conflating the two
+    /// would push every accented Latin character a column to the right.
+    ///
+    /// The spacer's own `c` is checked here too: it is a literal space `alacritty_terminal` wrote
+    /// (`term/mod.rs:1127-1129`), not a copy of the character or a NUL - which is precisely why
+    /// painting it used to insert a stray blank column after every wide glyph. Pinned so a future
+    /// dependency bump that changed it can't silently invalidate the renderer's assumption.
     #[test]
-    fn a_cjk_character_is_a_wide_cell_followed_by_a_spacer_cell() {
-        let mut grid = TerminalGrid::new(2, 10);
-        grid.append_bytes("你好X".as_bytes());
-        let rows = grid.visible_rows(&TerminalPalette::default());
+    fn real_utf8_is_labelled_wide_or_narrow_by_its_real_column_width() {
+        let wide = || vec![CellWidth::Wide, CellWidth::Spacer];
+        for (text, chars, expected) in [
+            (
+                "你好X",
+                vec!['你', '好', 'X'],
+                [wide(), wide(), vec![CellWidth::Narrow]].concat(),
+            ),
+            // `🎉` (U+1F389) is a real 4-byte sequence `unicode-width` reports as two columns.
+            (
+                "🎉ok",
+                vec!['🎉', 'o', 'k'],
+                [wide(), vec![CellWidth::Narrow; 2]].concat(),
+            ),
+            ("éa", vec!['é', 'a'], vec![CellWidth::Narrow; 2]),
+        ] {
+            let mut grid = TerminalGrid::new(2, 10);
+            grid.append_bytes(text.as_bytes());
+            let rows = grid.visible_rows(&TerminalPalette::default());
 
-        assert_eq!(rows[0][0].c, '你');
-        assert_eq!(rows[0][2].c, '好');
-        assert_eq!(rows[0][4].c, 'X');
-        assert_eq!(
-            widths(&rows[0][..5]),
-            vec![
-                CellWidth::Wide,
-                CellWidth::Spacer,
-                CellWidth::Wide,
-                CellWidth::Spacer,
-                CellWidth::Narrow,
-            ],
-        );
-    }
-
-    #[test]
-    fn the_spacer_cell_really_holds_a_plain_space_of_its_own() {
-        let mut grid = TerminalGrid::new(2, 10);
-        grid.append_bytes("好".as_bytes());
-        let rows = grid.visible_rows(&TerminalPalette::default());
-        assert_eq!(rows[0][1].c, ' ');
-        assert_eq!(rows[0][1].width, CellWidth::Spacer);
-    }
-
-    #[test]
-    fn an_emoji_is_a_wide_cell_too() {
-        let mut grid = TerminalGrid::new(2, 10);
-        grid.append_bytes("🎉ok".as_bytes());
-        let rows = grid.visible_rows(&TerminalPalette::default());
-
-        assert_eq!(rows[0][0].c, '🎉');
-        assert_eq!(rows[0][0].width, CellWidth::Wide);
-        assert_eq!(rows[0][1].width, CellWidth::Spacer);
-        assert_eq!(rows[0][2].c, 'o');
-        assert_eq!(rows[0][2].width, CellWidth::Narrow);
-    }
-
-    #[test]
-    fn a_multi_byte_but_single_width_character_stays_narrow() {
-        let mut grid = TerminalGrid::new(2, 10);
-        grid.append_bytes("éa".as_bytes());
-        let rows = grid.visible_rows(&TerminalPalette::default());
-        assert_eq!(rows[0][0].c, 'é');
-        assert_eq!(widths(&rows[0][..2]), vec![CellWidth::Narrow; 2]);
+            assert_eq!(
+                widths(&rows[0][..expected.len()]),
+                expected,
+                "cell widths for {text:?}"
+            );
+            let painted: Vec<char> = rows[0][..expected.len()]
+                .iter()
+                .zip(&expected)
+                .filter(|(_, width)| **width != CellWidth::Spacer)
+                .map(|(cell, _)| cell.c)
+                .collect();
+            assert_eq!(painted, chars, "characters for {text:?}");
+            for (cell, width) in rows[0].iter().zip(&expected) {
+                if *width == CellWidth::Spacer {
+                    assert_eq!(cell.c, ' ', "a spacer cell holds a plain space of its own");
+                }
+            }
+        }
     }
 
     #[test]
@@ -1561,8 +1536,10 @@ mod selection_tests {
         }
     }
 
+    /// Every way a gesture can end up selecting nothing worth copying - none of which may
+    /// overwrite the clipboard with an empty string or a stray character.
     #[test]
-    fn nothing_is_selected_until_a_selection_is_actually_dragged() {
+    fn nothing_worth_copying_is_never_reported_as_a_selection() {
         let mut grid = TerminalGrid::new(5, 20);
         grid.append_bytes(b"hello world");
         assert_eq!(grid.selected_text(), None, "no selection has been anchored");
@@ -1575,6 +1552,15 @@ mod selection_tests {
             None,
             "an anchored-but-never-dragged selection must not put a stray character on the \
              clipboard"
+        );
+
+        // A real drag, but across rows that have nothing on them at all.
+        grid.start_selection(left(2, 0));
+        grid.update_selection(right(2, 15));
+        assert_eq!(
+            grid.selected_text(),
+            None,
+            "an all-blank span must not overwrite the clipboard with an empty string"
         );
     }
 
@@ -1646,22 +1632,21 @@ mod selection_tests {
         assert_eq!(grid.selected_text(), None);
     }
 
-    #[test]
-    fn a_drag_across_blank_screen_selects_nothing_worth_copying() {
-        let mut grid = TerminalGrid::new(5, 20);
-        grid.start_selection(left(2, 0));
-        grid.update_selection(right(2, 15));
-        assert_eq!(
-            grid.selected_text(),
-            None,
-            "an all-blank span must not overwrite the clipboard with an empty string"
-        );
-    }
-
+    /// The selection has to be *visible*, not just readable - a `GridCell` that never carried
+    /// the flag would leave the renderer with nothing to paint, so a user dragging across the
+    /// terminal would see no feedback at all.
     #[test]
     fn selected_cells_are_flagged_for_the_renderer() {
         let mut grid = TerminalGrid::new(5, 20);
         grid.append_bytes(b"hello world");
+        assert!(
+            grid.visible_rows(&TerminalPalette::default())
+                .iter()
+                .flatten()
+                .all(|cell| !cell.selected),
+            "sanity check: with no selection anchored, no cell carries the flag"
+        );
+
         grid.start_selection(left(0, 6));
         grid.update_selection(right(0, 10));
 
@@ -1678,14 +1663,11 @@ mod selection_tests {
         );
     }
 
-    #[test]
-    fn no_selection_means_no_cell_is_flagged() {
-        let mut grid = TerminalGrid::new(5, 20);
-        grid.append_bytes(b"hello world");
-        let rows = grid.visible_rows(&TerminalPalette::default());
-        assert!(rows.iter().flatten().all(|cell| !cell.selected));
-    }
-
+    /// A wide character's *trailing spacer* column is genuinely part of the selection as far as
+    /// `alacritty_terminal` is concerned, but the copied text must still contain the character
+    /// exactly once - `Term::line_to_string` skips spacer cells (`term/mod.rs:605`). Proves
+    /// [`GridCell::width`] didn't have to teach the clipboard anything: dragging over the second
+    /// half of `好` copies `好`, not `好 `.
     #[test]
     fn selecting_a_wide_character_copies_it_once_not_once_plus_its_spacer() {
         let mut grid = TerminalGrid::new(5, 20);

--- a/crates/app/src/terminal/links.rs
+++ b/crates/app/src/terminal/links.rs
@@ -128,38 +128,54 @@ pub fn resolve(cwd: &Path, path: &str) -> PathBuf {
 }
 
 #[cfg(test)]
-mod tests {
+mod link_detection_tests {
     use super::*;
 
+    /// Every real shape of file reference this app is expected to turn into a clickable link,
+    /// against the one thing that matters about each: which path, which line, which column.
+    /// A backtrace frame (`at src/main.rs:142:9`) needs no special-casing - it is structurally
+    /// just another `path:line:col` occurrence, which is why it sits in the same table.
     #[test]
-    fn detects_a_real_cargo_style_path_line_col_reference() {
-        let matches = find_links("src/main.rs:42:10");
-        assert_eq!(matches.len(), 1);
-        assert_eq!(matches[0].path, "src/main.rs");
-        assert_eq!(matches[0].line, Some(42));
-        assert_eq!(matches[0].column, Some(10));
-        assert_eq!(matches[0].start, 0);
-        assert_eq!(matches[0].end, "src/main.rs:42:10".chars().count());
-    }
-
-    #[test]
-    fn detects_a_real_cargo_diagnostic_arrow_line_with_a_leading_prefix() {
-        let text = "  --> src/lib.rs:12:5";
-        let matches = find_links(text);
-        assert_eq!(matches.len(), 1);
-        assert_eq!(matches[0].path, "src/lib.rs");
-        assert_eq!(matches[0].line, Some(12));
-        assert_eq!(matches[0].column, Some(5));
-        assert_eq!(matches[0].start, text.find("src/lib.rs").unwrap());
-    }
-
-    #[test]
-    fn a_line_number_with_no_column_is_a_real_partial_match_not_a_whole_line_style() {
-        let matches = find_links("thread panicked at tests/upload.rs:88");
-        assert_eq!(matches.len(), 1);
-        assert_eq!(matches[0].path, "tests/upload.rs");
-        assert_eq!(matches[0].line, Some(88));
-        assert_eq!(matches[0].column, None);
+    fn every_real_shape_of_file_reference_resolves_to_its_own_path_line_and_column() {
+        for (text, path, line, column) in [
+            ("src/main.rs:42:10", "src/main.rs", Some(42), Some(10)),
+            ("  --> src/lib.rs:12:5", "src/lib.rs", Some(12), Some(5)),
+            (
+                "   3: my_crate::do_thing\n             at src/main.rs:142:9",
+                "src/main.rs",
+                Some(142),
+                Some(9),
+            ),
+            (
+                "thread panicked at tests/upload.rs:88",
+                "tests/upload.rs",
+                Some(88),
+                None,
+            ),
+            (" M Cargo.toml", "Cargo.toml", None, None),
+            (
+                " A src/db/query_builder.rs",
+                "src/db/query_builder.rs",
+                None,
+                None,
+            ),
+            // `:0` is a real, if unusual, shape terminal output can contain, and must never flow
+            // through as a real one-based line target.
+            ("foo.rs:0", "foo.rs", None, None),
+        ] {
+            let matches = find_links(text);
+            assert_eq!(matches.len(), 1, "expected exactly one link in {text:?}");
+            assert_eq!(matches[0].path, path, "path in {text:?}");
+            assert_eq!(matches[0].line, line, "line in {text:?}");
+            assert_eq!(matches[0].column, column, "column in {text:?}");
+            // The link starts where the real path begins, not at whatever prefix precedes it.
+            let start_char = text.char_indices().nth(matches[0].start).map(|(i, _)| i);
+            assert_eq!(
+                start_char,
+                text.find(path),
+                "the link span must begin at the path itself in {text:?}"
+            );
+        }
     }
 
     #[test]
@@ -178,40 +194,6 @@ mod tests {
     }
 
     #[test]
-    fn a_bare_repo_root_filename_with_a_known_extension_is_a_real_link() {
-        let matches = find_links(" M Cargo.toml");
-        assert_eq!(matches.len(), 1);
-        assert_eq!(matches[0].path, "Cargo.toml");
-        assert_eq!(matches[0].line, None);
-    }
-
-    #[test]
-    fn a_multi_segment_path_with_no_line_number_is_still_a_real_link() {
-        let matches = find_links(" A src/db/query_builder.rs");
-        assert_eq!(matches.len(), 1);
-        assert_eq!(matches[0].path, "src/db/query_builder.rs");
-        assert_eq!(matches[0].line, None);
-    }
-
-    #[test]
-    fn ordinary_prose_with_dots_but_no_real_extension_is_never_linked() {
-        for line in [
-            "e.g. this failed",
-            "see v0.14.0 for details",
-            "p = 0.00 < 0.05",
-            "left: 5242880",
-            "scan/baseline           time:   [41.203 ms 41.878 ms 42.611 ms]",
-            "Compiling jerry-db v0.14.0 (~/.jerry/wt/index-scan)",
-        ] {
-            assert!(
-                find_links(line).is_empty(),
-                "expected no link in {line:?}, got {:?}",
-                find_links(line)
-            );
-        }
-    }
-
-    #[test]
     fn multiple_links_on_one_line_are_all_detected_left_to_right() {
         let matches = find_links("see src/a.rs:1 and src/b.rs:2 both");
         assert_eq!(matches.len(), 2);
@@ -222,64 +204,20 @@ mod tests {
         assert!(matches[0].end <= matches[1].start);
     }
 
-    #[test]
-    fn a_real_backtrace_frame_is_detected_like_any_other_path_line_col_reference() {
-        let matches = find_links("   3: my_crate::do_thing\n             at src/main.rs:142:9");
-        assert_eq!(matches.len(), 1);
-        assert_eq!(matches[0].path, "src/main.rs");
-        assert_eq!(matches[0].line, Some(142));
-        assert_eq!(matches[0].column, Some(9));
-    }
-
-    #[test]
-    fn resolve_joins_a_relative_path_onto_the_given_cwd() {
-        let cwd = Path::new("/home/colin/wt/feature");
-        assert_eq!(
-            resolve(cwd, "src/main.rs"),
-            PathBuf::from("/home/colin/wt/feature/src/main.rs")
-        );
-    }
-
-    #[test]
-    fn resolve_leaves_an_absolute_path_untouched() {
-        let cwd = Path::new("/home/colin/wt/feature");
-        assert_eq!(resolve(cwd, "/etc/hosts"), PathBuf::from("/etc/hosts"));
-    }
-
-    #[test]
-    fn resolve_normalizes_dot_dot_segments_and_deliberately_allows_escaping_cwd() {
-        let cwd = Path::new("/home/colin/wt/feature");
-        assert_eq!(
-            resolve(cwd, "../../../etc/shadow.conf"),
-            PathBuf::from("/home/etc/shadow.conf"),
-            "`..` segments must be collapsed into a real path with no literal `..` left in it"
-        );
-    }
-
-    #[test]
-    fn resolve_normalizes_a_dot_dot_that_would_otherwise_go_above_the_root() {
-        let cwd = Path::new("/home");
-        assert_eq!(
-            resolve(cwd, "../../../etc/passwd"),
-            PathBuf::from("/etc/passwd"),
-            "a `..` with nowhere left to pop (already at the real filesystem root) must be \
-             dropped, not underflow into something nonsensical"
-        );
-    }
-
-    #[test]
-    fn a_url_in_real_cargo_output_is_never_detected_as_a_link() {
-        let text = "see https://doc.rust-lang.org/cargo/reference/manifest.html for more";
-        assert!(
-            find_links(text).is_empty(),
-            "expected no link in {text:?}, got {:?}",
-            find_links(text)
-        );
-    }
-
+    /// The false positives found by probing the production regex against realistic terminal
+    /// output. A URL is the sharpest of them: mod-clicking one used to resolve to a nonexistent
+    /// absolute path (`/doc.rust-lang.org/...`), because the old regex's leading `/?`
+    /// alternation latched onto the second slash of `://`.
     #[test]
     fn realistic_non_path_output_never_produces_a_false_link() {
         for line in [
+            "e.g. this failed",
+            "see v0.14.0 for details",
+            "p = 0.00 < 0.05",
+            "left: 5242880",
+            "scan/baseline           time:   [41.203 ms 41.878 ms 42.611 ms]",
+            "Compiling jerry-db v0.14.0 (~/.jerry/wt/index-scan)",
+            "see https://doc.rust-lang.org/cargo/reference/manifest.html for more",
             // An SSH-style git remote: before the fix, this matched a fake `github.c` (`"c"`
             // is a known bare extension) *and* a fake `foo/bar.git`.
             "$ git clone git@github.com:foo/bar.git",
@@ -287,8 +225,7 @@ mod tests {
             // *any* extension, so `12.5/100.0` looked exactly like `path/file.ext`.
             "12.5/100.0 MB downloaded",
             "the answer is 42/7.0 approx",
-            // A URL whose host:port looks path-shaped once the scheme/host prefix is ignored -
-            // covered by the same URL rejection as the `doc.rust-lang.org` case above.
+            // A URL whose host:port looks path-shaped once the scheme/host prefix is ignored.
             "curl http://127.0.0.1:8080/api/v1/health.json",
         ] {
             assert!(
@@ -300,13 +237,26 @@ mod tests {
     }
 
     #[test]
-    fn a_captured_line_number_of_zero_is_treated_as_no_line() {
-        let matches = find_links("foo.rs:0");
-        assert_eq!(matches.len(), 1);
-        assert_eq!(matches[0].path, "foo.rs");
-        assert_eq!(
-            matches[0].line, None,
-            "a captured `:0` must never pass through as a real one-based line target"
-        );
+    fn resolve_produces_a_real_absolute_path_with_no_dot_dot_left_in_it() {
+        for (cwd, path, expected) in [
+            (
+                "/home/colin/wt/feature",
+                "src/main.rs",
+                "/home/colin/wt/feature/src/main.rs",
+            ),
+            ("/home/colin/wt/feature", "/etc/hosts", "/etc/hosts"),
+            (
+                "/home/colin/wt/feature",
+                "../../../etc/shadow.conf",
+                "/home/etc/shadow.conf",
+            ),
+            ("/home", "../../../etc/passwd", "/etc/passwd"),
+        ] {
+            assert_eq!(
+                resolve(Path::new(cwd), path),
+                PathBuf::from(expected),
+                "resolving {path:?} against {cwd:?}"
+            );
+        }
     }
 }

--- a/crates/app/src/terminal/osc.rs
+++ b/crates/app/src/terminal/osc.rs
@@ -157,7 +157,7 @@ impl OscWatcher {
 }
 
 #[cfg(test)]
-mod tests {
+mod osc_signal_tests {
     use super::*;
 
     fn watch(bytes: &[u8]) -> OscWatcher {
@@ -166,76 +166,80 @@ mod tests {
         watcher
     }
 
+    /// Every real spelling of "the agent wants the human", and the near-misses that share its
+    /// prefix. OSC can be terminated by BEL *or* by ST (`ESC \`) - real senders use both - and
+    /// OSC 777 carries non-notification sub-commands only one of which is an attention request.
     #[test]
-    fn a_bare_osc_9_notification_pings_for_attention_once() {
-        let mut watcher = watch(b"\x1b]9;Claude needs your permission\x07");
-        assert!(watcher.take_attention_ping());
-        assert!(
-            !watcher.take_attention_ping(),
-            "the ping is a point-in-time event and must not re-fire on a second read"
-        );
+    fn only_a_real_attention_request_pings_and_it_pings_exactly_once() {
+        for (bytes, expected) in [
+            (b"\x1b]9;Claude needs your permission\x07".as_slice(), true),
+            (b"\x1b]9;done\x1b\\".as_slice(), true),
+            (
+                b"\x1b]777;notify;Gemini;waiting on you\x07".as_slice(),
+                true,
+            ),
+            (b"\x1b]777;precmd;0\x07".as_slice(), false),
+            (b"\x1b]9\x07".as_slice(), false),
+            (b"\x1b]9;4;1;42\x07".as_slice(), false),
+        ] {
+            let mut watcher = watch(bytes);
+            assert_eq!(
+                watcher.take_attention_ping(),
+                expected,
+                "{bytes:?} must {}ping for attention",
+                if expected { "" } else { "not " }
+            );
+            assert!(
+                !watcher.take_attention_ping(),
+                "the ping is a point-in-time event and must not re-fire on a second read"
+            );
+        }
     }
 
+    /// The OSC 9;4 progress vocabulary, whole: each documented state, the percentage rules, and
+    /// the reports that define no progress at all.
     #[test]
-    fn an_st_terminated_osc_9_also_pings() {
-        let mut watcher = watch(b"\x1b]9;done\x1b\\");
-        assert!(watcher.take_attention_ping());
-    }
-
-    #[test]
-    fn osc_777_notify_pings_but_other_777_subcommands_do_not() {
-        let mut watcher = watch(b"\x1b]777;notify;Gemini;waiting on you\x07");
-        assert!(watcher.take_attention_ping());
-
-        let mut watcher = watch(b"\x1b]777;precmd;0\x07");
-        assert!(
-            !watcher.take_attention_ping(),
-            "OSC 777 has non-notification sub-commands; only `notify` is an attention request"
-        );
-    }
-
-    #[test]
-    fn osc_9_4_is_progress_not_a_notification() {
-        let mut watcher = watch(b"\x1b]9;4;1;42\x07");
-        assert_eq!(
-            watcher.progress(),
+    fn every_progress_report_parses_to_its_documented_meaning() {
+        let normal = |percent| {
             Some(Progress {
                 state: ProgressState::Normal,
-                percent: Some(42)
+                percent,
             })
-        );
-        assert!(
-            !watcher.take_attention_ping(),
-            "a progress report is not a request for the human's attention"
-        );
-    }
-
-    #[test]
-    fn every_progress_state_parses_to_its_documented_meaning() {
-        assert_eq!(watch(b"\x1b]9;4;0;0\x07").progress(), None);
-        assert_eq!(
-            watch(b"\x1b]9;4;2;80\x07").progress(),
-            Some(Progress {
-                state: ProgressState::Error,
-                percent: Some(80)
-            })
-        );
-        assert_eq!(
-            watch(b"\x1b]9;4;3;0\x07").progress(),
-            Some(Progress {
-                state: ProgressState::Indeterminate,
-                percent: None
-            }),
-            "indeterminate defines no percentage - reporting the sender's filler 0 as \"0% done\" \
-             would be inventing a fact"
-        );
-        assert_eq!(
-            watch(b"\x1b]9;4;4;33\x07").progress(),
-            Some(Progress {
-                state: ProgressState::Paused,
-                percent: Some(33)
-            })
-        );
+        };
+        for (bytes, expected) in [
+            (b"\x1b]9;4;1;42\x07".as_slice(), normal(Some(42))),
+            // Clamped, and an unparseable percentage is absent rather than zero.
+            (b"\x1b]9;4;1;999\x07".as_slice(), normal(Some(100))),
+            (b"\x1b]9;4;1;abc\x07".as_slice(), normal(None)),
+            (
+                b"\x1b]9;4;2;80\x07".as_slice(),
+                Some(Progress {
+                    state: ProgressState::Error,
+                    percent: Some(80),
+                }),
+            ),
+            // Indeterminate defines no percentage - reporting the sender's filler 0 as "0% done"
+            // would be inventing a fact.
+            (
+                b"\x1b]9;4;3;0\x07".as_slice(),
+                Some(Progress {
+                    state: ProgressState::Indeterminate,
+                    percent: None,
+                }),
+            ),
+            (
+                b"\x1b]9;4;4;33\x07".as_slice(),
+                Some(Progress {
+                    state: ProgressState::Paused,
+                    percent: Some(33),
+                }),
+            ),
+            (b"\x1b]9;4;0;0\x07".as_slice(), None),
+            (b"\x1b]9;4;7;50\x07".as_slice(), None),
+            (b"\x1b]9;4\x07".as_slice(), None),
+        ] {
+            assert_eq!(watch(bytes).progress(), expected, "parsing {bytes:?}");
+        }
     }
 
     #[test]
@@ -246,40 +250,17 @@ mod tests {
         assert!(!ProgressState::Paused.is_active());
     }
 
+    /// Progress is live state, not an append-only log: a later report replaces an earlier one,
+    /// and a clear report really clears it.
     #[test]
-    fn a_clear_report_clears_an_earlier_progress() {
-        let mut watcher = OscWatcher::default();
-        watcher.feed(b"\x1b]9;4;1;50\x07");
-        assert!(watcher.progress().is_some());
-        watcher.feed(b"\x1b]9;4;0\x07");
-        assert_eq!(watcher.progress(), None);
-    }
-
-    #[test]
-    fn a_later_progress_report_supersedes_an_earlier_one() {
+    fn a_later_progress_report_supersedes_an_earlier_one_and_a_clear_wipes_it() {
         let mut watcher = OscWatcher::default();
         watcher.feed(b"\x1b]9;4;1;10\x07");
         watcher.feed(b"\x1b]9;4;1;90\x07");
         assert_eq!(watcher.progress().and_then(|p| p.percent), Some(90));
-    }
 
-    #[test]
-    fn a_percentage_above_100_is_clamped_and_a_junk_one_is_dropped() {
-        assert_eq!(
-            watch(b"\x1b]9;4;1;999\x07").progress().unwrap().percent,
-            Some(100)
-        );
-        assert_eq!(
-            watch(b"\x1b]9;4;1;abc\x07").progress().unwrap().percent,
-            None,
-            "an unparseable percentage is absent, not zero"
-        );
-    }
-
-    #[test]
-    fn an_out_of_range_progress_state_is_ignored_entirely() {
-        assert_eq!(watch(b"\x1b]9;4;7;50\x07").progress(), None);
-        assert_eq!(watch(b"\x1b]9;4\x07").progress(), None);
+        watcher.feed(b"\x1b]9;4;0\x07");
+        assert_eq!(watcher.progress(), None);
     }
 
     #[test]
@@ -307,11 +288,5 @@ mod tests {
             watcher.feed(chunk);
         }
         assert_eq!(watcher.progress().and_then(|p| p.percent), Some(77));
-    }
-
-    #[test]
-    fn a_bare_osc_9_with_no_message_is_not_a_notification() {
-        let mut watcher = watch(b"\x1b]9\x07");
-        assert!(!watcher.take_attention_ping());
     }
 }

--- a/crates/app/src/terminal/pane.rs
+++ b/crates/app/src/terminal/pane.rs
@@ -259,19 +259,29 @@ fn configured_shell_program(configured: Option<&str>) -> Option<PathBuf> {
 mod shell_program_tests {
     use super::*;
 
+    /// Both platform variants' own decisions, side by side. The Windows row is GitHub issue
+    /// #50's actual regression: the fallback must be a real Windows path (`cmd.exe`), never the
+    /// Unix `/bin/bash` this crate used to fall back to unconditionally - `$SHELL` is a Unix-only
+    /// convention Windows never sets, so every Windows session with no override was trying to
+    /// launch a Unix path that does not exist there at all.
     #[test]
-    fn a_real_env_value_is_used_verbatim() {
+    fn an_env_value_is_used_verbatim_and_an_absent_one_falls_back_per_platform() {
         assert_eq!(
             shell_program_from_env(Some(std::ffi::OsString::from("/usr/bin/zsh")), "/bin/bash"),
             PathBuf::from("/usr/bin/zsh")
         );
-    }
-
-    #[test]
-    fn an_absent_env_value_falls_back() {
         assert_eq!(
             shell_program_from_env(None, "/bin/bash"),
             PathBuf::from("/bin/bash")
+        );
+
+        let windows_fallback = shell_program_from_env(None, "cmd.exe");
+        assert_eq!(windows_fallback, PathBuf::from("cmd.exe"));
+        assert_ne!(
+            windows_fallback,
+            PathBuf::from("/bin/bash"),
+            "the Windows default shell must never be the Unix path - that real path does not \
+             exist on Windows, which is the whole bug GitHub issue #50 reports"
         );
     }
 
@@ -303,20 +313,22 @@ mod shell_program_tests {
     }
 
     #[test]
-    fn no_configured_shell_is_byte_for_byte_the_previous_os_default() {
+    fn a_configured_shell_is_trimmed_and_a_nameless_one_falls_back_to_the_os_default() {
         let cwd = std::env::temp_dir();
         let os_default = TerminalSpec::default_shell_program();
 
-        assert_eq!(TerminalSpec::shell(cwd.clone(), None).program, os_default);
+        for configured in [None, Some(""), Some("   ")] {
+            assert_eq!(
+                TerminalSpec::shell(cwd.clone(), configured).program,
+                os_default,
+                "{configured:?} names no real program, so it means 'use the system default'"
+            );
+            assert_eq!(configured_shell_program(configured), None);
+        }
+
         assert_eq!(
-            TerminalSpec::shell(cwd.clone(), Some("")).program,
-            os_default,
-            "an empty setting means 'use the system default', not a program with no name"
-        );
-        assert_eq!(
-            TerminalSpec::shell(cwd, Some("   ")).program,
-            os_default,
-            "a whitespace-only setting must fall back too, never spawn a program named ' '"
+            configured_shell_program(Some("  zsh  ")),
+            Some(PathBuf::from("zsh"))
         );
     }
 
@@ -346,28 +358,6 @@ mod shell_program_tests {
             ),
             Ok(_) => panic!("a shell that doesn't exist must not spawn"),
         }
-    }
-
-    #[test]
-    fn a_configured_shell_is_trimmed_before_it_becomes_a_program() {
-        assert_eq!(
-            configured_shell_program(Some("  zsh  ")),
-            Some(PathBuf::from("zsh"))
-        );
-        assert_eq!(configured_shell_program(None), None);
-        assert_eq!(configured_shell_program(Some(" ")), None);
-    }
-
-    #[test]
-    fn the_windows_fallback_is_a_real_windows_path_not_the_unix_one() {
-        let windows_fallback = shell_program_from_env(None, "cmd.exe");
-        assert_eq!(windows_fallback, PathBuf::from("cmd.exe"));
-        assert_ne!(
-            windows_fallback,
-            PathBuf::from("/bin/bash"),
-            "the Windows default shell must never be the Unix path - that real path does not \
-             exist on Windows, which is the whole bug this issue reports"
-        );
     }
 }
 
@@ -2589,8 +2579,124 @@ impl Render for TerminalPane {
     }
 }
 
+/// Shared fixtures for the test modules below that drive a **real** child process on a **real**
+/// pty. Everything here exists because those two clocks are genuinely different: the poll loop's
+/// ticks are driven by GPUI's simulated executor clock, while the pty reader is an ordinary OS
+/// thread that only makes progress in real wall-clock time. A loop that advanced only the virtual
+/// clock would race ahead of the reader; a fixed `thread::sleep` would be simultaneously too
+/// short under load and dead time when idle. `test_support::wait_until`/`stays_false` are the
+/// workspace's one sanctioned wall-clock wait (`docs/testing.md`), so both clocks advance
+/// together, one poll at a time.
+#[cfg(test)]
+mod pty_pane_fixtures {
+    use super::{TerminalPane, TerminalSpec, POLL_INTERVAL, ROW_FONT_SIZE_PX};
+    use gpui::{AppContext, Entity, TestAppContext};
+    use std::time::Duration;
+
+    /// How long a real pty round trip is given before a test calls it a failure. Generous: it has
+    /// to survive a full-suite run where dozens of other tests' own child processes are competing
+    /// for the same cores.
+    pub(super) const PTY_ROUND_TRIP: Duration = Duration::from_secs(30);
+
+    /// A pane backed by a real child process, spawned and settled.
+    pub(super) fn spawn_pane(
+        cx: &mut TestAppContext,
+        program: &str,
+        args: &[&str],
+    ) -> Entity<TerminalPane> {
+        let pane = cx.new(|cx| {
+            TerminalPane::new(
+                TerminalSpec::command(
+                    program,
+                    args.iter().map(|arg| arg.to_string()).collect(),
+                    std::env::temp_dir(),
+                ),
+                ROW_FONT_SIZE_PX,
+                cx,
+            )
+        });
+        cx.run_until_parked();
+        pane
+    }
+
+    /// Drives real poll ticks until `done` holds, or until [`PTY_ROUND_TRIP`] elapses.
+    pub(super) fn pump_until(
+        cx: &mut TestAppContext,
+        mut done: impl FnMut(&mut TestAppContext) -> bool,
+    ) -> bool {
+        cx.run_until_parked();
+        test_support::wait_until(PTY_ROUND_TRIP, || {
+            cx.background_executor.advance_clock(POLL_INTERVAL);
+            cx.run_until_parked();
+            done(cx)
+        })
+    }
+
+    /// The inverse: drives real poll ticks for `window` and reports whether `unwanted` stayed
+    /// false throughout - for proving something genuinely never reaches the child, rather than
+    /// merely being slow to arrive.
+    pub(super) fn stays_absent(
+        cx: &mut TestAppContext,
+        window: Duration,
+        mut unwanted: impl FnMut(&mut TestAppContext) -> bool,
+    ) -> bool {
+        cx.run_until_parked();
+        test_support::stays_false(window, || {
+            cx.background_executor.advance_clock(POLL_INTERVAL);
+            cx.run_until_parked();
+            unwanted(cx)
+        })
+    }
+
+    /// Drops `pane` and makes GPUI actually release it, killing its real child process tree.
+    ///
+    /// **Every test in this file that spawns a real pty must end with this.** GPUI releases an
+    /// entity whose last handle was dropped during `flush_effects`, which only runs inside an app
+    /// update - letting the `Entity` fall out of scope at the end of a test body does not trigger
+    /// one, and `run_until_parked` does not either. Until it happens the pane's `PtySession` is
+    /// still alive, so `PtySession::drop`'s process-tree teardown has not run and the child (and
+    /// anything it spawned) keeps running for the rest of the test *binary's* life.
+    ///
+    /// That is not a theoretical hazard: sampled every 100ms during a single-process
+    /// `cargo test -p app --lib terminal::` run before this existed, this module alone held **29
+    /// live children at once**. GitHub issue #427 counted 509 across all of `crates/app`. It does
+    /// not show up in a before/after `ps` diff, because the moment the test binary exits, the pty
+    /// master fd closes and the kernel SIGHUPs each pty's foreground process group - so the
+    /// evidence is only visible while the run is in flight.
+    ///
+    /// `pane_teardown_tests` pins the underlying property this relies on.
+    pub(super) fn release(cx: &mut TestAppContext, pane: Entity<TerminalPane>) {
+        drop(pane);
+        // A pane built with `add_window_view` is the window's *root view*, so the window holds a
+        // strong handle of its own and dropping the test's is not enough. Closing the test's
+        // windows here rather than asking each caller to is deliberate: `release` is the last
+        // statement of a test either way, and a helper that silently worked for `cx.new` panes
+        // and silently did nothing for windowed ones is exactly the kind of half-teardown this
+        // whole fixture exists to stop.
+        for window in cx.windows() {
+            let _ = window.update(cx, |_, window, _| window.remove_window());
+        }
+        cx.update(|_cx| {});
+        cx.run_until_parked();
+    }
+
+    /// Whether any visible grid row contains `needle`.
+    pub(super) fn grid_shows(
+        cx: &mut TestAppContext,
+        pane: &Entity<TerminalPane>,
+        needle: &str,
+    ) -> bool {
+        pane.read_with(cx, |pane, _| {
+            pane.visible_text_lines()
+                .iter()
+                .any(|line| line.contains(needle))
+        })
+    }
+}
+
 #[cfg(test)]
 mod cadence_tests {
+    use super::pty_pane_fixtures::{grid_shows, pump_until, release, spawn_pane};
     use super::*;
     use gpui::TestAppContext;
 
@@ -2598,14 +2704,7 @@ mod cadence_tests {
     fn a_background_pane_drains_on_the_background_interval_read_fresh_each_tick(
         cx: &mut TestAppContext,
     ) {
-        let pane = cx.new(|cx| {
-            TerminalPane::new(
-                TerminalSpec::command("cat", Vec::new(), std::env::temp_dir()),
-                ROW_FONT_SIZE_PX,
-                cx,
-            )
-        });
-        cx.run_until_parked();
+        let pane = spawn_pane(cx, "cat", &[]);
 
         // Fire the loop's first (foreground-armed) tick, demote the pane, then fire one more
         // tick so the demotion is picked up and a BACKGROUND_POLL_INTERVAL sleep is armed.
@@ -2615,65 +2714,42 @@ mod cadence_tests {
         cx.background_executor.advance_clock(POLL_INTERVAL);
         cx.run_until_parked();
 
-        // Ctrl-L; the pty's ECHOCTL echo ("^L", see
-        // `clear_with_a_live_session_sends_a_real_ctrl_l_the_pty_echoes_back`) lands in the
-        // output channel within real milliseconds - sleep long enough that it is certainly
-        // sitting there before any virtual time passes.
+        // Ctrl-L; the pty's ECHOCTL echo is "^L" (see
+        // `clear_with_a_live_session_sends_a_real_ctrl_l_the_pty_echoes_back`).
         pane.update(cx, |pane, cx| pane.clear(cx));
-        std::thread::sleep(Duration::from_millis(400));
 
-        // Three foreground-sized steps: 24ms of virtual time, less than one 33ms background
-        // tick - a correctly-backgrounded pane must not have drained the echo yet.
-        for _ in 0..3 {
-            cx.background_executor.advance_clock(POLL_INTERVAL);
-            cx.run_until_parked();
-        }
-        let lines = pane.read_with(cx, |pane, _| pane.visible_text_lines());
+        // Advance one *foreground*-sized step at a time, counting how much simulated time it
+        // took for the echo to appear. A loop that hoisted `is_foreground` out and kept the
+        // spawn-time `true` would drain it on the very next 8ms tick; one that re-reads the flag
+        // cannot drain before its 33ms background timer next fires, whenever the echo arrives.
+        let mut virtual_elapsed = Duration::ZERO;
         assert!(
-            !lines.iter().any(|line| line.contains("^L")),
-            "a background pane drained pty output in under one BACKGROUND_POLL_INTERVAL - \
-             the poll loop is not reading the live foreground flag each tick"
-        );
-
-        // Past the background interval the echo must drain normally (bounded tick loop, as in
-        // the ctrl-l test above, since exactly which tick isn't under test).
-        let mut saw_caret_l = false;
-        for _ in 0..50 {
-            cx.background_executor
-                .advance_clock(BACKGROUND_POLL_INTERVAL);
-            cx.run_until_parked();
-            let lines = pane.read_with(cx, |pane, _| pane.visible_text_lines());
-            if lines.iter().any(|line| line.contains("^L")) {
-                saw_caret_l = true;
-                break;
-            }
-        }
-        assert!(
-            saw_caret_l,
+            test_support::wait_until(super::pty_pane_fixtures::PTY_ROUND_TRIP, || {
+                cx.background_executor.advance_clock(POLL_INTERVAL);
+                cx.run_until_parked();
+                virtual_elapsed += POLL_INTERVAL;
+                grid_shows(cx, &pane, "^L")
+            }),
             "the background cadence must still drain output - coarser, not never"
         );
+        assert!(
+            virtual_elapsed >= BACKGROUND_POLL_INTERVAL,
+            "a background pane drained pty output after only {virtual_elapsed:?} of simulated \
+             time, less than one BACKGROUND_POLL_INTERVAL ({BACKGROUND_POLL_INTERVAL:?}) - the \
+             poll loop is not reading the live foreground flag each tick"
+        );
 
-        // And a promoted pane resumes draining (which tick is again not under test - only
-        // that promotion doesn't strand it).
+        // And a promoted pane resumes draining (which tick is not under test here - only that
+        // promotion doesn't strand it).
         pane.update(cx, |pane, cx| {
             pane.set_foreground(true);
             pane.clear(cx); // wipes the grid, sends a fresh Ctrl-L
         });
-        std::thread::sleep(Duration::from_millis(400));
-        let mut saw_caret_l_again = false;
-        for _ in 0..50 {
-            cx.background_executor.advance_clock(POLL_INTERVAL);
-            cx.run_until_parked();
-            let lines = pane.read_with(cx, |pane, _| pane.visible_text_lines());
-            if lines.iter().any(|line| line.contains("^L")) {
-                saw_caret_l_again = true;
-                break;
-            }
-        }
         assert!(
-            saw_caret_l_again,
+            pump_until(cx, |cx| grid_shows(cx, &pane, "^L")),
             "a pane promoted back to foreground must keep draining output"
         );
+        release(cx, pane);
     }
 
     #[test]
@@ -2727,38 +2803,10 @@ mod resize_tests {
     }
 
     #[test]
-    fn size_to_grid_derives_columns_and_rows_from_the_given_size_not_a_fixed_constant() {
-        // A plausible centre-pane content width once Phase A's shell chrome (rail + panel +
-        // borders) is subtracted from a 1440px window - roughly 820px, not the full 1440.
-        let (rows, cols) = size_to_grid(size(px(820.0), px(800.0)), test_cell_size());
-        assert_eq!(cols, (820.0 / APPROX_CELL_WIDTH_PX) as u16);
-        assert_eq!(rows, (800.0 / ROW_LINE_HEIGHT_PX) as u16);
-    }
-
-    #[test]
     fn size_to_grid_enforces_a_minimum_row_and_column_count() {
         let (rows, cols) = size_to_grid(size(px(10.0), px(10.0)), test_cell_size());
         assert_eq!(cols, 20);
         assert_eq!(rows, 10);
-    }
-
-    #[test]
-    fn size_to_grid_from_a_real_pane_width_is_plausible_not_the_full_window_derived_count() {
-        // Regression guard for the Phase-A bug: deriving columns from the whole 1440px window
-        // (ignoring shell chrome either side) computed ~205 columns; the real centre-pane
-        // width is ~820-840px, ~118-120 columns. Both are "correct" `size_to_grid` outputs for
-        // their inputs - the bug was `maybe_resize_pty` feeding it the wrong one. Pins the two
-        // magnitudes apart so a regression back to `window.viewport_size()` gets caught here.
-        let (_rows, whole_window_cols) =
-            size_to_grid(size(px(1440.0), px(928.0)), test_cell_size());
-        let (_rows, real_pane_cols) = size_to_grid(size(px(828.0), px(800.0)), test_cell_size());
-        assert!(
-            whole_window_cols > real_pane_cols * 3 / 2,
-            "expected the whole-window column count ({whole_window_cols}) to be \
-             substantially larger than the real-pane-width column count ({real_pane_cols}) \
-             - if they're close, something about the approximation changed"
-        );
-        assert!(real_pane_cols < 130, "got {real_pane_cols}");
     }
 
     #[test]
@@ -2774,31 +2822,6 @@ mod resize_tests {
             big_cells,
             (small_cells.0 / 2, small_cells.1 / 2),
             "doubling the cell size must exactly halve both dimensions"
-        );
-    }
-
-    #[test]
-    fn size_to_grid_documents_the_real_before_after_column_count_at_a_typical_pane_width() {
-        // At a plausible centre-pane width (828px) and typical panel height (~800px): how many
-        // rows the old guessed cell size (7.0 x 16.0) computed versus the line-height-corrected
-        // one (7.0 x 19.0). Isolates the height half of the Phase-C bug - the width half is
-        // that `cell_size`'s width now comes from a real font-metrics measurement instead of a
-        // guess, which this pure function can't itself demonstrate.
-        let old_guess = size(px(APPROX_CELL_WIDTH_PX), px(16.0));
-        let new_real = size(px(APPROX_CELL_WIDTH_PX), px(ROW_LINE_HEIGHT_PX));
-        let pane = size(px(828.0), px(800.0));
-
-        let (old_rows, _) = size_to_grid(pane, old_guess);
-        let (new_rows, _) = size_to_grid(pane, new_real);
-
-        // The old, too-short line-height guess asked for more rows than the pane could
-        // actually show without clipping (`800.0 / 16.0 = 50` vs. `800.0 / 19.0 = 42`) - a
-        // ~19% over-request, not a rounding artifact.
-        assert_eq!(old_rows, 50);
-        assert_eq!(new_rows, 42);
-        assert!(
-            old_rows > new_rows,
-            "the old guess must over-request rows relative to the real, corrected line height"
         );
     }
 
@@ -2937,61 +2960,6 @@ mod eof_poll_tests {
             None => panic!("expected the tick cap to force a resolution"),
         }
     }
-
-    #[test]
-    fn real_process_closing_pty_fds_before_exiting_is_not_yet_reaped_at_eof() {
-        let mut session = pty_core::spawn(
-            pty_core::SpawnOptions::new("sh")
-                .arg("-c")
-                .arg("exec 0<&- 1>&- 2>&-; sleep 1; exit 7"),
-        )
-        .expect("spawning the shell should succeed");
-
-        // Drain until the output channel disconnects - exactly the `TryRecvError::
-        // Disconnected` signal `TerminalPane`'s poll loop reacts to.
-        let deadline = Instant::now() + Duration::from_secs(5);
-        loop {
-            let remaining = deadline.saturating_duration_since(Instant::now());
-            if remaining.is_zero() {
-                panic!("timed out waiting for the pty output channel to disconnect (EOF)");
-            }
-            if session.output().recv_timeout(remaining).is_err() {
-                break; // disconnected
-            }
-        }
-
-        // At the moment of EOF the process has not exited yet (it's mid-`sleep 1`) - a
-        // single `try_wait` here legitimately observes nothing. If this assertion itself
-        // fails, the test's timing assumption is wrong, not the fix under test.
-        let immediately_after_eof = session
-            .try_wait()
-            .expect("try_wait should not error for a live child");
-        assert!(
-            immediately_after_eof.is_none(),
-            "expected the process to still be alive (sleeping) right after its pty fds \
-             closed - a single try_wait must not yet observe an exit"
-        );
-
-        // The bounded retry loop `eof_poll_decision` drives in real usage: keep checking
-        // until the real exit status becomes observable.
-        let mut observed = None;
-        let poll_deadline = Instant::now() + Duration::from_secs(5);
-        while Instant::now() < poll_deadline {
-            if let Some(status) = session
-                .try_wait()
-                .expect("try_wait should not error while polling")
-            {
-                observed = Some(status);
-                break;
-            }
-            std::thread::sleep(Duration::from_millis(20));
-        }
-
-        let status =
-            observed.expect("the process should eventually be reaped with a real exit status");
-        assert!(!status.success());
-        assert_eq!(status.exit_code(), 7);
-    }
 }
 
 #[cfg(test)]
@@ -3026,88 +2994,78 @@ mod keystroke_tests {
         );
     }
 
+    /// Direct proof of the control-byte mapping itself, independent of whether GPUI's own
+    /// dispatch ever lets these keystrokes reach this pane's `on_key_down` to be mapped. For
+    /// both of them it no longer does in practice - `secondary-p` is `TogglePalette`'s unscoped
+    /// global binding, and `secondary-z` is scoped away from terminals by
+    /// `TextUndo`/`TextRedo`'s `Some("text-input")` - which is exactly why the pure mapping is
+    /// pinned here: `crate::root::focus::tab_strip_keybinding_tests` and
+    /// `crate::root::focus::text_undo_scoping_tests` prove the app-level dispatch's half; this
+    /// proves what reaches the pty for whatever context still gets here.
     #[test]
-    fn an_unmodified_letter_is_still_forwarded_normally() {
-        let ks = keystroke("n", Modifiers::default());
-        assert_eq!(keystroke_to_bytes(&ks), Some(b"n".to_vec()));
-    }
-
-    #[test]
-    fn ctrl_p_maps_to_the_real_readline_previous_history_control_byte() {
-        let modifiers = Modifiers {
+    fn a_ctrl_letter_maps_to_its_real_control_byte_and_a_plain_letter_to_itself() {
+        let control = Modifiers {
             control: true,
             ..Default::default()
         };
-        let ks = keystroke("p", modifiers);
+        // The standard readline "previous history" byte, and the SIGTSTP terminal-suspend byte -
+        // the two essentially every interactive program relies on.
         assert_eq!(
-            keystroke_to_bytes(&ks),
-            Some(vec![0x10]),
-            "Ctrl+P must map to the real Ctrl+<letter> control code (0x10), the standard \
-             readline 'previous history' byte every real shell relies on"
+            keystroke_to_bytes(&keystroke("p", control)),
+            Some(vec![0x10])
+        );
+        assert_eq!(
+            keystroke_to_bytes(&keystroke("z", control)),
+            Some(vec![0x1a])
+        );
+        assert_eq!(
+            keystroke_to_bytes(&keystroke("n", Modifiers::default())),
+            Some(b"n".to_vec()),
+            "an unmodified letter is still forwarded as itself"
         );
     }
 
     #[test]
-    fn ctrl_z_maps_to_the_real_sigtstp_control_byte() {
-        let modifiers = Modifiers {
+    fn shift_tab_sends_the_real_back_tab_sequence_distinct_from_every_other_tab() {
+        let shift = Modifiers {
+            shift: true,
+            ..Default::default()
+        };
+        let ctrl_shift = Modifiers {
+            shift: true,
             control: true,
             ..Default::default()
         };
-        let ks = keystroke("z", modifiers);
-        assert_eq!(
-            keystroke_to_bytes(&ks),
-            Some(vec![0x1a]),
-            "Ctrl+Z must map to the real Ctrl+<letter> control code (0x1a), the SIGTSTP \
-             terminal-suspend byte essentially every interactive program relies on"
-        );
-    }
 
-    #[test]
-    fn shift_tab_sends_the_real_back_tab_sequence_distinct_from_plain_tab() {
-        let plain = keystroke("tab", Modifiers::default());
-        assert_eq!(
-            keystroke_to_bytes(&plain),
-            Some(b"\t".to_vec()),
-            "plain Tab must still send the ordinary tab byte"
-        );
-
-        let shifted = keystroke(
-            "tab",
-            Modifiers {
-                shift: true,
-                ..Default::default()
-            },
-        );
-        assert_eq!(
-            keystroke_to_bytes(&shifted),
-            Some(b"\x1b[Z".to_vec()),
-            "Shift+Tab must send the standard CSI back-tab sequence (\\x1b[Z), not the plain \
-             tab byte - this is what readline-based tools and Claude Code's own CLI listen for \
-             to cycle their mode in the opposite direction"
-        );
+        for (modifiers, expected, why) in [
+            (
+                Modifiers::default(),
+                b"\t".as_slice(),
+                "plain Tab must still send the ordinary tab byte",
+            ),
+            (
+                shift,
+                b"\x1b[Z".as_slice(),
+                "Shift+Tab must send the standard CSI back-tab sequence, which is what \
+                 readline-based tools and Claude Code's own CLI listen for",
+            ),
+            (
+                ctrl_shift,
+                b"\t".as_slice(),
+                "Ctrl+Shift+Tab must keep sending the plain tab byte, unchanged by the fix",
+            ),
+        ] {
+            assert_eq!(
+                keystroke_to_bytes(&keystroke("tab", modifiers)),
+                Some(expected.to_vec()),
+                "{why}"
+            );
+        }
 
         assert_ne!(
-            keystroke_to_bytes(&plain),
-            keystroke_to_bytes(&shifted),
+            keystroke_to_bytes(&keystroke("tab", Modifiers::default())),
+            keystroke_to_bytes(&keystroke("tab", shift)),
             "Tab and Shift+Tab must be distinguishable on the wire"
-        );
-    }
-
-    #[test]
-    fn ctrl_shift_tab_is_unaffected_by_the_back_tab_fix() {
-        let ks = keystroke(
-            "tab",
-            Modifiers {
-                shift: true,
-                control: true,
-                ..Default::default()
-            },
-        );
-        assert_eq!(
-            keystroke_to_bytes(&ks),
-            Some(b"\t".to_vec()),
-            "Ctrl+Shift+Tab must keep sending the plain tab byte, unchanged by the Shift+Tab \
-             back-tab fix"
         );
     }
 }
@@ -3126,155 +3084,188 @@ mod link_segment_tests {
         }
     }
 
+    /// The CHANGELOG's contract: "a line is authored as `[prefix, colour, link, suffix]` - the
+    /// link is a span inside the line, not a whole-line style". Every position a link can take
+    /// on a row, and what each one must leave around it: never a whole-row link, never a dropped
+    /// plain run, and never an empty segment where the link happens to touch an edge.
     #[test]
-    fn a_row_with_no_links_is_a_single_plain_segment() {
-        let segments = split_segments(10, &[]);
-        assert_eq!(segments, vec![RowSegment::Plain { start: 0, end: 10 }]);
+    fn a_link_is_a_span_inside_the_row_wherever_on_it_the_link_falls() {
+        let plain = |start, end| RowSegment::Plain { start, end };
+        let linked = |start, end, path: &str| RowSegment::Link {
+            start,
+            end,
+            link: link(start, end, path),
+        };
+
+        for (what, row_len, links, expected) in [
+            ("no links at all", 10, vec![], vec![plain(0, 10)]),
+            (
+                // `"  \u{21b3} tests/upload.rs:88:"` - the link spans chars 4..19.
+                "in the middle",
+                20,
+                vec![link(4, 19, "tests/upload.rs")],
+                vec![plain(0, 4), linked(4, 19, "tests/upload.rs"), plain(19, 20)],
+            ),
+            (
+                "at the very start",
+                8,
+                vec![link(0, 5, "a.txt")],
+                vec![linked(0, 5, "a.txt"), plain(5, 8)],
+            ),
+            (
+                "at the very end",
+                8,
+                vec![link(3, 8, "a.txt")],
+                vec![plain(0, 3), linked(3, 8, "a.txt")],
+            ),
+            (
+                "covering the whole row",
+                10,
+                vec![link(0, 10, "src/main.rs")],
+                vec![linked(0, 10, "src/main.rs")],
+            ),
+            (
+                "two links with plain text between them",
+                14,
+                vec![link(2, 5, "a.rs"), link(9, 12, "b.rs")],
+                vec![
+                    plain(0, 2),
+                    linked(2, 5, "a.rs"),
+                    plain(5, 9),
+                    linked(9, 12, "b.rs"),
+                    plain(12, 14),
+                ],
+            ),
+        ] {
+            assert_eq!(split_segments(row_len, &links), expected, "a link {what}");
+        }
+    }
+}
+
+/// The property every other test in this file depends on without saying so: a `TerminalPane`
+/// that goes out of scope takes its whole real process tree with it.
+///
+/// This is what makes the terminal suite leak-free. GitHub issue #427 measured 509 child
+/// processes surviving a single app test run; PR #432 fixed the macOS half of the teardown
+/// (`pty_core`'s descendant walk read `/proc`, which does not exist there), and `pty_core`'s own
+/// `drop_terminates_entire_process_tree_including_escaped_grandchild` pins that at the crate
+/// level. What was never pinned is the layer the leak was actually reported at: that a *pane* (a
+/// GPUI entity, released by the app rather than by an explicit `drop` a test author has to
+/// remember) really does reach that teardown. If it stopped doing so, every real-pty test in this
+/// file would start leaking again and nothing would fail.
+///
+/// unix-only, like `pty-core`'s own teardown suite: it needs real process-group and
+/// escaped-descendant semantics.
+#[cfg(all(test, unix))]
+mod pane_teardown_tests {
+    use super::pty_pane_fixtures::{spawn_pane, PTY_ROUND_TRIP};
+    use gpui::TestAppContext;
+    use std::process::{Command, Stdio};
+    use test_support::ChildGuard;
+
+    /// Whether `pid` names a live process, asked of the OS itself via `kill -0` rather than
+    /// through `pty_core`'s own (private) `pid_exists` - so what is checked here is independent
+    /// of the code under test.
+    fn pid_is_alive(pid: &str) -> bool {
+        let mut command = Command::new("kill");
+        command
+            .args(["-0", pid])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        let mut probe = ChildGuard::spawn(&mut command).expect("spawn kill -0");
+        probe
+            .wait()
+            .expect("kill -0 should always terminate")
+            .success()
     }
 
-    #[test]
-    fn a_link_in_the_middle_splits_into_prefix_link_suffix_not_a_whole_line_style() {
-        let links = [link(4, 19, "tests/upload.rs")];
-        let segments = split_segments(20, &links);
-        assert_eq!(
-            segments,
-            vec![
-                RowSegment::Plain { start: 0, end: 4 },
-                RowSegment::Link {
-                    start: 4,
-                    end: 19,
-                    link: links[0].clone(),
-                },
-                RowSegment::Plain { start: 19, end: 20 },
-            ]
+    #[gpui::test]
+    fn dropping_a_pane_takes_its_whole_real_process_tree_with_it(cx: &mut TestAppContext) {
+        // `set -m` turns on job control, which puts the background job in its own process group -
+        // precisely what defeats a `killpg` on the direct child alone, so only a real descendant
+        // walk can reach it. The shell reports the escaped grandchild's pid back over the pty so
+        // this test does not have to race that walk to discover it.
+        let pane = spawn_pane(
+            cx,
+            "sh",
+            &[
+                "-c",
+                "set -m; sleep 100 & echo ADE-GRANDCHILD:$!; exec sleep 300",
+            ],
         );
-    }
 
-    #[test]
-    fn a_link_at_the_very_start_has_no_leading_plain_segment() {
-        let links = [link(0, 5, "a.txt")];
-        let segments = split_segments(8, &links);
-        assert_eq!(
-            segments,
-            vec![
-                RowSegment::Link {
-                    start: 0,
-                    end: 5,
-                    link: links[0].clone(),
-                },
-                RowSegment::Plain { start: 5, end: 8 },
-            ]
+        let mut reported = None;
+        assert!(
+            super::pty_pane_fixtures::pump_until(cx, |cx| {
+                reported = pane.read_with(cx, |pane, _| {
+                    pane.visible_text_lines().iter().find_map(|line| {
+                        line.split_once("ADE-GRANDCHILD:")
+                            .map(|(_, pid)| pid.trim().to_string())
+                    })
+                });
+                reported.is_some()
+            }),
+            "the shell must report its detached grandchild's pid over the real pty"
         );
-    }
+        let grandchild = reported.expect("pump_until only returns true once this is Some");
+        let direct = pane
+            .read_with(cx, |pane, _| {
+                pane.session.as_ref().and_then(|s| s.process_id())
+            })
+            .expect("a live pane has a real child pid")
+            .to_string();
 
-    #[test]
-    fn a_link_at_the_very_end_has_no_trailing_plain_segment() {
-        let links = [link(3, 8, "a.txt")];
-        let segments = split_segments(8, &links);
-        assert_eq!(
-            segments,
-            vec![
-                RowSegment::Plain { start: 0, end: 3 },
-                RowSegment::Link {
-                    start: 3,
-                    end: 8,
-                    link: links[0].clone(),
-                },
-            ]
+        assert!(
+            pid_is_alive(&direct),
+            "sanity check: the direct child is up"
         );
-    }
+        assert!(
+            pid_is_alive(&grandchild),
+            "sanity check: the escaped grandchild is up"
+        );
 
-    #[test]
-    fn multiple_links_each_get_their_own_span_with_plain_text_between_them() {
-        let links = [link(2, 5, "a.rs"), link(9, 12, "b.rs")];
-        let segments = split_segments(14, &links);
-        assert_eq!(
-            segments,
-            vec![
-                RowSegment::Plain { start: 0, end: 2 },
-                RowSegment::Link {
-                    start: 2,
-                    end: 5,
-                    link: links[0].clone(),
-                },
-                RowSegment::Plain { start: 5, end: 9 },
-                RowSegment::Link {
-                    start: 9,
-                    end: 12,
-                    link: links[1].clone(),
-                },
-                RowSegment::Plain { start: 12, end: 14 },
-            ]
-        );
-    }
+        drop(pane);
+        // `cx.update` and not just `run_until_parked`, and this is the whole point of the
+        // fixture below: GPUI releases an entity whose last handle was dropped during
+        // `flush_effects`, which only runs inside an app update. `run_until_parked` alone does
+        // not trigger one, so `TerminalPane` - and with it `PtySession`, and with it the child
+        // process tree - is *not* dropped by `drop(pane)` on its own. That is exactly how a test
+        // suite ends up with hundreds of live children at once (GitHub issue #427 measured 509),
+        // and why `release_panes` exists.
+        cx.update(|_cx| {});
+        cx.run_until_parked();
 
-    #[test]
-    fn a_link_covering_the_whole_row_is_a_single_link_segment() {
-        let links = [link(0, 10, "src/main.rs")];
-        let segments = split_segments(10, &links);
-        assert_eq!(
-            segments,
-            vec![RowSegment::Link {
-                start: 0,
-                end: 10,
-                link: links[0].clone(),
-            }]
-        );
+        for (pid, what) in [
+            (&direct, "direct child"),
+            (&grandchild, "escaped grandchild"),
+        ] {
+            assert!(
+                test_support::wait_until(PTY_ROUND_TRIP, || !pid_is_alive(pid)),
+                "the {what} ({pid}) was still alive after its TerminalPane was dropped - every \
+                 real-pty test in this file leaks a process if this stops holding"
+            );
+        }
     }
 }
 
 #[cfg(test)]
 mod clear_pty_signal_tests {
-    use super::*;
+    use super::pty_pane_fixtures::{grid_shows, pump_until, release, spawn_pane};
     use gpui::TestAppContext;
 
     #[gpui::test]
     fn clear_with_a_live_session_sends_a_real_ctrl_l_the_pty_echoes_back(cx: &mut TestAppContext) {
-        let pane = cx.new(|cx| {
-            TerminalPane::new(
-                TerminalSpec::command("cat", Vec::new(), std::env::temp_dir()),
-                ROW_FONT_SIZE_PX,
-                cx,
-            )
-        });
-        cx.run_until_parked();
+        let pane = spawn_pane(cx, "cat", &[]);
 
         pane.update(cx, |pane, cx| pane.clear(cx));
 
-        // The real pty reader thread and the real `cat` child it feeds run entirely outside
-        // GPUI's deterministic scheduler, so `advance_clock` alone (a purely *simulated* clock)
-        // grants them zero actual wall-clock scheduling time. Standalone, with an otherwise idle
-        // CPU, the real echo lands within real microseconds and a loop that only ever advances
-        // the virtual clock never notices it's racing ahead of real time - but under real
-        // full-suite parallel load (dozens of other tests' own real subprocesses contending for
-        // the same cores) the OS can genuinely take real milliseconds to schedule this thread,
-        // and a loop with no real-time floor at all can burn through every check before that
-        // happens. A real `std::thread::sleep` between checks (bounded by a real deadline, not a
-        // fixed tick count) gives it a genuine chance, mirroring this same file's own
-        // `a_background_pane_drains_on_the_background_interval_read_fresh_each_tick`'s upfront
-        // `std::thread::sleep(Duration::from_millis(400))` for the identical Ctrl-L/ECHOCTL
-        // round trip.
-        let mut saw_caret_l = false;
-        let deadline = std::time::Instant::now() + Duration::from_secs(45);
-        loop {
-            cx.background_executor.advance_clock(POLL_INTERVAL);
-            cx.run_until_parked();
-            let lines = pane.read_with(cx, |pane, _| pane.visible_text_lines());
-            if lines.iter().any(|line| line.contains("^L")) {
-                saw_caret_l = true;
-                break;
-            }
-            if std::time::Instant::now() >= deadline {
-                break;
-            }
-            std::thread::sleep(Duration::from_millis(5));
-        }
         assert!(
-            saw_caret_l,
+            pump_until(cx, |cx| grid_shows(cx, &pane, "^L")),
             "expected the real pty's own echo of the Ctrl-L byte clear() sends to eventually \
              appear in the grid - this is what actually proves the byte reached the pty, not \
              just that write_input() was called"
         );
+        release(cx, pane);
     }
 }
 
@@ -3284,6 +3275,7 @@ mod clear_pty_signal_tests {
 /// escape bytes are produced by a real `printf`, exactly as a real agent CLI produces them.
 #[cfg(test)]
 mod terminal_signal_tests {
+    use super::pty_pane_fixtures::{pump_until, release, spawn_pane};
     use super::*;
     use crate::rail::title_signal::{classify_title, TitleSignal};
     use crate::terminal::osc::{Progress, ProgressState};
@@ -3292,40 +3284,18 @@ mod terminal_signal_tests {
     /// Spawns a real `sh` that writes `script`'s escape sequences and then blocks, so the
     /// process is still alive (and the pane still `is_running`) while the assertions run - the
     /// same real-pty pattern this module's other tests use, and `sh` rather than bare `printf`
-    /// so the sequences and the sleep are one child process.
+    /// so the sequences and the wait are one child process.
     fn pane_emitting(cx: &mut TestAppContext, script: &str) -> gpui::Entity<TerminalPane> {
-        cx.new(|cx| {
-            TerminalPane::new(
-                TerminalSpec::command(
-                    "sh",
-                    vec!["-c".to_string(), format!("{script}; sleep 60")],
-                    std::env::temp_dir(),
-                ),
-                ROW_FONT_SIZE_PX,
-                cx,
-            )
-        })
+        spawn_pane(cx, "sh", &["-c", &format!("{script}; sleep 60")])
     }
 
-    /// Drives the pane's real poll loop until `done` reports true, or gives up. The pty write
-    /// itself takes real wall time (a real process, real fd) while the *drain* only happens on
-    /// poll ticks, which the test executor's clock drives - hence both a real sleep and the
-    /// virtual-clock loop, matching `cadence_tests`' own approach.
+    /// Drives the pane's real poll loop until `done` reports true, or gives up.
     fn poll_until(
         cx: &mut TestAppContext,
         pane: &gpui::Entity<TerminalPane>,
         done: impl Fn(&TerminalPane) -> bool,
     ) -> bool {
-        cx.run_until_parked();
-        for _ in 0..60 {
-            std::thread::sleep(Duration::from_millis(50));
-            cx.background_executor.advance_clock(POLL_INTERVAL);
-            cx.run_until_parked();
-            if pane.read_with(cx, |pane, _| done(pane)) {
-                return true;
-            }
-        }
-        false
+        pump_until(cx, |cx| pane.read_with(cx, |pane, _| done(pane)))
     }
 
     #[gpui::test]
@@ -3348,8 +3318,7 @@ mod terminal_signal_tests {
             "a real agent CLI's real working title must classify as Busy end to end"
         );
 
-        pane.update(cx, |pane, cx| pane.shutdown(cx));
-        cx.run_until_parked();
+        release(cx, pane);
     }
 
     #[gpui::test]
@@ -3373,8 +3342,7 @@ mod terminal_signal_tests {
             "the pane's ping must survive being read"
         );
 
-        pane.update(cx, |pane, cx| pane.shutdown(cx));
-        cx.run_until_parked();
+        release(cx, pane);
     }
 
     #[gpui::test]
@@ -3385,8 +3353,7 @@ mod terminal_signal_tests {
             "a real OSC 777 notify off a real pty never reached the pane"
         );
 
-        pane.update(cx, |pane, cx| pane.shutdown(cx));
-        cx.run_until_parked();
+        release(cx, pane);
     }
 
     #[gpui::test]
@@ -3408,22 +3375,14 @@ mod terminal_signal_tests {
             "a progress report is not a notification - OSC 9;4 must not ping for attention"
         );
 
-        pane.update(cx, |pane, cx| pane.shutdown(cx));
-        cx.run_until_parked();
+        release(cx, pane);
     }
 
     #[gpui::test]
     fn a_pty_process_that_says_nothing_reports_no_signal_at_all(cx: &mut TestAppContext) {
         // The honest default, and the one every non-agent process hits: a `cat` sitting on a
         // real pty has no title, no ping and no progress - not an invented one.
-        let pane = cx.new(|cx| {
-            TerminalPane::new(
-                TerminalSpec::command("cat", Vec::new(), std::env::temp_dir()),
-                ROW_FONT_SIZE_PX,
-                cx,
-            )
-        });
-        cx.run_until_parked();
+        let pane = spawn_pane(cx, "cat", &[]);
         for _ in 0..5 {
             cx.background_executor.advance_clock(POLL_INTERVAL);
             cx.run_until_parked();
@@ -3434,8 +3393,7 @@ mod terminal_signal_tests {
             assert_eq!(pane.progress(), None);
         });
 
-        pane.update(cx, |pane, cx| pane.shutdown(cx));
-        cx.run_until_parked();
+        release(cx, pane);
     }
 }
 
@@ -3459,72 +3417,63 @@ mod cell_position_tests {
         )
     }
 
+    /// Where a pixel lands, and what happens at each of the four edges. The `side` matters as
+    /// much as the column: it is what decides whether the cell under the pointer is included in
+    /// the selection at all (`Selection::to_range`'s `range_simple` drops a cell the selection
+    /// ends left of), so the half-cell boundary is real behaviour, not a detail - and clamping a
+    /// past-the-right-edge drag to the *left* of the last column would silently drop that column
+    /// from the selection.
     #[test]
-    fn the_top_left_pixel_is_row_zero_column_zero() {
-        assert_eq!(
-            at(0.0, 0.0),
-            CellPosition {
-                row: 0,
-                column: 0,
-                side: CellSide::Left
-            }
-        );
-    }
+    fn a_pixel_resolves_to_the_cell_containing_it_and_clamps_at_every_edge() {
+        for (x, y, row, column, side, what) in [
+            (0.0, 0.0, 0, 0, CellSide::Left, "the top-left pixel"),
+            // x = 34px -> column 3 (30..40), 0.4 of the way in; y = 55px -> row 2 (40..60).
+            (34.0, 55.0, 2, 3, CellSide::Left, "a cell's own left half"),
+            (
+                34.9,
+                0.0,
+                0,
+                3,
+                CellSide::Left,
+                "just short of the midpoint",
+            ),
+            (35.0, 0.0, 0, 3, CellSide::Right, "exactly the midpoint"),
+            (39.9, 0.0, 0, 3, CellSide::Right, "the far end of the cell"),
+            (
+                10_000.0,
+                0.0,
+                0,
+                79,
+                CellSide::Right,
+                "a drag past the right edge",
+            ),
+            (
+                0.0,
+                10_000.0,
+                23,
+                0,
+                CellSide::Left,
+                "a drag past the bottom",
+            ),
+        ] {
+            assert_eq!(
+                at(x, y),
+                CellPosition { row, column, side },
+                "{what} at ({x}, {y})"
+            );
+        }
 
-    #[test]
-    fn a_position_resolves_to_the_cell_containing_it() {
-        // x = 34px -> column 3 (30..40), 0.4 of the way in -> left half.
-        // y = 55px -> row 2 (40..60).
-        assert_eq!(
-            at(34.0, 55.0),
-            CellPosition {
-                row: 2,
-                column: 3,
-                side: CellSide::Left
-            }
-        );
-    }
-
-    #[test]
-    fn the_right_half_of_a_cell_reports_the_right_side() {
-        assert_eq!(at(35.0, 0.0).side, CellSide::Right);
-        assert_eq!(at(39.9, 0.0).side, CellSide::Right);
-        assert_eq!(at(34.9, 0.0).side, CellSide::Left);
-        assert_eq!(
-            at(35.0, 0.0).column,
-            3,
-            "the column is unchanged by the side"
-        );
-    }
-
-    #[test]
-    fn a_drag_past_the_right_edge_clamps_to_the_last_column_inclusively() {
-        let position = at(10_000.0, 0.0);
-        assert_eq!(position.column, 79);
-        assert_eq!(
-            position.side,
-            CellSide::Right,
-            "clamping to the *left* of the last column would silently drop that column from \
-             the selection"
-        );
-    }
-
-    #[test]
-    fn a_drag_past_the_bottom_clamps_to_the_last_row() {
-        assert_eq!(at(0.0, 10_000.0).row, 23);
-    }
-
-    #[test]
-    fn a_position_above_and_left_of_the_origin_clamps_to_the_first_cell() {
-        let position = cell_position_in_grid(
+        // Dragging back above/left of the grid origin - a real gesture, the pointer leaves the
+        // pane - must clamp to the first cell rather than underflow into a huge `usize`.
+        let outside = cell_position_in_grid(
             point(px(0.0), px(0.0)),
             point(px(100.0), px(200.0)),
             size(px(10.0), px(20.0)),
             24,
             80,
         );
-        assert_eq!(position.row, 0);
-        assert_eq!(position.column, 0);
+        assert_eq!(outside.row, 0);
+        assert_eq!(outside.column, 0);
     }
 
     #[test]
@@ -3581,23 +3530,17 @@ mod paste_payload_tests {
 /// clipboard write, and a real clipboard read produces real bytes on a real pty.
 #[cfg(test)]
 mod clipboard_tests {
+    use super::pty_pane_fixtures::{grid_shows, pump_until, release, spawn_pane};
     use super::*;
     use gpui::TestAppContext;
 
     fn new_pane(cx: &mut TestAppContext, program: &str) -> gpui::Entity<TerminalPane> {
-        cx.new(|cx| {
-            TerminalPane::new(
-                TerminalSpec::command(program, Vec::new(), std::env::temp_dir()),
-                ROW_FONT_SIZE_PX,
-                cx,
-            )
-        })
+        spawn_pane(cx, program, &[])
     }
 
     #[gpui::test]
     fn copying_a_real_selection_writes_it_to_the_real_system_clipboard(cx: &mut TestAppContext) {
         let pane = new_pane(cx, "cat");
-        cx.run_until_parked();
 
         cx.update(|cx| cx.write_to_clipboard(gpui::ClipboardItem::new_string("before".into())));
 
@@ -3622,12 +3565,12 @@ mod clipboard_tests {
         );
         let text = cx.update(|cx| cx.read_from_clipboard().and_then(|item| item.text()));
         assert_eq!(text.as_deref(), Some("world"));
+        release(cx, pane);
     }
 
     #[gpui::test]
     fn copying_with_no_selection_leaves_the_clipboard_untouched(cx: &mut TestAppContext) {
         let pane = new_pane(cx, "cat");
-        cx.run_until_parked();
 
         cx.update(|cx| cx.write_to_clipboard(gpui::ClipboardItem::new_string("keep me".into())));
 
@@ -3639,12 +3582,12 @@ mod clipboard_tests {
         assert!(!copied);
         let text = cx.update(|cx| cx.read_from_clipboard().and_then(|item| item.text()));
         assert_eq!(text.as_deref(), Some("keep me"));
+        release(cx, pane);
     }
 
     #[gpui::test]
     fn pasting_writes_the_real_clipboard_text_to_the_real_pty(cx: &mut TestAppContext) {
         let pane = new_pane(cx, "cat");
-        cx.run_until_parked();
 
         cx.update(|cx| {
             cx.write_to_clipboard(gpui::ClipboardItem::new_string("ade-pasted-text".into()))
@@ -3652,76 +3595,33 @@ mod clipboard_tests {
         let pasted = pane.update(cx, |pane, cx| pane.paste_from_clipboard(cx));
         assert!(pasted, "a live session must accept a real paste");
 
-        let mut saw_pasted_text = false;
-        for _ in 0..50 {
-            cx.background_executor.advance_clock(POLL_INTERVAL);
-            cx.run_until_parked();
-            let lines = pane.read_with(cx, |pane, _| pane.visible_text_lines());
-            if lines.iter().any(|line| line.contains("ade-pasted-text")) {
-                saw_pasted_text = true;
-                break;
-            }
-        }
         assert!(
-            saw_pasted_text,
+            pump_until(cx, |cx| grid_shows(cx, &pane, "ade-pasted-text")),
             "expected the real pty's own echo of the pasted bytes to appear in the grid"
         );
+        release(cx, pane);
     }
 
     #[gpui::test]
     fn pasting_an_empty_clipboard_writes_nothing(cx: &mut TestAppContext) {
         let pane = new_pane(cx, "cat");
-        cx.run_until_parked();
 
         cx.update(|cx| cx.write_to_clipboard(gpui::ClipboardItem::new_string(String::new())));
         let pasted = pane.update(cx, |pane, cx| pane.paste_from_clipboard(cx));
         assert!(!pasted);
+        release(cx, pane);
     }
 }
 
 /// GitHub issue #288's delivery mechanism, against a real pty and a real child process.
 #[cfg(test)]
 mod send_prompt_tests {
+    use super::pty_pane_fixtures::{grid_shows, pump_until, release, spawn_pane, stays_absent};
     use super::*;
     use gpui::TestAppContext;
 
-    /// A real child on a real pty. `program`/`args` are spawned as-is.
-    fn new_pane(
-        cx: &mut TestAppContext,
-        program: &str,
-        args: Vec<String>,
-    ) -> gpui::Entity<TerminalPane> {
-        cx.new(|cx| {
-            TerminalPane::new(
-                TerminalSpec::command(program, args, std::env::temp_dir()),
-                ROW_FONT_SIZE_PX,
-                cx,
-            )
-        })
-    }
-
-    /// Pumps the real poll loop until `ready`, or gives up after a real wall-clock deadline.
-    /// Mixes virtual-clock advance with a real `sleep`, exactly as
-    /// `crate::work_surface::render`'s own `wait_for_real_pty_output` does and for the same
-    /// reason: the pty reader is a real OS thread, so a virtual-clock-only loop races it.
-    fn pump_until(
-        cx: &mut TestAppContext,
-        mut ready: impl FnMut(&mut TestAppContext) -> bool,
-    ) -> bool {
-        let deadline = std::time::Instant::now() + Duration::from_secs(20);
-        loop {
-            cx.background_executor.advance_clock(POLL_INTERVAL);
-            cx.run_until_parked();
-            if ready(cx) {
-                return true;
-            }
-            if std::time::Instant::now() >= deadline {
-                return false;
-            }
-            std::thread::sleep(Duration::from_millis(5));
-        }
-    }
-
+    /// The real thing: a child that turns bracketed paste on (exactly as an agent's full-screen
+    /// TUI does) receives a real multi-line batch, in one write, and echoes it back.
     #[gpui::test]
     fn a_multi_line_batch_reaches_a_real_pty_whose_child_has_bracketed_paste_on(
         cx: &mut TestAppContext,
@@ -3729,12 +3629,7 @@ mod send_prompt_tests {
         // `printf` sets `DECSET 2004` on its own output, which is how the grid - and therefore
         // `bracketed_paste_enabled` - learns about it. Nothing here is simulated: the mode really
         // arrives over the pty from a real child, then `cat` echoes whatever is written back.
-        let pane = new_pane(
-            cx,
-            "sh",
-            vec!["-c".to_string(), "printf '\\033[?2004h'; cat".to_string()],
-        );
-        cx.run_until_parked();
+        let pane = spawn_pane(cx, "sh", &["-c", "printf '\\033[?2004h'; cat"]);
         assert!(
             pump_until(cx, |cx| pane
                 .read_with(cx, |pane, _| pane.bracketed_paste_enabled())),
@@ -3754,25 +3649,19 @@ mod send_prompt_tests {
         );
 
         assert!(
-            pump_until(cx, |cx| {
-                pane.read_with(cx, |pane, _| {
-                    pane.visible_text_lines()
-                        .iter()
-                        .any(|line| line.contains("ade-note-tenant-id"))
-                })
-            }),
+            pump_until(cx, |cx| grid_shows(cx, &pane, "ade-note-tenant-id")),
             "the real pty's own echo of the batched prompt must appear in the grid - this is \
              round-tripped evidence the note text genuinely left the app, not an assertion that \
              `write_input` was called"
         );
+        release(cx, pane);
     }
 
     #[gpui::test]
     fn a_multi_line_batch_is_refused_when_the_child_has_bracketed_paste_off(
         cx: &mut TestAppContext,
     ) {
-        let pane = new_pane(cx, "cat", Vec::new());
-        cx.run_until_parked();
+        let pane = spawn_pane(cx, "cat", &[]);
         assert!(
             !pane.read_with(cx, |pane, _| pane.bracketed_paste_enabled()),
             "precondition: a plain `cat` never turns bracketed paste on"
@@ -3786,56 +3675,45 @@ mod send_prompt_tests {
             "a payload that could split must be refused, not sent"
         );
 
-        // Pumped for real, so "nothing arrived" is a measured fact rather than an assumption
-        // about timing.
-        for _ in 0..40 {
-            cx.background_executor.advance_clock(POLL_INTERVAL);
-            cx.run_until_parked();
-            std::thread::sleep(Duration::from_millis(2));
-        }
-        pane.read_with(cx, |pane, _| {
-            assert!(
-                !pane
-                    .visible_text_lines()
-                    .iter()
-                    .any(|line| line.contains("ade-refused")),
-                "not one byte of a refused batch may reach the child"
-            );
-            assert!(
-                pane.spawn_error.is_some(),
-                "and the refusal must be said out loud on the pane, not swallowed"
-            );
-        });
+        // Pumped for real over a bounded quiet window, so "nothing arrived" is a measured fact
+        // rather than an assumption about timing.
+        assert!(
+            stays_absent(cx, Duration::from_millis(200), |cx| grid_shows(
+                cx,
+                &pane,
+                "ade-refused"
+            )),
+            "not one byte of a refused batch may reach the child"
+        );
+        assert!(
+            pane.read_with(cx, |pane, _| pane.spawn_error.is_some()),
+            "and the refusal must be said out loud on the pane, not swallowed"
+        );
+        release(cx, pane);
     }
 
     #[gpui::test]
     fn the_single_line_form_is_delivered_to_a_child_with_bracketed_paste_off(
         cx: &mut TestAppContext,
     ) {
-        let pane = new_pane(cx, "cat", Vec::new());
-        cx.run_until_parked();
+        let pane = spawn_pane(cx, "cat", &[]);
 
         let sent = pane.update(cx, |pane, cx| {
             pane.send_prompt("line 5: ade-flat-one \u{b7} line 9: ade-flat-two", cx)
         });
         assert!(sent);
         assert!(
-            pump_until(cx, |cx| {
-                pane.read_with(cx, |pane, _| {
-                    pane.visible_text_lines()
-                        .iter()
-                        .any(|line| line.contains("ade-flat-two"))
-                })
-            }),
+            pump_until(cx, |cx| grid_shows(cx, &pane, "ade-flat-two")),
             "the flat form must really reach the child"
         );
+        release(cx, pane);
     }
 
     #[gpui::test]
     fn an_empty_prompt_writes_nothing(cx: &mut TestAppContext) {
-        let pane = new_pane(cx, "cat", Vec::new());
-        cx.run_until_parked();
+        let pane = spawn_pane(cx, "cat", &[]);
         assert!(!pane.update(cx, |pane, cx| pane.send_prompt("", cx)));
+        release(cx, pane);
     }
 }
 
@@ -3844,6 +3722,7 @@ mod send_prompt_tests {
 /// produced a selection and "copy" would have had nothing to copy even with a binding in place.
 #[cfg(test)]
 mod mouse_selection_tests {
+    use super::pty_pane_fixtures::release;
     use super::*;
     use gpui::{point, Entity, Modifiers, MouseButton, TestAppContext, VisualTestContext};
 
@@ -3935,6 +3814,7 @@ mod mouse_selection_tests {
             Some("world"),
             "a real left-drag across the grid must produce a real alacritty_terminal selection"
         );
+        release(cx, pane);
     }
 
     #[gpui::test]
@@ -3959,6 +3839,7 @@ mod mouse_selection_tests {
             pane.read_with(cx, |pane, _| pane.selected_text_for_test()),
             None
         );
+        release(cx, pane);
     }
 
     #[gpui::test]
@@ -3981,32 +3862,7 @@ mod mouse_selection_tests {
             pane.read_with(cx, |pane, _| pane.selected_text_for_test()),
             None
         );
-    }
-
-    #[gpui::test]
-    fn a_drag_marks_the_covered_cells_selected_for_the_renderer(cx: &mut TestAppContext) {
-        let (pane, cx, bounds, cell_size) = painted_pane(cx);
-
-        let start = point(
-            bounds.origin.x + px(PANE_PADDING_PX) + cell_size.width * 0.1,
-            cell_centre(bounds, cell_size, 0, 0).y,
-        );
-        let end = point(
-            bounds.origin.x + px(PANE_PADDING_PX) + cell_size.width * 4.9,
-            cell_centre(bounds, cell_size, 0, 4).y,
-        );
-        cx.simulate_mouse_down(start, MouseButton::Left, Modifiers::none());
-        cx.simulate_mouse_move(end, MouseButton::Left, Modifiers::none());
-        cx.run_until_parked();
-
-        let flagged = pane.read_with(cx, |pane, _| {
-            pane.grid.visible_rows(&TerminalPalette::default())[0]
-                .iter()
-                .filter(|cell| cell.selected)
-                .map(|cell| cell.c)
-                .collect::<String>()
-        });
-        assert_eq!(flagged, "hello");
+        release(cx, pane);
     }
 
     #[gpui::test]
@@ -4034,31 +3890,7 @@ mod mouse_selection_tests {
                 .as_deref(),
             Some("world")
         );
-    }
-
-    #[gpui::test]
-    fn a_drag_over_cjk_characters_copies_them_once_each(cx: &mut TestAppContext) {
-        let (pane, cx, bounds, cell_size) = painted_pane_showing(cx, "你好world".as_bytes());
-
-        let start = point(
-            bounds.origin.x + px(PANE_PADDING_PX) + cell_size.width * 0.1,
-            cell_centre(bounds, cell_size, 0, 0).y,
-        );
-        let end = point(
-            bounds.origin.x + px(PANE_PADDING_PX) + cell_size.width * 3.9,
-            cell_centre(bounds, cell_size, 0, 3).y,
-        );
-
-        cx.simulate_mouse_down(start, MouseButton::Left, Modifiers::none());
-        cx.simulate_mouse_move(end, MouseButton::Left, Modifiers::none());
-        cx.simulate_mouse_up(end, MouseButton::Left, Modifiers::none());
-        cx.run_until_parked();
-
-        assert_eq!(
-            pane.read_with(cx, |pane, _| pane.selected_text_for_test())
-                .as_deref(),
-            Some("你好")
-        );
+        release(cx, pane);
     }
 }
 
@@ -4066,6 +3898,7 @@ mod mouse_selection_tests {
 /// it.
 #[cfg(test)]
 mod utf8_input_tests {
+    use super::pty_pane_fixtures::release;
     use super::*;
     use gpui::{Modifiers, TestAppContext};
 
@@ -4168,6 +4001,7 @@ mod utf8_input_tests {
                 CellWidth::Spacer,
             ]
         );
+        release(cx, pane);
     }
 }
 
@@ -4178,6 +4012,7 @@ mod utf8_input_tests {
 /// right.
 #[cfg(test)]
 mod wide_char_render_tests {
+    use super::pty_pane_fixtures::release;
     use super::*;
 
     /// Row 0 of a real grid after parsing `bytes`.
@@ -4222,7 +4057,7 @@ mod wide_char_render_tests {
     }
 
     #[test]
-    fn each_wide_character_is_its_own_two_column_run() {
+    fn each_wide_character_is_its_own_two_column_run_never_merged_with_its_neighbours() {
         let runs = row_runs(&row_zero("你好world", 20));
 
         assert_eq!(runs[0].text, "你");
@@ -4238,6 +4073,18 @@ mod wide_char_render_tests {
             runs[2].text.chars().count(),
             "a narrow run covers exactly one column per character"
         );
+
+        // A wide character with narrow text on *both* sides of it - the case a merge would be
+        // most tempted by.
+        let surrounded = row_runs(&row_zero("a好b", 20));
+        let shapes: Vec<(&str, usize)> = surrounded
+            .iter()
+            .map(|run| (run.text.trim_end(), run.columns))
+            .collect();
+        assert_eq!(shapes[0], ("a", 1));
+        assert_eq!(shapes[1], ("好", 2));
+        // The trailing run is `b` plus the row's blank remainder.
+        assert_eq!(&shapes[2].0[..1], "b");
     }
 
     #[test]
@@ -4247,18 +4094,9 @@ mod wide_char_render_tests {
         assert_eq!(wide_run_width(&runs[2], px(8.0)), None);
     }
 
-    #[test]
-    fn a_wide_run_never_merges_into_the_narrow_text_around_it() {
-        let runs = row_runs(&row_zero("a好b", 20));
-        let shapes: Vec<(&str, usize)> = runs
-            .iter()
-            .map(|run| (run.text.trim_end(), run.columns))
-            .collect();
-        assert_eq!(shapes[0], ("a", 1));
-        assert_eq!(shapes[1], ("好", 2));
-        assert_eq!(&shapes[2].0[..1], "b");
-    }
-
+    /// Link detection has to see the row's real text, not the emulator's padding. With the spacer
+    /// cells still in the row text this reads `/tmp/日 本 /main.rs`, whose space breaks the path
+    /// apart; the link then either fails to match or matches the wrong span.
     #[test]
     fn a_link_containing_wide_characters_is_still_detected_as_one_link() {
         let runs = row_runs(&row_zero("see /tmp/日本/main.rs:12 ok", 40));
@@ -4279,17 +4117,27 @@ mod wide_char_render_tests {
 
         let link_text: String = linked.iter().map(|run| run.text.as_str()).collect();
         assert_eq!(link_text, "/tmp/日本/main.rs:12");
-    }
 
-    #[test]
-    fn a_link_after_a_wide_character_still_lands_on_the_right_characters() {
-        let runs = row_runs(&row_zero("好 src/main.rs done", 40));
-        let linked: Vec<&RowRun> = runs.iter().filter(|run| run.link.is_some()).collect();
-        let link_text: String = linked.iter().map(|run| run.text.as_str()).collect();
-        assert_eq!(link_text, "src/main.rs");
-
-        let painted: String = runs.iter().map(|run| run.text.as_str()).collect();
-        assert_eq!(painted.trim_end(), "好 src/main.rs done");
+        // And a link sitting *after* a wide character still gets its own span with the plain
+        // text around it preserved - i.e. `split_segments`'s char offsets and the painted cells
+        // stayed in lockstep once the spacers were dropped.
+        let after = row_runs(&row_zero("好 src/main.rs done", 40));
+        let after_linked: Vec<&RowRun> = after.iter().filter(|run| run.link.is_some()).collect();
+        assert_eq!(
+            after_linked
+                .iter()
+                .map(|run| run.text.as_str())
+                .collect::<String>(),
+            "src/main.rs"
+        );
+        assert_eq!(
+            after
+                .iter()
+                .map(|run| run.text.as_str())
+                .collect::<String>()
+                .trim_end(),
+            "好 src/main.rs done"
+        );
     }
 
     #[test]
@@ -4342,6 +4190,7 @@ mod wide_char_render_tests {
             pane.read_with(cx, |pane, _| pane.visible_text_lines())[0],
             "完了 🎉"
         );
+        release(cx, pane);
     }
 }
 
@@ -4349,6 +4198,7 @@ mod wide_char_render_tests {
 /// rendered colours must follow the selected theme.
 #[cfg(test)]
 mod terminal_theme_tests {
+    use super::pty_pane_fixtures::release;
     use super::*;
     use gpui::{Entity, TestAppContext, VisualTestContext};
     use std::rc::Rc;
@@ -4463,36 +4313,7 @@ mod terminal_theme_tests {
             light.foreground,
             light.background
         );
-    }
-
-    #[gpui::test]
-    fn two_different_dark_themes_paint_two_different_terminals(cx: &mut TestAppContext) {
-        let (pane, cx) = painted_pane(cx, b"hello world");
-
-        let ember = {
-            let _theme = with_bundled_theme("Ember");
-            pane.update(cx, |_pane, cx| cx.notify());
-            cx.run_until_parked();
-            pane.read_with(cx, |pane, _| pane.last_painted_palette_for_test())
-                .expect("painted")
-        };
-        let moss = {
-            let _theme = with_bundled_theme("Moss");
-            pane.update(cx, |_pane, cx| cx.notify());
-            cx.run_until_parked();
-            pane.read_with(cx, |pane, _| pane.last_painted_palette_for_test())
-                .expect("painted")
-        };
-
-        assert_eq!(
-            ember.background,
-            bundled_rgb("Ember", "terminal.background")
-        );
-        assert_eq!(moss.background, bundled_rgb("Moss", "terminal.background"));
-        assert_ne!(
-            ember, moss,
-            "two bundled dark themes must not paint the terminal identically"
-        );
+        release(cx, pane);
     }
 
     #[gpui::test]
@@ -4517,19 +4338,7 @@ mod terminal_theme_tests {
             light_green, dark_green,
             "Paper ships the light ANSI palette, so its green is genuinely a different colour"
         );
-    }
-
-    #[gpui::test]
-    fn unstyled_output_takes_the_themes_own_foreground_and_background(cx: &mut TestAppContext) {
-        let (pane, cx) = painted_pane(cx, b"plain");
-        let _theme = with_bundled_theme("Slate");
-        pane.update(cx, |_pane, cx| cx.notify());
-        cx.run_until_parked();
-
-        let cell = pane.read_with(cx, |pane, _| pane.painted_rows_for_test()[0][0]);
-        assert_eq!(cell.c, 'p');
-        assert_eq!(cell.fg, bundled_rgb("Slate", "terminal.foreground"));
-        assert_eq!(cell.bg, bundled_rgb("Slate", "terminal.background"));
+        release(cx, pane);
     }
 }
 
@@ -4540,6 +4349,7 @@ mod terminal_theme_tests {
 /// loop while scrolled back neither moving the viewport nor going unnoticed.
 #[cfg(test)]
 mod scrollback_pane_tests {
+    use super::pty_pane_fixtures::release;
     use super::*;
     use gpui::{Modifiers, TestAppContext};
 
@@ -4606,18 +4416,42 @@ mod scrollback_pane_tests {
         cx: &mut gpui::VisualTestContext,
         predicate: impl Fn(&str) -> bool,
     ) -> String {
-        let mut joined = String::new();
-        for _ in 0..400 {
+        let joined = |cx: &mut gpui::VisualTestContext| {
+            pane.read_with(cx, |pane, _| pane.visible_text_lines())
+                .join("")
+        };
+        test_support::wait_until(super::pty_pane_fixtures::PTY_ROUND_TRIP, || {
             cx.background_executor.advance_clock(POLL_INTERVAL);
             cx.run_until_parked();
-            joined = pane
-                .read_with(cx, |pane, _| pane.visible_text_lines())
-                .join("");
-            if predicate(&joined) {
-                break;
-            }
-        }
-        joined
+            predicate(&joined(cx))
+        });
+        joined(cx)
+    }
+
+    /// A pane on a real `cat -v` child: it visualizes control bytes (`ESC` -> the literal two
+    /// characters `^[`) as ordinary printable text, so bytes this pane forwards to the child show
+    /// up in this same pane's own grid as literal text instead of being reinterpreted as escape
+    /// sequences by this same grid's own VT parser - the one way to observe the *exact* bytes a
+    /// real child process received without a second, hand-rolled test-only pty seam.
+    fn alt_screen_pane(
+        cx: &mut TestAppContext,
+    ) -> (gpui::Entity<TerminalPane>, &mut gpui::VisualTestContext) {
+        let (pane, cx) = cx.add_window_view(|_window, cx| {
+            TerminalPane::new(
+                TerminalSpec::command("cat", vec!["-v".to_string()], std::env::temp_dir()),
+                ROW_FONT_SIZE_PX,
+                cx,
+            )
+        });
+        cx.run_until_parked();
+        pane.update(cx, |pane, cx| {
+            pane.inject_bytes_for_test(b"\x1b[?1049h", cx); // enter the alt screen
+        });
+        assert!(
+            pane.read_with(cx, |pane, _| pane.grid.alt_scroll_forwarding_active()),
+            "sanity check: the grid must report the alt screen as active"
+        );
+        (pane, cx)
     }
 
     #[gpui::test]
@@ -4644,6 +4478,7 @@ mod scrollback_pane_tests {
             0,
             "PageDown by the same one page must land exactly back at live"
         );
+        release(cx, pane);
     }
 
     #[gpui::test]
@@ -4679,6 +4514,7 @@ mod scrollback_pane_tests {
             "no new content may appear after PageUp with no further input - a real echoed PageUp \
              byte sequence would show up here"
         );
+        release(cx, pane);
     }
 
     #[gpui::test]
@@ -4705,6 +4541,7 @@ mod scrollback_pane_tests {
             !pane.read_with(cx, |pane, _| pane.grid.is_scrolled_back()),
             "a real keystroke reaching the pty must jump the view back to live"
         );
+        release(cx, pane);
     }
 
     fn wheel_event(delta: gpui::ScrollDelta) -> ScrollWheelEvent {
@@ -4739,156 +4576,69 @@ mod scrollback_pane_tests {
             );
         });
         assert_eq!(pane.read_with(cx, |pane, _| pane.grid.scroll_offset()), 0);
+        release(cx, pane);
     }
 
     #[gpui::test]
-    fn alt_screen_scroll_forwards_page_keys_to_the_real_pty(cx: &mut TestAppContext) {
-        let (pane, cx) = cx.add_window_view(|_window, cx| {
-            TerminalPane::new(
-                TerminalSpec::command("cat", vec!["-v".to_string()], std::env::temp_dir()),
-                ROW_FONT_SIZE_PX,
-                cx,
-            )
-        });
-        cx.run_until_parked();
+    fn an_alt_screen_scroll_forwards_page_keys_proportionally_and_never_arrow_keys(
+        cx: &mut TestAppContext,
+    ) {
+        for (lines, page_ups, page_downs, what) in [
+            (2.0, 1, 0, "a two-line upward scroll, under one notch"),
+            (
+                -3.0,
+                0,
+                1,
+                "a three-line downward scroll, exactly one notch",
+            ),
+            (3.0 * WHEEL_LINES_PER_NOTCH, 3, 0, "a three-notch flick"),
+        ] {
+            let (pane, cx) = alt_screen_pane(cx);
 
-        pane.update(cx, |pane, cx| {
-            pane.inject_bytes_for_test(b"\x1b[?1049h", cx); // enter the alt screen
-        });
-        assert!(
-            pane.read_with(cx, |pane, _| pane.grid.alt_scroll_forwarding_active()),
-            "sanity check: the grid must report the alt screen as active before scrolling"
-        );
+            pane.update_in(cx, |pane, window, cx| {
+                pane.handle_scroll_wheel(
+                    &wheel_event(gpui::ScrollDelta::Lines(gpui::point(0.0, lines))),
+                    window,
+                    cx,
+                );
+            });
 
-        pane.update_in(cx, |pane, window, cx| {
-            pane.handle_scroll_wheel(
-                &wheel_event(gpui::ScrollDelta::Lines(gpui::point(0.0, 2.0))),
-                window,
-                cx,
+            let joined = drain_until(&pane, cx, |text| {
+                text.matches("^[[5~").count() >= page_ups
+                    && text.matches("^[[6~").count() >= page_downs
+            });
+
+            assert_eq!(
+                pane.read_with(cx, |pane, _| pane.grid.scroll_offset()),
+                0,
+                "the alt screen has no scrollback of its own - scroll_display must never have \
+                 moved for {what}"
             );
-        });
-
-        // Real `cat -v` printing back exactly what it received on stdin - pump the poll loop
-        // until it lands.
-        let joined = drain_until(&pane, cx, |text| text.contains("^[[5~"));
-
-        assert_eq!(
-            pane.read_with(cx, |pane, _| pane.grid.scroll_offset()),
-            0,
-            "the alt screen has no scrollback of its own - scroll_display must never have moved"
-        );
-        assert_eq!(
-            joined.matches("^[[5~").count(),
-            1,
-            "a two-line upward scroll is under one wheel notch, so it must forward exactly one \
-             real PageUp byte sequence, visualized by `cat -v` as the literal text `^[[5~`: \
-             {joined:?}"
-        );
-        assert_eq!(
-            joined.matches("^[[6~").count(),
-            0,
-            "an upward scroll must never also send a PageDown byte sequence: {joined:?}"
-        );
-        assert_eq!(
-            joined.matches("^[[A").count() + joined.matches("^[[B").count(),
-            0,
-            "GitHub issue #368: no arrow-key bytes may reach the child any more - forwarding \
-             those is what made Claude Code's CLI tell the user to press PgUp/PgDn instead: \
-             {joined:?}"
-        );
-    }
-
-    #[gpui::test]
-    fn alt_screen_scroll_down_forwards_page_down_keys(cx: &mut TestAppContext) {
-        let (pane, cx) = cx.add_window_view(|_window, cx| {
-            TerminalPane::new(
-                TerminalSpec::command("cat", vec!["-v".to_string()], std::env::temp_dir()),
-                ROW_FONT_SIZE_PX,
-                cx,
-            )
-        });
-        cx.run_until_parked();
-
-        pane.update(cx, |pane, cx| {
-            pane.inject_bytes_for_test(b"\x1b[?1049h", cx); // enter the alt screen
-        });
-
-        pane.update_in(cx, |pane, window, cx| {
-            pane.handle_scroll_wheel(
-                &wheel_event(gpui::ScrollDelta::Lines(gpui::point(0.0, -3.0))),
-                window,
-                cx,
+            assert_eq!(
+                joined.matches("^[[5~").count(),
+                page_ups,
+                "{what} must forward exactly {page_ups} real PageUp sequence(s), visualized by \
+                 `cat -v` as the literal text `^[[5~`: {joined:?}"
             );
-        });
-
-        let joined = drain_until(&pane, cx, |text| text.contains("^[[6~"));
-        assert_eq!(
-            joined.matches("^[[6~").count(),
-            1,
-            "a three-line downward scroll is exactly one wheel notch \
-             ([`WHEEL_LINES_PER_NOTCH`]), so it must forward exactly one real PageDown byte \
-             sequence - not one per line, which would fling a full-screen program three \
-             screenfuls away on a single detent: {joined:?}"
-        );
-        assert_eq!(joined.matches("^[[5~").count(), 0);
-        assert_eq!(
-            joined.matches("^[[A").count() + joined.matches("^[[B").count(),
-            0
-        );
-    }
-
-    #[gpui::test]
-    fn a_fast_alt_screen_flick_forwards_proportionally_more_page_keys(cx: &mut TestAppContext) {
-        let (pane, cx) = cx.add_window_view(|_window, cx| {
-            TerminalPane::new(
-                TerminalSpec::command("cat", vec!["-v".to_string()], std::env::temp_dir()),
-                ROW_FONT_SIZE_PX,
-                cx,
-            )
-        });
-        cx.run_until_parked();
-
-        pane.update(cx, |pane, cx| {
-            pane.inject_bytes_for_test(b"\x1b[?1049h", cx); // enter the alt screen
-        });
-
-        pane.update_in(cx, |pane, window, cx| {
-            pane.handle_scroll_wheel(
-                &wheel_event(gpui::ScrollDelta::Lines(gpui::point(
-                    0.0,
-                    3.0 * WHEEL_LINES_PER_NOTCH,
-                ))),
-                window,
-                cx,
+            assert_eq!(
+                joined.matches("^[[6~").count(),
+                page_downs,
+                "{what} must forward exactly {page_downs} real PageDown sequence(s): {joined:?}"
             );
-        });
-
-        let joined = drain_until(&pane, cx, |text| text.matches("^[[5~").count() >= 3);
-        assert_eq!(
-            joined.matches("^[[5~").count(),
-            3,
-            "three notches of upward delta must forward three real PageUp presses: {joined:?}"
-        );
+            assert_eq!(
+                joined.matches("^[[A").count() + joined.matches("^[[B").count(),
+                0,
+                "GitHub issue #368: no arrow-key bytes may reach the child any more - forwarding \
+                 those is what made Claude Code's CLI tell the user to press PgUp/PgDn instead: \
+                 {joined:?}"
+            );
+            release(cx, pane);
+        }
     }
 
     #[gpui::test]
     fn a_real_page_key_reaches_a_full_screen_program(cx: &mut TestAppContext) {
-        let (pane, cx) = cx.add_window_view(|_window, cx| {
-            TerminalPane::new(
-                TerminalSpec::command("cat", vec!["-v".to_string()], std::env::temp_dir()),
-                ROW_FONT_SIZE_PX,
-                cx,
-            )
-        });
-        cx.run_until_parked();
-
-        pane.update(cx, |pane, cx| {
-            pane.inject_bytes_for_test(b"\x1b[?1049h", cx); // enter the alt screen
-        });
-        assert!(
-            pane.read_with(cx, |pane, _| pane.grid.alt_screen_active()),
-            "sanity check: the alt screen must really be active"
-        );
+        let (pane, cx) = alt_screen_pane(cx);
 
         pane.update_in(cx, |pane, window, cx| {
             pane.handle_key_down(&key_event(nav_key("pageup")), window, cx);
@@ -4908,6 +4658,7 @@ mod scrollback_pane_tests {
             1,
             "a real PageDown press must cross the pty as the standard `ESC [ 6 ~`: {joined:?}"
         );
+        release(cx, pane);
     }
 
     #[gpui::test]
@@ -4939,6 +4690,7 @@ mod scrollback_pane_tests {
             "back on the normal screen, a scroll must move real scroll_display exactly as \
              before this issue - not still be forwarded to the child as key presses"
         );
+        release(cx, pane);
     }
 
     #[gpui::test]
@@ -5016,6 +4768,7 @@ mod scrollback_pane_tests {
             "real overflow must still create real scrollback"
         );
         assert!(cx.debug_bounds("terminal-scrollbar").is_some());
+        release(cx, pane);
     }
 
     #[gpui::test]
@@ -5055,40 +4808,25 @@ mod scrollback_pane_tests {
             "once the resize really reached the live pty, the pane is settled and the one-time \
              discard has run"
         );
+        release(cx, pane);
     }
 
-    #[gpui::test]
-    fn a_fresh_pane_with_little_content_shows_no_scrollbar(cx: &mut TestAppContext) {
-        let (pane, cx) = new_pane(cx);
-        pane.update(cx, |pane, cx| {
-            pane.inject_bytes_for_test(b"$ echo hello\r\nhello\r\n$ ", cx);
-        });
-        cx.run_until_parked();
-
-        assert_eq!(
-            pane.read_with(cx, |pane, _| pane.grid.scroll_history_len()),
-            0,
-            "a handful of lines, well under the real viewport height, must never manufacture \
-             scrollback"
-        );
-        assert!(
-            cx.debug_bounds("terminal-scrollbar").is_none(),
-            "the scrollbar must not be painted when there is nothing to scroll to"
-        );
-
-        let rows = pane.read_with(cx, |pane, _| pane.grid_dimensions().1 as usize);
-        push_numbered_lines(&pane, cx, rows * 3);
-
-        assert!(
-            pane.read_with(cx, |pane, _| pane.grid.scroll_history_len()) > 0,
-            "sanity check: this really did overflow"
-        );
-        assert!(
-            cx.debug_bounds("terminal-scrollbar").is_some(),
-            "genuine overflow must still show the scrollbar - this fix must not suppress it"
-        );
-    }
-
+    /// The precise mechanism behind the placeholder-spawn race (GitHub issue #362):
+    /// `TerminalPane::new`
+    /// spawns the child (and sizes `TerminalGrid`) at the `TERMINAL_ROWS`/`TERMINAL_COLS`
+    /// placeholder before this pane has ever measured its own real content-box size. If the
+    /// child prints more than the eventual *real* (smaller) viewport will hold - but still less
+    /// than the placeholder's own height - before that correction lands,
+    /// `alacritty_terminal`'s own shrink-resize semantics legitimately evict the overflow into
+    /// real retained scrollback the instant `TerminalPane::maybe_resize_pty` applies the
+    /// correct, smaller size. This reproduces that exact race deterministically by resetting a
+    /// pane back to its pre-first-paint state (a placeholder-sized grid, `content_bounds` still
+    /// unmeasured), resizing the pane's *real* test window down to the small target size the
+    /// eventual measurement will find, then printing content that fits the placeholder but not
+    /// that real size - the pane's own measuring `canvas()` self-heals toward the real window on
+    /// its own once it renders again (see that `canvas()` call's own docs), so this only has to
+    /// drive real output and let a couple of real frames land, not call `maybe_resize_pty`
+    /// directly the way this test did before that self-healing existed.
     #[gpui::test]
     fn the_placeholder_spawn_races_content_bounds_but_the_first_real_resize_discards_it(
         cx: &mut TestAppContext,
@@ -5200,6 +4938,7 @@ mod scrollback_pane_tests {
              via the ordinary shrink path - this fix must not have latched some permanent \
              discard-on-every-resize behavior"
         );
+        release(cx, pane);
     }
 
     #[gpui::test]
@@ -5243,6 +4982,7 @@ mod scrollback_pane_tests {
             "two 2/3-row deltas together exceed one full row and must produce a real one-line \
              scroll, not be dropped individually"
         );
+        release(cx, pane);
     }
 
     #[gpui::test]
@@ -5339,6 +5079,7 @@ mod scrollback_pane_tests {
         cx.run_until_parked();
         assert!(!pane.read_with(cx, |pane, _| pane.grid.is_scrolled_back()));
         assert!(!pane.read_with(cx, |pane, _| pane.new_output_while_scrolled));
+        release(cx, pane);
     }
 
     #[test]

--- a/crates/app/src/test_support.rs
+++ b/crates/app/src/test_support.rs
@@ -1,0 +1,133 @@
+//! GPUI-flavoured test fixtures: opening a real `AdeApp` in a test window.
+//!
+//! Deliberately *not* part of `crates/test-support`, which the gpui-free core crates
+//! dev-depend on (`docs/architecture/decisions.md` §1) — a Cargo feature would not be enough,
+//! since workspace feature unification would pull `gpui` into their dev graph anyway. Repo,
+//! git and wait fixtures with no GPUI in them belong there, not here.
+
+use crate::root::AdeApp;
+use crate::settings::store as settings_store;
+use gpui::{Entity, TestAppContext, VisualTestContext};
+use std::path::{Path, PathBuf};
+
+/// A temporary directory whose [`Self::path`] is already the root `AdeApp` will resolve it to.
+///
+/// `AdeApp` canonicalizes every repo root it is handed ([`crate::rail::repo::canonical_repo_path`])
+/// and then keys repos, worktrees, agents and open files by exact-path equality or `strip_prefix`
+/// against it. On macOS `std::env::temp_dir()` is behind a `/var` -> `/private/var` symlink, so a
+/// fixture that hands the app a bare `tempfile::TempDir::path()` and then builds its expected
+/// values from that same uncanonicalized path compares two different strings for the same
+/// directory, and every worktree-scoped lookup in the test silently misses.
+pub(crate) struct TempRoot {
+    /// Held for its `Drop`; the directory is removed when this value is.
+    _dir: tempfile::TempDir,
+    root: PathBuf,
+}
+
+impl TempRoot {
+    pub(crate) fn path(&self) -> &Path {
+        &self.root
+    }
+
+    pub(crate) fn to_path_buf(&self) -> PathBuf {
+        self.root.clone()
+    }
+
+    /// Writes `contents` to a `self`-relative `name`, creating parent directories, and returns the
+    /// absolute path.
+    pub(crate) fn write(&self, name: &str, contents: &str) -> PathBuf {
+        let path = self.root.join(name);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).expect("create parent directories");
+        }
+        std::fs::write(&path, contents).expect("write fixture file");
+        path
+    }
+}
+
+/// An empty [`TempRoot`] — for the tests whose subject is a directory, not a repository.
+pub(crate) fn temp_root() -> TempRoot {
+    let dir = tempfile::tempdir().expect("tempdir");
+    canonicalized(dir)
+}
+
+/// A [`TempRoot`] holding `test_support::seed_repo`'s repository: branch `main`, one commit
+/// (`file.txt`), clean tree.
+pub(crate) fn temp_repo() -> TempRoot {
+    canonicalized(test_support::seed_repo())
+}
+
+/// A [`TempRoot`] whose repository `seed` builds against the canonicalized root, so a fixture that
+/// seeds commits and one that records app state agree on a single spelling of the path.
+pub(crate) fn temp_repo_with(seed: impl FnOnce(&Path)) -> TempRoot {
+    let root = canonicalized(tempfile::tempdir().expect("tempdir"));
+    seed(root.path());
+    root
+}
+
+fn canonicalized(dir: tempfile::TempDir) -> TempRoot {
+    let root = dir.path().canonicalize().expect("canonicalize tempdir");
+    TempRoot { _dir: dir, root }
+}
+
+/// Opens an `AdeApp` in a test GPUI window against `repo_path`.
+///
+/// Uses `AdeApp::new_with_settings` with an in-memory `Settings::default()` and no settings
+/// path, so a test never reads or writes the developer's real `settings.toml`.
+pub(crate) fn open_test_app(
+    cx: &mut TestAppContext,
+    repo_path: PathBuf,
+) -> (Entity<AdeApp>, &mut VisualTestContext) {
+    open_test_app_with_settings(cx, repo_path, settings_store::Settings::default(), None)
+}
+
+/// [`open_test_app`] with an explicit settings value and, optionally, a real on-disk settings
+/// path — for the tests that assert on what actually gets persisted.
+pub(crate) fn open_test_app_with_settings(
+    cx: &mut TestAppContext,
+    repo_path: PathBuf,
+    settings: settings_store::Settings,
+    settings_path: Option<PathBuf>,
+) -> (Entity<AdeApp>, &mut VisualTestContext) {
+    cx.add_window_view(|window, cx| {
+        AdeApp::new_with_settings(Some(repo_path), true, settings, settings_path, window, cx)
+    })
+}
+
+#[cfg(test)]
+mod test_window_fixture_tests {
+    use crate::rail::repo::canonical_repo_path;
+    use crate::settings::store::Settings;
+    use crate::test_support::{open_test_app, open_test_app_with_settings};
+    use gpui::TestAppContext;
+
+    #[gpui::test]
+    fn open_test_app_focuses_the_repository_it_is_given(cx: &mut TestAppContext) {
+        let repo = test_support::seed_repo();
+
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+
+        assert_eq!(
+            app.read_with(cx, |app, _| app.focused_repo_path()),
+            canonical_repo_path(repo.path()),
+            "the fixture must open on the caller's repository, not one remembered on disk"
+        );
+    }
+
+    #[gpui::test]
+    fn open_test_app_with_settings_carries_the_settings_it_is_given(cx: &mut TestAppContext) {
+        let repo = test_support::seed_repo();
+        let mut settings = Settings::default();
+        settings.appearance.editor_font_size = 21.0;
+
+        let (app, cx) = open_test_app_with_settings(cx, repo.path().to_path_buf(), settings, None);
+        cx.run_until_parked();
+
+        assert_eq!(
+            app.read_with(cx, |app, _| app.settings.appearance.editor_font_size),
+            21.0,
+            "a test that passes settings in must see them, or it is asserting on defaults"
+        );
+    }
+}

--- a/crates/app/src/theme.rs
+++ b/crates/app/src/theme.rs
@@ -2778,36 +2778,21 @@ mod lang_token_tests {
         same(a.0.resolve(), b.0.resolve()) && same(a.1.resolve(), b.1.resolve())
     }
 
+    /// The four language chips design spec D pins by hex. The rest of the chips are checked only
+    /// for distinctness, below - the spec names these four.
     #[test]
-    fn ts_matches_the_real_spec_d_hex_pair() {
-        assert!(same_pair(
-            lang::TS,
-            (rgba_from_u32(0x6b9bd1), rgba_from_u32(0x1b2838))
-        ));
-    }
-
-    #[test]
-    fn vue_matches_the_real_spec_d_hex_pair() {
-        assert!(same_pair(
-            lang::VUE,
-            (rgba_from_u32(0x5cb87f), rgba_from_u32(0x16261e))
-        ));
-    }
-
-    #[test]
-    fn py_matches_the_real_spec_d_hex_pair() {
-        assert!(same_pair(
-            lang::PY,
-            (rgba_from_u32(0xc9b04a), rgba_from_u32(0x2a2612))
-        ));
-    }
-
-    #[test]
-    fn go_matches_the_real_spec_d_hex_pair() {
-        assert!(same_pair(
-            lang::GO,
-            (rgba_from_u32(0x5fa8c4), rgba_from_u32(0x152730))
-        ));
+    fn every_spec_pinned_lang_chip_still_carries_its_spec_hex_pair() {
+        for (name, chip, foreground, background) in [
+            ("ts", lang::TS, 0x6b9bd1, 0x1b2838),
+            ("vue", lang::VUE, 0x5cb87f, 0x16261e),
+            ("py", lang::PY, 0xc9b04a, 0x2a2612),
+            ("go", lang::GO, 0x5fa8c4, 0x152730),
+        ] {
+            assert!(
+                same_pair(chip, (rgba_from_u32(foreground), rgba_from_u32(background))),
+                "{name}'s chip no longer matches its spec hex pair"
+            );
+        }
     }
 
     #[test]
@@ -2848,16 +2833,10 @@ mod ui_scale_tests {
     use super::ui_scale::scaled_px;
 
     #[test]
-    fn one_hundred_percent_is_a_real_no_op() {
-        assert_eq!(scaled_px(12.0, 100), px(12.0));
-    }
-
-    #[test]
-    fn scales_up_and_down_proportionally() {
-        // `125`/`50` (not e.g. `90`) so the expected value is exactly representable in `f32`
-        // and this stays an exact-equality check rather than needing an epsilon comparison.
-        assert_eq!(scaled_px(12.0, 125), px(15.0));
-        assert_eq!(scaled_px(12.0, 50), px(6.0));
+    fn ui_scale_scales_proportionally_and_leaves_one_hundred_percent_alone() {
+        for (percent, expected) in [(100, 12.0), (150, 18.0), (50, 6.0)] {
+            assert_eq!(scaled_px(12.0, percent), px(expected), "at {percent}%");
+        }
     }
 }
 
@@ -3670,23 +3649,20 @@ mod syntax_contrast_tests {
             .collect()
     }
 
-    #[test]
-    fn every_syntax_token_clears_a_real_contrast_floor_in_jerry_dark_and_paper() {
-        const MIN_RATIO: f32 = 2.5;
-        for name in ["Jerry Dark", "Paper"] {
-            let _guard = with_bundled_theme(name);
-            let background = surface::CENTER.resolve();
-            for (key, token) in syntax_tokens() {
-                let ratio = contrast_ratio(token.resolve(), background);
-                assert!(
-                    ratio >= MIN_RATIO,
-                    "{key} only reaches {ratio:.2}:1 against surface::CENTER in {name} - below \
-                     the real {MIN_RATIO}:1 floor"
-                );
-            }
-        }
-    }
-
+    /// The sidebar strip's one structural invariant, in every bundled theme (GitHub issue #291).
+    ///
+    /// `design_handoff_jerry_ade/revision 5/STAGE-A-CHANGELOG.md` §4v: "a tab only reads as
+    /// connected if the strip behind it is **darker than the panel**, and here strip and rail were
+    /// both `#101113`, so the slab floated." The selected cell fills with [`surface::RAIL`] and
+    /// paints its own rule in the same colour, so a theme that let [`surface::SIDEBAR_STRIP`]
+    /// collapse onto `RAIL` would take the strip's entire selection idiom with it - a failure no
+    /// contrast floor catches, because both colours would still be perfectly legible.
+    ///
+    /// Stated as *recession*, not as "darker", because `Paper` is a real bundled light theme whose
+    /// derivation legitimately inverts the ramp: there, every surface Jerry Dark makes darker is
+    /// made lighter. So the invariant is measured against [`surface::WINDOW`] - the palette's own
+    /// "one step back from a panel" - and asks only that the strip sits on that same side of the
+    /// rail, by at least as much.
     #[test]
     fn the_sidebar_strip_stays_recessed_below_the_rail_in_every_bundled_theme() {
         for def in crate::settings::state::THEME_DEFS.iter() {
@@ -3717,18 +3693,27 @@ mod syntax_contrast_tests {
         }
     }
 
+    /// Two floors, because `Jerry Dark` and `Paper` are the two palettes actually authored - the
+    /// other four are mechanical `derive_shift` transforms and are held to a looser bound so a
+    /// derivation artifact does not read as a palette defect.
     #[test]
-    fn every_syntax_token_clears_a_looser_floor_across_every_bundled_theme() {
+    fn every_syntax_token_clears_its_themes_own_contrast_floor() {
+        const MIN_RATIO_AUTHORED: f32 = 2.5;
         const MIN_RATIO: f32 = 1.5;
         for def in crate::settings::state::THEME_DEFS.iter() {
             let _guard = with_bundled_theme(def.name);
+            let min_ratio = if matches!(def.name, "Jerry Dark" | "Paper") {
+                MIN_RATIO_AUTHORED
+            } else {
+                MIN_RATIO
+            };
             let background = surface::CENTER.resolve();
             for (key, token) in syntax_tokens() {
                 let ratio = contrast_ratio(token.resolve(), background);
                 assert!(
-                    ratio >= MIN_RATIO,
+                    ratio >= min_ratio,
                     "{key} only reaches {ratio:.2}:1 against surface::CENTER in {} - below the \
-                     real {MIN_RATIO}:1 floor",
+                     real {min_ratio}:1 floor",
                     def.name
                 );
             }
@@ -3788,38 +3773,16 @@ mod syntax_bracket_ring_tests {
             .collect()
     }
 
-    #[test]
-    fn cyclically_adjacent_ring_colours_stay_far_apart_in_every_bundled_theme() {
-        // Lower again than the ring this replaced, and for the same *kind* of reason it was
-        // lowered once before: ΔE is bought with chroma, and the redesign's ring is deliberately
-        // held below the palette's accents in chroma (that is the spec - a bracket must never
-        // shout louder than a string). Six hues at one lightness and one low chroma have a
-        // mathematical ceiling on how far apart they can be, and 18 is set from what a reader
-        // needs - ~8x the ~2.3 just-noticeable difference - not from what an optimiser can reach.
-        // Real measured worst case across every bundled theme: 20.7.
-        const MIN_DELTA_E: f32 = 18.0;
-        for def in crate::settings::state::THEME_DEFS.iter() {
-            let _guard = with_bundled_theme(def.name);
-            let ring = ring_tokens();
-            for index in 0..ring.len() {
-                let (name_a, token_a) = ring[index];
-                let (name_b, token_b) = ring[(index + 1) % ring.len()];
-                let distance = delta_e(token_a.resolve(), token_b.resolve());
-                assert!(
-                    distance >= MIN_DELTA_E,
-                    "{name_a} and {name_b} are adjacent depths but only ΔE {distance:.1} apart in \
-                     {} - a reader could not tell one nesting level from the next",
-                    def.name
-                );
-            }
-        }
-    }
-
+    /// The whole point of the feature: two nesting levels a reader is comparing must not look
+    /// alike. Every pair, not only the cyclically adjacent ones - six levels of nesting has to
+    /// stay legible, not merely three.
     #[test]
     fn no_two_ring_colours_collide_in_any_bundled_theme() {
-        // With six hues evenly spaced at one lightness and one chroma, the nearest pair *is* an
-        // adjacent pair, so this floor is the same one - see above for why it is what it is. Real
-        // measured worst case: 20.7.
+        // ΔE is bought with chroma, and this ring is deliberately held below the palette's accents
+        // in chroma (a bracket must never shout louder than a string). Six hues at one lightness
+        // and one low chroma have a mathematical ceiling on how far apart they can be, so 18 is
+        // set from what a reader needs - ~8x the ~2.3 just-noticeable difference - not from what
+        // an optimiser can reach. Real measured worst case across every bundled theme: 20.7.
         const MIN_DELTA_E: f32 = 18.0;
         for def in crate::settings::state::THEME_DEFS.iter() {
             let _guard = with_bundled_theme(def.name);
@@ -3865,13 +3828,23 @@ mod syntax_bracket_ring_tests {
             ("VARIABLE", syntax::VARIABLE),
             ("ERROR_UNDERLINE", syntax::ERROR_UNDERLINE),
         ];
+        /// Measured worst case in Jerry Dark itself is 20.8, against 11.3 for the ring this
+        /// replaced - a palette that grew from eight semantic hue families to ten ended up with a
+        /// *more* clearly separated ring, which is the whole argument for spending lightness
+        /// rather than hue on it.
+        const MIN_DELTA_E_AUTHORED: f32 = 18.0;
         for def in crate::settings::state::THEME_DEFS.iter() {
             let _guard = with_bundled_theme(def.name);
+            let floor = if def.name == "Jerry Dark" {
+                MIN_DELTA_E_AUTHORED
+            } else {
+                MIN_DELTA_E
+            };
             for (ring_name, ring_token) in ring_tokens() {
                 for (accent_name, accent_token) in accents {
                     let distance = delta_e(ring_token.resolve(), accent_token.resolve());
                     assert!(
-                        distance >= MIN_DELTA_E,
+                        distance >= floor,
                         "{ring_name} is only ΔE {distance:.1} from {accent_name} in {} - a \
                          coloured bracket must never impersonate a semantic token",
                         def.name
@@ -3881,44 +3854,31 @@ mod syntax_bracket_ring_tests {
         }
     }
 
+    /// A *matched* bracket reading like an *unmatched* one would erase the whole
+    /// matched/unmatched distinction this feature's honest-degradation design rests on. Since the
+    /// redesign there are two tones to stay clear of, not one: plain text, and
+    /// `syntax::PUNCTUATION_BRACKET`'s own dimmer unmatched tone.
     #[test]
-    fn every_ring_colour_stays_clear_of_the_de_emphasized_bracket_tone() {
+    fn every_ring_colour_stays_clear_of_both_tones_it_must_not_be_mistaken_for() {
+        // Real measured worst case: 16.7, in Jerry Dark. If this fires after a change to the
+        // defaults, the generated theme files probably need regenerating (see
+        // `crate::settings::builtin_themes`).
         const MIN_DELTA_E: f32 = 14.0;
         for def in crate::settings::state::THEME_DEFS.iter() {
             let _guard = with_bundled_theme(def.name);
-            let unmatched = syntax::PUNCTUATION_BRACKET.resolve();
-            for (name, token) in ring_tokens() {
-                let distance = delta_e(token.resolve(), unmatched);
-                assert!(
-                    distance >= MIN_DELTA_E,
-                    "{name} is only ΔE {distance:.1} from the unmatched-bracket tone in {} - the \
-                     matched/unmatched distinction would be invisible",
-                    def.name
-                );
-            }
-        }
-    }
-
-    #[test]
-    fn every_ring_colour_is_perceptibly_different_from_plain_text() {
-        // Real measured worst case: 16.7, in Jerry Dark. Note this check got *harder* in the
-        // redesign, not easier: `syntax::PUNCTUATION_BRACKET` is no longer plain text but a
-        // genuinely dimmer tone, so a ring colour now has to stay clear of two different things.
-        // `every_ring_colour_stays_clear_of_the_de_emphasized_bracket_tone` covers the other one.
-        const MIN_DELTA_E: f32 = 14.0;
-        for def in crate::settings::state::THEME_DEFS.iter() {
-            let _guard = with_bundled_theme(def.name);
-            let text = syntax::TEXT.resolve();
-            for (name, token) in ring_tokens() {
-                let distance = delta_e(token.resolve(), text);
-                assert!(
-                    distance >= MIN_DELTA_E,
-                    "{name} is only ΔE {distance:.1} from plain text in {} - a matched bracket \
-                     would be indistinguishable from an unmatched one. If this fired after a \
-                     change to the defaults, the five generated theme files probably need \
-                     regenerating (see crate::settings::builtin_themes).",
-                    def.name
-                );
+            for (reference_name, reference) in [
+                ("the unmatched-bracket tone", syntax::PUNCTUATION_BRACKET),
+                ("plain text", syntax::TEXT),
+            ] {
+                for (name, token) in ring_tokens() {
+                    let distance = delta_e(token.resolve(), reference.resolve());
+                    assert!(
+                        distance >= MIN_DELTA_E,
+                        "{name} is only ΔE {distance:.1} from {reference_name} in {} - a matched \
+                         bracket would be indistinguishable from an unmatched one",
+                        def.name
+                    );
+                }
             }
         }
     }
@@ -4018,34 +3978,9 @@ mod syntax_bracket_ring_tests {
         }
     }
 
-    #[test]
-    fn no_ring_colour_impersonates_the_semantic_token_it_borrows_its_hue_from() {
-        const MIN_DELTA_E: f32 = 18.0;
-        let semantic: [(&str, ColorToken); 10] = [
-            ("KEYWORD", syntax::KEYWORD),
-            ("FUNCTION", syntax::FUNCTION),
-            ("FUNCTION_DEFINITION", syntax::FUNCTION_DEFINITION),
-            ("TYPE", syntax::TYPE),
-            ("CONSTANT", syntax::CONSTANT),
-            ("STRING", syntax::STRING),
-            ("VARIABLE", syntax::VARIABLE),
-            ("VARIABLE_PARAMETER", syntax::VARIABLE_PARAMETER),
-            ("PROPERTY", syntax::PROPERTY),
-            ("ATTRIBUTE", syntax::ATTRIBUTE),
-        ];
-        let _guard = with_bundled_theme("Jerry Dark");
-        for (ring_name, ring_token) in ring_tokens() {
-            for (semantic_name, semantic_token) in semantic {
-                let distance = delta_e(ring_token.resolve(), semantic_token.resolve());
-                assert!(
-                    distance >= MIN_DELTA_E,
-                    "{ring_name} is only ΔE {distance:.1} from {semantic_name} - a coloured \
-                     bracket would read as that token rather than as structure"
-                );
-            }
-        }
-    }
-
+    /// The ring is six *independently keyed* tokens a theme file can move one at a time, not six
+    /// aliases of one colour - the mistake that would quietly turn this feature back into the flat
+    /// single-bracket-colour non-solution GitHub issue #168 explicitly rejected.
     #[test]
     fn the_six_ring_tokens_are_six_real_independently_keyed_colours() {
         let keys: std::collections::HashSet<&str> =

--- a/crates/app/src/title_bar/menu.rs
+++ b/crates/app/src/title_bar/menu.rs
@@ -6,8 +6,6 @@
 //! versus "what can I actually do from it".
 
 use super::*;
-#[cfg(test)]
-use crate::root::focus::palette_focus_tests;
 use crate::root::widgets::{menu_popover_chrome, render_menu_group_divider};
 use crate::title_bar::menu_model::{MenuCommand, MenuRow};
 use crate::work_surface::render::render_dropdown_menu_row;
@@ -423,8 +421,8 @@ mod title_menu_tests {
     fn open_windows_variant(
         cx: &mut TestAppContext,
     ) -> (Entity<AdeApp>, &mut gpui::VisualTestContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         app.update(cx, |app, cx| {
             app.set_window_controls_style(WindowControlsStyle::WindowsLinuxStyle, cx);
         });
@@ -473,24 +471,23 @@ mod title_menu_tests {
     }
 
     #[gpui::test]
-    fn clicking_the_file_label_opens_the_real_file_menu(cx: &mut TestAppContext) {
+    fn clicking_each_title_label_opens_its_own_real_menu(cx: &mut TestAppContext) {
         let (app, cx) = open_windows_variant(cx);
-        let bounds = app.read_with(cx, |app, _| {
-            app.title_menu_button_bounds[TitleMenu::File.index()]
-        });
-        assert_ne!(
-            bounds,
-            gpui::Bounds::default(),
-            "the File label should have really painted by now"
-        );
 
-        cx.simulate_click(center_of(bounds), gpui::Modifiers::none());
-        cx.run_until_parked();
+        for menu in TitleMenu::ALL {
+            let bounds = app.read_with(cx, |app, _| app.title_menu_button_bounds[menu.index()]);
+            assert_ne!(
+                bounds,
+                gpui::Bounds::default(),
+                "the {} label should have really painted by now",
+                menu.label()
+            );
 
-        assert_eq!(
-            app.read_with(cx, |app, _| app.title_menu_open),
-            Some(TitleMenu::File)
-        );
+            cx.simulate_click(center_of(bounds), gpui::Modifiers::none());
+            cx.run_until_parked();
+
+            assert_eq!(app.read_with(cx, |app, _| app.title_menu_open), Some(menu));
+        }
     }
 
     #[gpui::test]
@@ -525,9 +522,9 @@ mod title_menu_tests {
     fn file_menu_open_folder_row_focuses_a_real_chosen_folder_in_this_window(
         cx: &mut TestAppContext,
     ) {
-        let original_repo = tempfile::tempdir().expect("tempdir");
-        let chosen_repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, original_repo.path().to_path_buf());
+        let original_repo = crate::test_support::temp_root();
+        let chosen_repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, original_repo.path().to_path_buf());
         app.update(cx, |app, cx| {
             app.set_window_controls_style(WindowControlsStyle::WindowsLinuxStyle, cx);
         });
@@ -610,28 +607,20 @@ mod title_menu_tests {
         });
     }
 
-    #[gpui::test]
-    fn clicking_the_edit_label_opens_the_real_edit_menu(cx: &mut TestAppContext) {
-        let (app, cx) = open_windows_variant(cx);
-        let bounds = app.read_with(cx, |app, _| {
-            app.title_menu_button_bounds[TitleMenu::Edit.index()]
-        });
-
-        cx.simulate_click(center_of(bounds), gpui::Modifiers::none());
-        cx.run_until_parked();
-
-        assert_eq!(
-            app.read_with(cx, |app, _| app.title_menu_open),
-            Some(TitleMenu::Edit)
-        );
-    }
-
+    /// The Edit menu's *first* row is now real **text** undo (GitHub issue #17), and it is a real
+    /// affordance in both directions: inert with nothing to undo (no `on_click` attached at all,
+    /// per `render_dropdown_menu_row`'s own enabled/disabled contract), and genuinely undoing the
+    /// active buffer's own last step once there is one.
+    ///
+    /// The negative half matters as much as the positive one: before this issue that same first
+    /// row fired a real `git reset --soft` while advertising `mod+z`, which is no longer what
+    /// `mod+z` does inside a text widget.
     #[gpui::test]
     fn edit_menu_text_undo_row_is_inert_until_there_is_real_text_to_undo(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
         let file_path = repo.path().join("notes.txt");
         std::fs::write(&file_path, "hello\n").expect("write notes.txt");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         app.update(cx, |app, cx| {
             app.set_window_controls_style(WindowControlsStyle::WindowsLinuxStyle, cx);
         });
@@ -691,22 +680,8 @@ mod title_menu_tests {
         assert_eq!(app.read_with(cx, |app, _| app.title_menu_open), None);
     }
 
-    #[gpui::test]
-    fn clicking_the_view_label_opens_the_real_view_menu(cx: &mut TestAppContext) {
-        let (app, cx) = open_windows_variant(cx);
-        let bounds = app.read_with(cx, |app, _| {
-            app.title_menu_button_bounds[TitleMenu::View.index()]
-        });
-
-        cx.simulate_click(center_of(bounds), gpui::Modifiers::none());
-        cx.run_until_parked();
-
-        assert_eq!(
-            app.read_with(cx, |app, _| app.title_menu_open),
-            Some(TitleMenu::View)
-        );
-    }
-
+    /// The View menu's first row ("Command Palette") really opens the real palette (default
+    /// scope, unlike the File menu's files-scoped row).
     #[gpui::test]
     fn view_menu_command_palette_row_opens_the_real_palette(cx: &mut TestAppContext) {
         let (app, cx) = open_windows_variant(cx);
@@ -728,22 +703,9 @@ mod title_menu_tests {
         });
     }
 
-    #[gpui::test]
-    fn clicking_the_agent_label_opens_the_real_agent_menu(cx: &mut TestAppContext) {
-        let (app, cx) = open_windows_variant(cx);
-        let bounds = app.read_with(cx, |app, _| {
-            app.title_menu_button_bounds[TitleMenu::Agent.index()]
-        });
-
-        cx.simulate_click(center_of(bounds), gpui::Modifiers::none());
-        cx.run_until_parked();
-
-        assert_eq!(
-            app.read_with(cx, |app, _| app.title_menu_open),
-            Some(TitleMenu::Agent)
-        );
-    }
-
+    /// The Agent menu's first row ("New Terminal") really spawns a new real agent tab (the
+    /// same real `Agents::spawn` call the tab strip's own `+` menu row and `secondary-n` use),
+    /// not just a decoration - the agent count genuinely increases.
     #[gpui::test]
     fn agent_menu_new_terminal_row_spawns_a_real_agent(cx: &mut TestAppContext) {
         let (app, cx) = open_windows_variant(cx);
@@ -770,22 +732,11 @@ mod title_menu_tests {
         });
     }
 
-    #[gpui::test]
-    fn clicking_the_help_label_opens_the_real_help_menu(cx: &mut TestAppContext) {
-        let (app, cx) = open_windows_variant(cx);
-        let bounds = app.read_with(cx, |app, _| {
-            app.title_menu_button_bounds[TitleMenu::Help.index()]
-        });
-
-        cx.simulate_click(center_of(bounds), gpui::Modifiers::none());
-        cx.run_until_parked();
-
-        assert_eq!(
-            app.read_with(cx, |app, _| app.title_menu_open),
-            Some(TitleMenu::Help)
-        );
-    }
-
+    /// The Help menu's real "About" row (the third row, after a divider - so this test drives it
+    /// through `AdeApp::select_settings_page` state directly rather than computing a third row's
+    /// pixel offset, since the exact click-point math for a row-after-a-divider is already
+    /// covered by the simpler first-row tests above) really opens Settings on the real
+    /// `SettingsPage::About` page.
     #[gpui::test]
     fn help_menu_about_opens_real_settings_on_the_about_page(cx: &mut TestAppContext) {
         let (app, cx) = open_windows_variant(cx);
@@ -868,136 +819,27 @@ mod title_menu_tests {
         );
     }
 
-    #[gpui::test]
-    fn agent_menu_discard_row_arms_then_executes_a_real_discard(cx: &mut TestAppContext) {
-        use std::process::Command;
-
-        fn git(dir: &std::path::Path, args: &[&str]) {
-            let output = Command::new("git")
-                .current_dir(dir)
-                .args(args)
-                .output()
-                .expect("failed to spawn git");
-            assert!(output.status.success(), "git {args:?} failed in {dir:?}");
-        }
-
-        let repo = tempfile::tempdir().expect("tempdir");
-        git(repo.path(), &["init", "-b", "main"]);
-        git(repo.path(), &["config", "user.email", "test@example.com"]);
-        git(repo.path(), &["config", "user.name", "Test User"]);
-        std::fs::write(repo.path().join("base.txt"), "base\n").expect("write");
-        git(repo.path(), &["add", "base.txt"]);
-        git(repo.path(), &["commit", "-m", "initial"]);
-
-        let worktree_container = tempfile::tempdir().expect("tempdir");
-        let worktree_path = worktree_container.path().join("feature-wt");
-        drop(worktree_container);
-        git(
-            repo.path(),
-            &[
-                "worktree",
-                "add",
-                "-b",
-                "feature",
-                worktree_path.to_str().expect("utf8 path"),
-            ],
-        );
-        std::fs::write(worktree_path.join("dirty.txt"), "uncommitted\n").expect("write");
-
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
-        app.update(cx, |app, cx| {
-            app.set_window_controls_style(WindowControlsStyle::WindowsLinuxStyle, cx);
-        });
-        let id = app.update_in(cx, |app, window, cx| {
-            app.agents.spawn(
-                ProcessKind::Shell,
-                worktree_path.clone(),
-                app.settings.appearance.terminal_font_size,
-                app.settings.terminal.shell_override(),
-                None,
-                window,
-                cx,
-            )
-        });
-        app.update_in(cx, |app, window, cx| {
-            app.select_agent(id, window, cx);
-        });
-        cx.run_until_parked();
-
-        // Agent>Discard worktree is the last row - two dividers and three earlier rows above
-        // it, so this drives the real handler directly (`request_discard_worktree`) rather than
-        // computing that row's exact pixel offset. What's under real test here is the *result*
-        // of two real calls through the exact same real method the row's `on_click` calls - the
-        // arm-then-close-or-not menu logic itself is covered separately below.
-        app.update_in(cx, |app, window, cx| {
-            app.request_discard_worktree(id, window, cx);
-        });
-        cx.run_until_parked();
-        assert_eq!(
-            app.read_with(cx, |app, _| app.discard_confirm_armed),
-            Some(id),
-            "the first click should only arm confirmation, matching the footer's own two-click \
-             discipline"
-        );
-        assert!(
-            worktree_path.exists(),
-            "an armed-but-not-yet-confirmed discard must not have touched the real worktree"
-        );
-
-        app.update_in(cx, |app, window, cx| {
-            app.request_discard_worktree(id, window, cx);
-        });
-        cx.run_until_parked();
-
-        assert!(
-            !worktree_path.exists(),
-            "the second, confirming click should have run the real discard, actually removing \
-             the worktree directory"
-        );
-        app.read_with(cx, |app, _| {
-            assert_eq!(app.discard_confirm_armed, None);
-        });
-    }
-
+    /// The title menu's own click-handling for the Discard row (not just
+    /// `request_discard_worktree` itself, already covered above): the first, arming click must
+    /// leave the menu open so the row's label can really swap to "confirm discard?" for a second
+    /// click, and the second, executing click must close it. Drives this through two real
+    /// simulated clicks on the actual rendered Discard row ([`nth_row_click_point`]), matching
+    /// this file's own established style for every other title-menu test - an earlier version of
+    /// this test hand-copied the row's `on_click` condition inline instead, which meant it could
+    /// never actually catch a bug in the real rendered row's own click wiring (e.g. a wrong
+    /// bounds computation, or the row silently missing its `on_click` entirely).
     #[gpui::test]
     fn agent_menu_discard_row_stays_open_while_armed_and_closes_once_confirmed(
         cx: &mut TestAppContext,
     ) {
-        use std::process::Command;
-
-        fn git(dir: &std::path::Path, args: &[&str]) {
-            let output = Command::new("git")
-                .current_dir(dir)
-                .args(args)
-                .output()
-                .expect("failed to spawn git");
-            assert!(output.status.success(), "git {args:?} failed in {dir:?}");
-        }
-
-        let repo = tempfile::tempdir().expect("tempdir");
-        git(repo.path(), &["init", "-b", "main"]);
-        git(repo.path(), &["config", "user.email", "test@example.com"]);
-        git(repo.path(), &["config", "user.name", "Test User"]);
-        std::fs::write(repo.path().join("base.txt"), "base\n").expect("write");
-        git(repo.path(), &["add", "base.txt"]);
-        git(repo.path(), &["commit", "-m", "initial"]);
-
-        let worktree_container = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_repo();
+        let worktree_container = crate::test_support::temp_root();
         let worktree_path = worktree_container.path().join("feature-wt");
         drop(worktree_container);
-        git(
-            repo.path(),
-            &[
-                "worktree",
-                "add",
-                "-b",
-                "feature",
-                worktree_path.to_str().expect("utf8 path"),
-            ],
-        );
-        std::fs::write(worktree_path.join("dirty.txt"), "uncommitted\n").expect("write");
+        test_support::add_worktree(repo.path(), "feature", &worktree_path);
+        test_support::write_file(&worktree_path, "dirty.txt", "uncommitted\n");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         app.update(cx, |app, cx| {
             app.set_window_controls_style(WindowControlsStyle::WindowsLinuxStyle, cx);
         });
@@ -1025,9 +867,7 @@ mod title_menu_tests {
         // The Discard row is the 8th real row (index 7, 0-based) in the Agent menu: New
         // Terminal, New Agent Pane, [divider], Next Agent, Previous Agent, [divider], Review
         // Agent, Archive Agent, Keep All Changes, Discard Worktree - seven real rows and two
-        // dividers sit above it (see `MenuCommand::rows`'s own row order). `Review Agent` joined
-        // that third group with GitHub issue #295, which deleted the agent pane footer's own
-        // `Review` door along with the rest of the finished-agent action bar.
+        // dividers sit above it (see `MenuCommand::rows`'s own row order).
         let bounds = app.read_with(cx, |app, _| {
             app.title_menu_button_bounds[TitleMenu::Agent.index()]
         });
@@ -1073,9 +913,9 @@ mod title_menu_tests {
 
     #[gpui::test]
     fn select_relative_agent_cycles_through_real_agents_and_wraps_around(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let other_wt = tempfile::tempdir().expect("tempdir b");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let other_wt = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         app.update(cx, |app, _cx| {
             app.worktrees = vec![
@@ -1240,8 +1080,8 @@ mod title_menu_tests {
 
     #[gpui::test]
     fn next_agent_skips_shells_and_enters_the_cycle_from_one(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         for _ in 0..2 {

--- a/crates/app/src/title_bar/render.rs
+++ b/crates/app/src/title_bar/render.rs
@@ -4,8 +4,6 @@
 //! [`super::menu`].
 
 use super::*;
-#[cfg(test)]
-use crate::root::focus::palette_focus_tests;
 use crate::root::plural;
 
 /// Half-diagonal of an 11×1px rect rotated ±45° about its own center - `5.5 * cos(45°)`. Used to
@@ -545,8 +543,8 @@ mod caption_button_tests {
 
     #[gpui::test]
     fn clicking_the_close_caption_button_closes_the_real_window(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         // Pin the Windows/Linux caption-button variant regardless of the real host OS this test
         // happens to run on, so the test is deterministic everywhere.
@@ -579,8 +577,8 @@ mod caption_button_tests {
     fn a_single_click_on_empty_title_bar_space_never_reaches_the_maximize_call(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
         let _ = app;
 
@@ -614,8 +612,8 @@ mod macos_dot_cluster_tests {
 
     #[gpui::test]
     fn clicking_the_macos_maximize_dot_toggles_fullscreen_both_ways(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         // Pin the macOS dot-cluster variant regardless of the real host OS this test happens to
         // run on, so the test is deterministic everywhere (the same reasoning
@@ -688,8 +686,12 @@ mod agent_state_chip_text_tests {
         }
     }
 
+    /// The formatter's silence rules: a zero count never renders a chip for any status, and
+    /// `Review`/`Idle` never render one at all however non-zero they are. The design's own
+    /// title-bar example names exactly three states (§4) - finished and idle counts already have
+    /// a real home in the rail's agent rows and the status bar's five-way dot row.
     #[test]
-    fn a_zero_count_is_hidden_for_every_status() {
+    fn chip_text_is_silent_for_a_zero_count_and_for_review_or_idle() {
         for status in Status::ORDER {
             assert_eq!(
                 title_bar_agent_state_chip_text(status, 0),
@@ -697,15 +699,30 @@ mod agent_state_chip_text_tests {
                 "a zero count must never render a chip, for {status:?}"
             );
         }
-    }
-
-    #[test]
-    fn review_and_idle_never_get_a_title_bar_chip_even_with_a_real_nonzero_count() {
-        // The design's own title-bar example names exactly three states (§4) - finished and
-        // idle counts already have a real home in the rail's own agent rows and the status
-        // bar's five-way dot row, so they must stay silent here even when genuinely non-zero.
         assert_eq!(title_bar_agent_state_chip_text(Status::Review, 3), None);
         assert_eq!(title_bar_agent_state_chip_text(Status::Idle, 5), None);
+    }
+
+    /// Each shown state's own wording, conjugated against its own count. `Run`'s two-and
+    /// four-agent forms are `design_handoff_jerry_ade/revision 3/REVISION-2026-07-31.md` §4's
+    /// literal example text, reproduced verbatim.
+    #[test]
+    fn each_shown_state_conjugates_its_own_noun_and_verb() {
+        let cases: &[(Status, usize, &str)] = &[
+            (Status::Ask, 1, "1 agent needs input"),
+            (Status::Ask, 2, "2 agents need input"),
+            (Status::Ask, 7, "7 agents need input"),
+            (Status::Fail, 1, "1 agent failed"),
+            (Status::Fail, 2, "2 agents failed"),
+            (Status::Run, 1, "1 agent running"),
+            (Status::Run, 4, "4 agents running"),
+        ];
+        for (status, count, expected) in cases {
+            assert_eq!(
+                title_bar_agent_state_chip_text(*status, *count).as_deref(),
+                Some(*expected)
+            );
+        }
     }
 
     #[test]
@@ -724,48 +741,13 @@ mod agent_state_chip_text_tests {
         }
     }
 
-    #[test]
-    fn ask_conjugates_its_verb_at_exactly_one_vs_two_or_more() {
-        assert_eq!(
-            title_bar_agent_state_chip_text(Status::Ask, 1).as_deref(),
-            Some("1 agent needs input")
-        );
-        assert_eq!(
-            title_bar_agent_state_chip_text(Status::Ask, 2).as_deref(),
-            Some("2 agents need input")
-        );
-        assert_eq!(
-            title_bar_agent_state_chip_text(Status::Ask, 7).as_deref(),
-            Some("7 agents need input")
-        );
-    }
-
-    #[test]
-    fn fail_pluralizes_the_noun_only_the_verb_does_not_conjugate() {
-        assert_eq!(
-            title_bar_agent_state_chip_text(Status::Fail, 1).as_deref(),
-            Some("1 agent failed")
-        );
-        assert_eq!(
-            title_bar_agent_state_chip_text(Status::Fail, 2).as_deref(),
-            Some("2 agents failed")
-        );
-    }
-
-    #[test]
-    fn run_matches_the_design_doc_s_own_worked_example_exactly() {
-        assert_eq!(
-            title_bar_agent_state_chip_text(Status::Run, 1).as_deref(),
-            Some("1 agent running")
-        );
-        // `design_handoff_jerry_ade/revision 3/REVISION-2026-07-31.md` §4's own literal
-        // example text - "4 agents running" - reproduced verbatim.
-        assert_eq!(
-            title_bar_agent_state_chip_text(Status::Run, 4).as_deref(),
-            Some("4 agents running")
-        );
-    }
-
+    /// Rev 6 §7 rule 4, quoted verbatim: "Two states distinguished anywhere in the app are never
+    /// summed anywhere in it."
+    ///
+    /// The title bar is where `ask`/`fail`/`run` are distinguished, so no agent may contribute to
+    /// more than one chip, and no chip may carry a count larger than the number of agents really
+    /// in that state. Proved by construction over a mixed row set: the chip counts must partition
+    /// the rows exactly, never overlap.
     #[test]
     fn no_agent_is_ever_counted_in_two_chips_at_once() {
         let rows = vec![
@@ -786,6 +768,18 @@ mod agent_state_chip_text_tests {
                  that summed two states would report more"
             );
         }
+        // The degenerate case the same bug would show up in first: one agent can only ever be
+        // in one state, so it can only ever produce one chip.
+        for status in [Status::Ask, Status::Fail, Status::Run] {
+            let single = title_bar_agent_state_chips(&[row(1, status)]);
+            assert_eq!(
+                single.len(),
+                1,
+                "one agent in {status:?} must produce exactly one chip"
+            );
+            assert_eq!(single[0].1, 1);
+        }
+
         let charged: usize = chips.iter().map(|(_, count, _)| count).sum();
         let chip_eligible = rows
             .iter()
@@ -800,19 +794,9 @@ mod agent_state_chip_text_tests {
         );
     }
 
-    #[test]
-    fn one_agent_produces_exactly_one_chip_whatever_its_state() {
-        for status in [Status::Ask, Status::Fail, Status::Run] {
-            let chips = title_bar_agent_state_chips(&[row(1, status)]);
-            assert_eq!(
-                chips.len(),
-                1,
-                "one agent in {status:?} must produce exactly one chip"
-            );
-            assert_eq!(chips[0].1, 1);
-        }
-    }
-
+    /// §4b's compaction: the chip shows a bare count, and the fully conjugated sentence is what
+    /// the tooltip carries - so the two halves must come out of the same call, and the number
+    /// shown must be the number the sentence names.
     #[test]
     fn each_chip_carries_both_its_compact_count_and_its_full_sentence() {
         let rows = vec![
@@ -834,11 +818,6 @@ mod agent_state_chip_text_tests {
     }
 
     #[test]
-    fn zero_agents_anywhere_produces_an_entirely_empty_chip_list() {
-        assert_eq!(title_bar_agent_state_chips(&[]), Vec::new());
-    }
-
-    #[test]
     fn only_non_empty_states_produce_a_chip_and_review_idle_are_excluded() {
         let rows = vec![
             row(1, Status::Ask),
@@ -850,6 +829,11 @@ mod agent_state_chip_text_tests {
             vec![(Status::Ask, 1, "1 agent needs input".to_string())],
             "only the one non-empty Ask/Fail/Run state should produce a chip - Review and Idle \
              must stay silent even though they are the majority of the rows"
+        );
+        assert_eq!(
+            title_bar_agent_state_chips(&[]),
+            Vec::new(),
+            "and with no agents anywhere the list is entirely empty"
         );
     }
 
@@ -904,7 +888,6 @@ mod agent_state_chip_text_tests {
 #[cfg(test)]
 mod agent_state_chip_live_tests {
     use super::*;
-    use crate::root::focus::palette_focus_tests;
     use gpui::TestAppContext;
 
     fn worktree_item(path: PathBuf, label: &str) -> WorktreeItem {
@@ -926,8 +909,8 @@ mod agent_state_chip_live_tests {
 
     #[gpui::test]
     fn closing_the_only_real_agent_makes_the_chip_row_disappear(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         let startup_agent_id = app
@@ -976,9 +959,9 @@ mod agent_state_chip_live_tests {
     fn a_second_real_spawned_agent_flips_the_live_chip_from_singular_to_plural(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let wt_b = tempfile::tempdir().expect("tempdir wt-b");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let wt_b = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         let startup_agent_id = app
@@ -1063,22 +1046,19 @@ mod agent_state_chip_live_tests {
         // "^L" - so what's checked here is the actual thing this test cares about,
         // `idle_duration` itself, not a literal byte sequence that this particular shell state
         // was never going to produce.
-        let refresh_deadline = std::time::Instant::now() + std::time::Duration::from_secs(45);
-        let mut first_agent_refreshed = false;
-        loop {
-            cx.background_executor
-                .advance_clock(std::time::Duration::from_millis(8));
-            cx.run_until_parked();
-            let idle = first_pane.read_with(cx, |pane, _| pane.idle_duration());
-            if idle.is_some_and(|idle| idle < std::time::Duration::from_secs(1)) {
-                first_agent_refreshed = true;
-                break;
-            }
-            if std::time::Instant::now() >= refresh_deadline {
-                break;
-            }
-            std::thread::sleep(std::time::Duration::from_millis(5));
-        }
+        // Both clocks advance together, one poll at a time: the pane only notices new output on
+        // a simulated-clock poll tick, while the real pty reader is an ordinary OS thread that
+        // only makes progress in real time. `test_support::wait_until` is the workspace's one
+        // sanctioned wall-clock wait (`docs/testing.md`).
+        let first_agent_refreshed =
+            test_support::wait_until(std::time::Duration::from_secs(30), || {
+                cx.background_executor
+                    .advance_clock(std::time::Duration::from_millis(8));
+                cx.run_until_parked();
+                first_pane
+                    .read_with(cx, |pane, _| pane.idle_duration())
+                    .is_some_and(|idle| idle < std::time::Duration::from_secs(1))
+            });
         assert!(
             first_agent_refreshed,
             "expected the first agent's real pty activity to refresh after this real Ctrl-L \

--- a/crates/app/src/work_surface/render.rs
+++ b/crates/app/src/work_surface/render.rs
@@ -2854,7 +2854,6 @@ pub(in crate::work_surface) fn render_status_pill(status: Status) -> impl IntoEl
 mod tab_scoping_tests {
     use super::*;
     use crate::rail::worktrees::WorktreeItem;
-    use crate::root::focus::palette_focus_tests;
     use gpui::{Focusable, TestAppContext};
 
     fn worktree_item(path: PathBuf, label: &str) -> WorktreeItem {
@@ -2880,9 +2879,9 @@ mod tab_scoping_tests {
 
     #[gpui::test]
     fn multiple_agents_in_one_worktree_all_show_as_tabs_under_it(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let wt_a = tempfile::tempdir().expect("tempdir a");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let wt_a = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         app.update(cx, |app, _cx| {
             app.worktrees = vec![worktree_item(wt_a.path().to_path_buf(), "wt-a")];
@@ -2922,10 +2921,10 @@ mod tab_scoping_tests {
 
     #[gpui::test]
     fn spawn_resume_prepends_resume_ahead_of_the_real_hook_injection(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
-        let hook_temp = tempfile::tempdir().expect("hook temp dir");
+        let hook_temp = crate::test_support::temp_root();
         let runtime = crate::hooks::HookRuntime::start(hook_temp.path())
             .expect("the hook runtime must start in a test sandbox");
         let injection = runtime.injection();
@@ -2976,9 +2975,9 @@ mod tab_scoping_tests {
     fn ctrl_p_still_works_after_switching_to_a_worktree_with_no_open_agent(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let wt_empty = tempfile::tempdir().expect("tempdir empty");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let wt_empty = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.update(|_window, cx| cx.bind_keys(crate::default_key_bindings()));
 
         app.update(cx, |app, _cx| {
@@ -3010,10 +3009,10 @@ mod tab_scoping_tests {
 
     #[gpui::test]
     fn switching_worktree_selection_shows_that_worktrees_own_tabs(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let wt_a = tempfile::tempdir().expect("tempdir a");
-        let wt_b = tempfile::tempdir().expect("tempdir b");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let wt_a = crate::test_support::temp_root();
+        let wt_b = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         app.update(cx, |app, _cx| {
             seed_two_worktrees(app, wt_a.path().to_path_buf(), wt_b.path().to_path_buf());
@@ -3072,9 +3071,9 @@ mod tab_scoping_tests {
     fn closing_the_active_tab_falls_back_to_a_sibling_in_the_same_worktree(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let wt_a = tempfile::tempdir().expect("tempdir a");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let wt_a = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         app.update(cx, |app, _cx| {
             app.worktrees = vec![worktree_item(wt_a.path().to_path_buf(), "wt-a")];
         });
@@ -3123,10 +3122,10 @@ mod tab_scoping_tests {
     fn closing_the_last_tab_in_a_worktree_never_falls_back_to_a_different_worktrees_agent(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let wt_a = tempfile::tempdir().expect("tempdir a");
-        let wt_b = tempfile::tempdir().expect("tempdir b");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let wt_a = crate::test_support::temp_root();
+        let wt_b = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.update(|_window, cx| cx.bind_keys(crate::default_key_bindings()));
         app.update(cx, |app, _cx| {
             seed_two_worktrees(app, wt_a.path().to_path_buf(), wt_b.path().to_path_buf());
@@ -3185,8 +3184,8 @@ mod tab_scoping_tests {
 
     #[gpui::test]
     fn drag_reordering_two_agent_tabs_changes_their_order(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         let (initial_id, id2, id3) = app.update_in(cx, |app, window, cx| {
             let initial_id = app.agents.active_id().expect("initial shell agent");
@@ -3238,8 +3237,8 @@ mod tab_scoping_tests {
 
     #[gpui::test]
     fn drag_reorder_is_a_no_op_for_an_unknown_or_identical_id(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         let initial_id = app.read_with(cx, |app, _| {
             app.agents.active_id().expect("initial shell agent")
         });
@@ -3277,9 +3276,9 @@ mod tab_scoping_tests {
 
     #[gpui::test]
     fn only_the_active_agents_pane_polls_at_the_foreground_cadence(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let wt_empty = tempfile::tempdir().expect("tempdir empty");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let wt_empty = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         let foreground_ids =
             |app: &gpui::Entity<AdeApp>, cx: &mut TestAppContext| -> Vec<AgentId> {
@@ -3346,11 +3345,12 @@ mod tab_scoping_tests {
     }
 
     #[gpui::test]
-    fn dragging_a_file_tab_between_two_agent_tabs_interleaves_them(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let file_path = repo.path().join("a.txt");
-        std::fs::write(&file_path, "hello\n").expect("write a.txt");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+    fn dragging_a_file_or_graph_tab_between_two_agent_tabs_interleaves_them(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = crate::test_support::temp_root();
+        let file_path = repo.write("a.txt", "hello\n");
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         let (initial_id, second_id) = app.update_in(cx, |app, window, cx| {
             let initial_id = app.agents.active_id().expect("initial shell agent");
@@ -3364,76 +3364,30 @@ mod tab_scoping_tests {
                 cx,
             );
             app.open_file_view(file_path.clone(), window, cx);
-            (initial_id, second_id)
-        });
-
-        let before = app.read_with(cx, |app, _| app.combined_tab_order());
-        assert_eq!(
-            before,
-            vec![
-                work_surface::TabRef::Agent(initial_id),
-                work_surface::TabRef::Agent(second_id),
-                work_surface::TabRef::File(PathBuf::from("a.txt")),
-            ],
-            "with no drag yet, agents come first (creation order), then files - the old \
-             two-block layout"
-        );
-
-        app.update(cx, |app, cx| {
-            app.reorder_tab(
-                work_surface::TabRef::File(PathBuf::from("a.txt")),
-                work_surface::TabRef::Agent(second_id),
-                false,
-                cx,
-            );
-        });
-
-        let after = app.read_with(cx, |app, _| app.combined_tab_order());
-        assert_eq!(
-            after,
-            vec![
-                work_surface::TabRef::Agent(initial_id),
-                work_surface::TabRef::File(PathBuf::from("a.txt")),
-                work_surface::TabRef::Agent(second_id),
-            ],
-            "the file tab must now sit between the two agent tabs - the real cross-group \
-             interleaving this revision exists to unlock"
-        );
-    }
-
-    #[gpui::test]
-    fn dragging_the_graph_tab_between_two_agent_tabs_interleaves_it(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
-
-        let (initial_id, second_id) = app.update_in(cx, |app, window, cx| {
-            let initial_id = app.agents.active_id().expect("initial shell agent");
-            let second_id = app.agents.spawn(
-                ProcessKind::claude(),
-                repo.path().to_path_buf(),
-                12.0,
-                None,
-                None,
-                window,
-                cx,
-            );
             app.open_git_graph(window, cx);
             (initial_id, second_id)
         });
 
-        let before = app.read_with(cx, |app, _| app.combined_tab_order());
+        let file_ref = work_surface::TabRef::File(PathBuf::from("a.txt"));
         assert_eq!(
-            before,
+            app.read_with(cx, |app, _| app.combined_tab_order()),
             vec![
                 work_surface::TabRef::Agent(initial_id),
                 work_surface::TabRef::Agent(second_id),
+                file_ref.clone(),
                 work_surface::TabRef::Graph,
             ],
-            "with no drag yet, agents come first (creation order), then the freshly opened \
-             graph tab"
+            "with no drag yet, agents come first (creation order), then the non-agent tabs - the \
+             old two-block layout"
         );
 
         app.update(cx, |app, cx| {
+            app.reorder_tab(
+                file_ref.clone(),
+                work_surface::TabRef::Agent(second_id),
+                false,
+                cx,
+            );
             app.reorder_tab(
                 work_surface::TabRef::Graph,
                 work_surface::TabRef::Agent(second_id),
@@ -3442,65 +3396,23 @@ mod tab_scoping_tests {
             );
         });
 
-        let after = app.read_with(cx, |app, _| app.combined_tab_order());
         assert_eq!(
-            after,
+            app.read_with(cx, |app, _| app.combined_tab_order()),
             vec![
                 work_surface::TabRef::Agent(initial_id),
+                file_ref,
                 work_surface::TabRef::Graph,
                 work_surface::TabRef::Agent(second_id),
             ],
-            "the graph tab must now sit between the two agent tabs, the same real \
-             cross-kind interleaving file/agent tabs already get"
-        );
-    }
-
-    #[gpui::test]
-    fn dragging_the_graph_tab_dims_its_own_slot_then_clears_on_drop(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
-
-        let initial_id = app.update_in(cx, |app, window, cx| {
-            app.open_git_graph(window, cx);
-            app.agents.active_id().expect("initial shell agent")
-        });
-
-        app.update(cx, |app, cx| {
-            app.start_dragging_tab(work_surface::TabRef::Graph, cx);
-        });
-        assert_eq!(
-            app.read_with(cx, |app, _| app.dragging_tab.clone()),
-            Some(work_surface::TabRef::Graph),
-            "starting a drag on the graph tab must record exactly that tab"
-        );
-
-        app.update(cx, |app, cx| {
-            app.drop_dragged_tab(
-                work_surface::TabRef::Graph,
-                work_surface::TabRef::Agent(initial_id),
-                cx,
-            );
-        });
-        assert_eq!(
-            app.read_with(cx, |app, _| app.dragging_tab.clone()),
-            None,
-            "a handled drop must clear the now-stale dragging-tab state, same as any other kind"
-        );
-        // GitHub issue #93's own extension of the settle-fade (GitHub issue #16 §5): dropping
-        // the graph tab must record it into `Self::dropped_tab_settle` exactly like any other
-        // kind - `Self::drop_dragged_tab` is already kind-agnostic here, so this is really
-        // proving `render_graph_tab` reads the same real field, not a separate code path.
-        assert_eq!(
-            app.read_with(cx, |app, _| app.dropped_tab_settle.clone().map(|(t, _)| t)),
-            Some(work_surface::TabRef::Graph),
-            "a real drop of the graph tab must record it for the settle-in fade too"
+            "both non-agent tabs must now sit between the two agent tabs - the real cross-group \
+             interleaving these revisions exist to unlock"
         );
     }
 
     #[gpui::test]
     fn drop_dragged_tab_honors_the_recorded_insertion_side_then_clears_it(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         let (initial_id, second_id) = app.update_in(cx, |app, window, cx| {
             let initial_id = app.agents.active_id().expect("initial shell agent");
@@ -3548,11 +3460,14 @@ mod tab_scoping_tests {
     }
 
     #[gpui::test]
-    fn start_dragging_tab_records_exactly_the_tab_that_started_the_drag(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
-        let initial_id = app.read_with(cx, |app, _| app.agents.active_id().expect("shell agent"));
+    fn a_drag_records_its_own_tab_on_start_and_clears_it_on_drop(cx: &mut TestAppContext) {
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
+        let initial_id = app.update_in(cx, |app, window, cx| {
+            app.open_git_graph(window, cx);
+            app.agents.active_id().expect("initial shell agent")
+        });
         assert_eq!(
             app.read_with(cx, |app, _| app.dragging_tab.clone()),
             None,
@@ -3560,50 +3475,30 @@ mod tab_scoping_tests {
         );
 
         app.update(cx, |app, cx| {
-            app.start_dragging_tab(work_surface::TabRef::Agent(initial_id), cx);
+            app.start_dragging_tab(work_surface::TabRef::Graph, cx);
         });
-
         assert_eq!(
             app.read_with(cx, |app, _| app.dragging_tab.clone()),
-            Some(work_surface::TabRef::Agent(initial_id)),
+            Some(work_surface::TabRef::Graph),
             "starting a drag must record exactly the tab that started it"
         );
-    }
 
-    #[gpui::test]
-    fn dropping_a_tab_clears_dragging_tab(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
-
-        let (initial_id, second_id) = app.update_in(cx, |app, window, cx| {
-            let initial_id = app.agents.active_id().expect("initial shell agent");
-            let second_id = app.agents.spawn(
-                ProcessKind::Shell,
-                repo.path().to_path_buf(),
-                12.0,
-                None,
-                None,
-                window,
-                cx,
-            );
-            (initial_id, second_id)
-        });
-
-        app.update(cx, |app, cx| {
-            app.start_dragging_tab(work_surface::TabRef::Agent(initial_id), cx);
-        });
         app.update(cx, |app, cx| {
             app.drop_dragged_tab(
+                work_surface::TabRef::Graph,
                 work_surface::TabRef::Agent(initial_id),
-                work_surface::TabRef::Agent(second_id),
                 cx,
             );
         });
-
         assert_eq!(
             app.read_with(cx, |app, _| app.dragging_tab.clone()),
             None,
             "a handled drop must clear the now-stale dragging-tab state"
+        );
+        assert_eq!(
+            app.read_with(cx, |app, _| app.dropped_tab_settle.clone().map(|(t, _)| t)),
+            Some(work_surface::TabRef::Graph),
+            "and must record the dropped tab for the settle-in fade (GitHub issue #16 §5)"
         );
     }
 
@@ -3611,8 +3506,8 @@ mod tab_scoping_tests {
     fn cancel_any_tab_drag_clears_both_fields_and_reports_whether_anything_changed(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         let initial_id = app.read_with(cx, |app, _| app.agents.active_id().expect("shell agent"));
 
         assert!(
@@ -3638,7 +3533,7 @@ mod tab_scoping_tests {
     }
 
     #[test]
-    fn tab_settle_animation_id_matches_only_the_settled_tab() {
+    fn tab_settle_animation_id_matches_only_the_settled_tab_and_is_fresh_per_drop() {
         let dropped = work_surface::TabRef::File(PathBuf::from("a.txt"));
         let other = work_surface::TabRef::File(PathBuf::from("b.txt"));
         let settle = Some((dropped.clone(), 7));
@@ -3649,21 +3544,17 @@ mod tab_scoping_tests {
         );
         assert_eq!(tab_settle_animation_id(&settle, &other), None);
         assert_eq!(tab_settle_animation_id(&None, &dropped), None);
-    }
-
-    #[test]
-    fn tab_settle_animation_id_is_fresh_across_two_drops_of_the_same_tab() {
-        let tab = work_surface::TabRef::File(PathBuf::from("a.txt"));
-        let first_drop = tab_settle_animation_id(&Some((tab.clone(), 1)), &tab);
-        let second_drop = tab_settle_animation_id(&Some((tab.clone(), 2)), &tab);
-
-        assert_ne!(first_drop, second_drop);
+        assert_ne!(
+            tab_settle_animation_id(&Some((dropped.clone(), 1)), &dropped),
+            tab_settle_animation_id(&Some((dropped.clone(), 2)), &dropped),
+            "two drops of the same tab must never reuse one animation id"
+        );
     }
 
     #[gpui::test]
     fn drop_dragged_tab_records_a_fresh_settle_id_for_the_dropped_tab(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         let (initial_id, second_id) = app.update_in(cx, |app, window, cx| {
             let initial_id = app.agents.active_id().expect("initial shell agent");
@@ -3712,8 +3603,8 @@ mod tab_scoping_tests {
     fn drop_dragged_tab_records_real_slide_offsets_for_every_shifted_neighbour(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         let (first_id, second_id, third_id) = app.update_in(cx, |app, window, cx| {
             let first_id = app.agents.active_id().expect("initial shell agent");
@@ -3795,8 +3686,8 @@ mod tab_scoping_tests {
 
     #[gpui::test]
     fn drop_dragged_tab_records_no_slide_state_for_a_no_op_drop(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         let initial_id = app.read_with(cx, |app, _| {
             app.agents.active_id().expect("initial shell agent")
         });
@@ -3880,8 +3771,8 @@ mod tab_scoping_tests {
     fn a_tabs_label_is_its_panes_live_title_and_the_strip_repaints_when_that_title_changes(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         let shell_id = app.read_with(cx, |app, _| {
             app.agents
                 .active_id()
@@ -3934,9 +3825,9 @@ mod tab_scoping_tests {
     fn two_tabs_with_the_same_live_title_render_the_same_label_with_nothing_added(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let wt_a = tempfile::tempdir().expect("tempdir a");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let wt_a = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         app.update(cx, |app, _cx| {
             app.worktrees = vec![worktree_item(wt_a.path().to_path_buf(), "wt-a")];
@@ -3994,9 +3885,9 @@ mod tab_scoping_tests {
     fn a_pane_that_has_reported_no_title_shows_its_real_program_name_not_an_empty_tab(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let wt_a = tempfile::tempdir().expect("tempdir a");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let wt_a = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         app.update(cx, |app, _cx| {
             app.worktrees = vec![worktree_item(wt_a.path().to_path_buf(), "wt-a")];
@@ -4051,61 +3942,19 @@ mod tab_scoping_tests {
         );
     }
 
-    #[gpui::test]
-    fn an_agent_clis_tab_takes_its_live_title_exactly_like_a_shells_does(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let wt_a = tempfile::tempdir().expect("tempdir a");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
-
-        app.update(cx, |app, _cx| {
-            app.worktrees = vec![worktree_item(wt_a.path().to_path_buf(), "wt-a")];
-        });
-        let agent_id = app.update_in(cx, |app, window, cx| {
-            app.select_worktree(0, window, cx);
-            app.agents.spawn(
-                ProcessKind::claude(),
-                wt_a.path().to_path_buf(),
-                12.0,
-                None,
-                None,
-                window,
-                cx,
-            )
-        });
-        cx.run_until_parked();
-        assert_eq!(
-            app.read_with(cx, |app, _| work_surface::tab_chip_kind(
-                app.agents
-                    .iter()
-                    .find(|agent| agent.id == agent_id)
-                    .expect("agent")
-                    .kind
-            )),
-            work_surface::TabChipKind::Cli,
-            "sanity check: this is the CLI chip kind, the other half of the uniformity claim"
-        );
-        assert_eq!(
-            tab_label(&app, cx, agent_id),
-            "claude",
-            "before it says anything, an agent tab shows its real binary name"
-        );
-
-        set_live_title(&app, cx, agent_id, "\u{25d0} Claude Code");
-        cx.run_until_parked();
-
-        assert_eq!(
-            tab_label(&app, cx, agent_id),
-            "\u{25d0} Claude Code",
-            "an agent tab must follow its live title just as a shell tab does"
-        );
-    }
-
+    /// Revision R12 §3's exact `+` menu item list: "*New terminal* · *New agent*
+    /// (`runs in <branch>`) · *Git graph* · *Open file…* · *Next changed file*." Proven against
+    /// the real painted popover (`Self::render_dropdown_menu_row`'s own `debug_selector`, one per
+    /// row, keyed by its label), not just the source order - and confirms there is genuinely no
+    /// "New file" row any more (removed: the file tree already carries a real, always-visible
+    /// replacement, `crate::sidebar::render::render_file_tree_row`/
+    /// `render_right_sidebar_toggle`'s own per-directory and root-level "+" affordances).
     #[gpui::test]
     fn the_plus_menus_five_rows_match_revision_r12_3_in_order_with_no_new_file_row(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         app.update(cx, |app, cx| {
             app.plus_menu_open = true;
@@ -4152,8 +4001,8 @@ mod tab_scoping_tests {
 
     #[gpui::test]
     fn a_real_click_on_the_plus_menus_git_graph_row_opens_the_graph_tab(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         app.update(cx, |app, cx| {
             app.plus_menu_open = true;
@@ -4189,9 +4038,9 @@ mod tab_scoping_tests {
     fn the_new_agent_rows_secondary_text_uses_the_real_selected_worktrees_branch(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let wt_a = tempfile::tempdir().expect("tempdir a");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let wt_a = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         app.update(cx, |app, _cx| {
             app.worktrees = vec![worktree_item(
@@ -4226,9 +4075,9 @@ mod tab_scoping_tests {
 
     #[gpui::test]
     fn a_bare_worktrees_tab_strip_still_shows_every_open_file_tab(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let wt_a = tempfile::tempdir().expect("tempdir a");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let wt_a = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         app.update(cx, |app, _cx| {
             app.worktrees = vec![worktree_item(wt_a.path().to_path_buf(), "wt-a")];
@@ -4304,8 +4153,8 @@ mod tab_scoping_tests {
 
     #[gpui::test]
     fn window_focus_follows_a_same_worktree_terminal_switch(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         let first_id = app.read_with(cx, |app, _| {
             app.agents.active_id().expect("the initial shell agent")
@@ -4361,10 +4210,10 @@ mod tab_scoping_tests {
 
     #[gpui::test]
     fn opening_a_file_in_an_already_bare_worktree_still_gets_a_real_tab(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let wt_a = tempfile::tempdir().expect("tempdir a");
+        let repo = crate::test_support::temp_root();
+        let wt_a = crate::test_support::temp_root();
         std::fs::write(wt_a.path().join("README.md"), "hello\n").expect("write README.md");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         app.update(cx, |app, _cx| {
             app.worktrees = vec![worktree_item(wt_a.path().to_path_buf(), "wt-a")];
@@ -4406,90 +4255,25 @@ mod tab_scoping_tests {
         );
     }
 
-    #[gpui::test]
-    fn dragging_a_tab_while_bare_persists_every_open_files_position(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let wt_a = tempfile::tempdir().expect("tempdir a");
-        std::fs::write(wt_a.path().join("a.txt"), "a\n").expect("write a.txt");
-        std::fs::write(wt_a.path().join("b.txt"), "b\n").expect("write b.txt");
-        std::fs::write(wt_a.path().join("c.txt"), "c\n").expect("write c.txt");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
-
-        app.update(cx, |app, _cx| {
-            app.worktrees = vec![worktree_item(wt_a.path().to_path_buf(), "wt-a")];
-        });
-        app.update_in(cx, |app, window, cx| {
-            app.select_worktree(0, window, cx);
-            app.agents.spawn(
-                ProcessKind::Shell,
-                wt_a.path().to_path_buf(),
-                12.0,
-                None,
-                None,
-                window,
-                cx,
-            );
-            app.open_file_view(wt_a.path().join("a.txt"), window, cx);
-            app.open_file_view(wt_a.path().join("b.txt"), window, cx);
-            app.open_file_view(wt_a.path().join("c.txt"), window, cx);
-        });
-        assert!(
-            app.read_with(cx, |app, _| app.current_worktree_is_bare()),
-            "premise: only the default Shell tab exists"
-        );
-        let bare_order = app.read_with(cx, |app, _| app.combined_tab_order());
-        assert_eq!(
-            bare_order
-                .iter()
-                .filter(|t| matches!(t, work_surface::TabRef::File(_)))
-                .count(),
-            3,
-            "premise: every open file tab renders even while bare (GitHub issue #120)"
-        );
-
-        app.update(cx, |app, cx| {
-            app.reorder_tab(
-                work_surface::TabRef::File(PathBuf::from("c.txt")),
-                work_surface::TabRef::File(PathBuf::from("a.txt")),
-                false,
-                cx,
-            );
-        });
-        cx.run_until_parked();
-
-        let order_after_drag = app.read_with(cx, |app, _| app.combined_tab_order());
-        for name in ["a.txt", "b.txt", "c.txt"] {
-            assert!(
-                order_after_drag.iter().any(
-                    |tab_ref| matches!(tab_ref, work_surface::TabRef::File(path) if path == &PathBuf::from(name))
-                ),
-                "{name} must still be in the tab order after the drag"
-            );
-        }
-        assert!(
-            order_after_drag
-                .iter()
-                .position(|t| t == &work_surface::TabRef::File(PathBuf::from("c.txt")))
-                < order_after_drag
-                    .iter()
-                    .position(|t| t == &work_surface::TabRef::File(PathBuf::from("a.txt"))),
-            "the real drag must have really moved c.txt in front of a.txt"
-        );
-
-        let cwd = wt_a.path().to_path_buf();
-        let persisted = app.read_with(cx, |app, _| app.tab_order_state.file_order(&cwd));
-        assert_eq!(
-            persisted.len(),
-            3,
-            "the on-disk persisted order must keep all three files"
-        );
-    }
-
+    /// GitHub issue #382: [`AdeApp::active_agent_pane_id`]'s own cascade - the fix for GitHub
+    /// issue #227 - only ever zeroed out for the review/run/graph tabs, because those three are
+    /// plain `bool` flags. The File/Diff surface is a fourth centre-pane occupant with the
+    /// identical shape, but tracked through `Self::open_change` (a `PathBuf`, not a `bool`), and
+    /// was left out of the original fix. Opening a file tab while an agent was the active centre-
+    /// pane content left that agent's own tab strip entry (and rail row, which reads the same
+    /// method) still drawn as selected, alongside the file tab that had genuinely taken over the
+    /// centre pane - the exact "two selected at once" shape #227 fixed, just for a fourth occupant
+    /// nobody had chased down yet. Mirrors
+    /// `crate::run_history::render::tab_scoping_tests::switching_between_an_agent_and_a_history_run_leaves_exactly_one_selected`'s
+    /// own "exactly one selected" idiom, but for a file tab, and checks the real painted surfaces
+    /// (`"pty-surface"`/`"file-view-code-list"`) rather than only the logical predicate, so this
+    /// fails if the fix is real but `render_center_pane` itself ever drifts from
+    /// `active_agent_pane_id`'s cascade.
     #[gpui::test]
     fn switching_from_an_agent_to_a_file_tab_leaves_exactly_one_selected(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
         std::fs::write(repo.path().join("mod.rs"), "fn main() {}\n").expect("write");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         // A real second agent (the startup shell is `Agents`' first entry) so this exercises a
@@ -4568,135 +4352,6 @@ mod tab_scoping_tests {
     }
 }
 
-/// GitHub issue #20's `TerminalClear` action - real coverage that dispatching it reaches
-/// whichever agent is genuinely active right now, and only that one, mirroring
-/// `crate::terminal::pane::clear_pty_signal_tests`' own "observe the pty's real echo, not a
-/// direct call" discipline for proving `clear()`'s pty-signal half actually fired.
-#[cfg(test)]
-mod terminal_clear_action_tests {
-    use super::*;
-    use crate::root::focus::palette_focus_tests;
-    use gpui::TestAppContext;
-
-    /// The real pty's OS reader thread and the real child shell it feeds run entirely outside
-    /// GPUI's deterministic scheduler - `cx.background_executor.advance_clock` only fast-forwards
-    /// a *simulated* clock, which grants that real thread and that real process zero actual
-    /// wall-clock scheduling time. A retry loop that only ever advances the virtual clock (the
-    /// pre-fix shape here) can race arbitrarily far ahead of them: standalone, with an otherwise
-    /// idle CPU, the real echo lands within real microseconds so the race is never noticed, but
-    /// under real full-suite parallel load (dozens of other tests' own real subprocesses - other
-    /// ptys, `rust-analyzer`, `pyright`, `typescript-language-server` - contending for the same
-    /// cores) the OS can genuinely take real milliseconds to schedule the reader thread, and a
-    /// loop that burns through its whole retry budget in real microseconds finds every single
-    /// check empty and fails despite the real echo being on its way. This is exactly the same
-    /// class of bug `lsp::client::lsp_diagnostics_wiring_tests`' own `wait_for_real_diagnostics`/
-    /// `wait_until` exist to avoid one layer up (a real notification arriving on a real OS thread
-    /// outside GPUI's scheduler) - the fix is the same discipline: keep re-checking over *real*
-    /// wall-clock time (a real `std::thread::sleep` between checks), bounded by a real deadline,
-    /// not a fixed count of virtual-clock advances with no real-time floor at all.
-    fn wait_for_real_pty_output(
-        cx: &mut gpui::VisualTestContext,
-        deadline: std::time::Instant,
-        mut has_arrived: impl FnMut(&mut gpui::VisualTestContext) -> bool,
-    ) -> bool {
-        loop {
-            cx.background_executor
-                .advance_clock(std::time::Duration::from_millis(8));
-            cx.run_until_parked();
-            if has_arrived(cx) {
-                return true;
-            }
-            if std::time::Instant::now() >= deadline {
-                return false;
-            }
-            std::thread::sleep(std::time::Duration::from_millis(5));
-        }
-    }
-
-    #[gpui::test]
-    fn dispatching_terminal_clear_signals_only_the_active_agents_pty(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
-
-        let (first_id, second_id) = app.update_in(cx, |app, window, cx| {
-            let first = app.agents.spawn(
-                ProcessKind::Shell,
-                repo.path().to_path_buf(),
-                12.0,
-                None,
-                None,
-                window,
-                cx,
-            );
-            let second = app.agents.spawn(
-                ProcessKind::Shell,
-                repo.path().to_path_buf(),
-                12.0,
-                None,
-                None,
-                window,
-                cx,
-            );
-            (first, second)
-        });
-        cx.run_until_parked();
-        assert_eq!(
-            app.read_with(cx, |app, _| app.agents.active_id()),
-            Some(second_id),
-            "sanity check: spawning a second agent must make it the active one"
-        );
-
-        cx.dispatch_action(TerminalClear);
-
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(45);
-        let saw_real_output_on_second = wait_for_real_pty_output(cx, deadline, |cx| {
-            let second_lines = app.read_with(cx, |app, cx| {
-                app.agents
-                    .iter()
-                    .find(|agent| agent.id == second_id)
-                    .expect("second agent")
-                    .pane
-                    .read(cx)
-                    .visible_text_lines()
-            });
-            // `TerminalPane::clear` wipes its own local grid *first*, synchronously, before it
-            // ever writes the real Ctrl-L byte to the pty - so any real, non-blank content that
-            // reappears here can only be this real round trip's own echo. That echo can
-            // honestly take either shape: a raw `^L` (ECHOCTL, if the shell's own readline
-            // hasn't taken over the tty yet - the common case for a just-spawned shell) or a
-            // redrawn prompt (readline's own real `clear-screen` binding, once it has) - see
-            // `title_bar::render::agent_state_chip_live_tests`'s own docs for the identical real
-            // ambiguity, live-observed there first. Searching for the literal `^L` text alone
-            // made this test racy against exactly which one a real shell happens to pick under
-            // real full-suite load, where the extra real time before Ctrl-L is dispatched can
-            // let a freshly spawned shell's readline win a race it would usually lose on an
-            // otherwise-idle machine.
-            second_lines.iter().any(|line| !line.trim().is_empty())
-        });
-        assert!(
-            saw_real_output_on_second,
-            "expected the active (second) agent's real pty to echo something back after \
-             TerminalClear's real Ctrl-L byte reached it"
-        );
-
-        let first_lines = app.read_with(cx, |app, cx| {
-            app.agents
-                .iter()
-                .find(|agent| agent.id == first_id)
-                .expect("first agent")
-                .pane
-                .read(cx)
-                .visible_text_lines()
-        });
-        assert!(
-            !first_lines.iter().any(|line| line.contains("^L")),
-            "the inactive (first) agent must never receive the clear signal - only the active \
-             agent, matching handle_close_focused_tab_action's own 'act on whichever tab is \
-             genuinely showing right now' target"
-        );
-    }
-}
-
 /// GitHub issue #16's own "the resulting layout... persists per session/worktree and restores on
 /// relaunch" - real end-to-end coverage that a drag-reordered tab strip survives a genuine
 /// second `AdeApp` instance, not just a worktree switch within the same one.
@@ -4725,8 +4380,8 @@ mod tab_order_persistence_tests {
 
     #[gpui::test]
     fn a_drag_reordered_tab_strip_survives_a_real_restart(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let config_dir = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
+        let config_dir = crate::test_support::temp_root();
         let settings_path = config_dir.path().join("settings.toml");
         std::fs::write(repo.path().join("a.txt"), "a\n").expect("write a.txt");
         std::fs::write(repo.path().join("b.txt"), "b\n").expect("write b.txt");
@@ -4812,33 +4467,30 @@ mod tab_order_persistence_tests {
 /// `copy_relative_path_writes_the_worktree_relative_path` checks "Copy Path", since this app has
 /// exactly one clipboard mechanism and both go through it).
 #[cfg(test)]
-mod terminal_clipboard_action_tests {
+mod terminal_action_tests {
     use super::*;
-    use crate::root::focus::palette_focus_tests;
     use gpui::{Focusable, TestAppContext};
 
-    /// See `terminal_clear_action_tests::wait_for_real_pty_output`'s own docs for why this real
-    /// wall-clock-bounded retry (not a fixed count of virtual-clock advances) is genuinely
-    /// required here too: the real pty reader thread and the real child shell it feeds are
-    /// outside GPUI's deterministic scheduler, so only real elapsed time - not simulated time -
-    /// gives them a real chance to run under full-suite parallel load.
-    fn wait_for_real_pty_output(
+    /// How long a real pty round trip is given before a test calls it a failure. Generous: it has
+    /// to survive a full-suite run where dozens of other tests' own child processes compete for
+    /// the same cores.
+    const PTY_ROUND_TRIP: std::time::Duration = std::time::Duration::from_secs(30);
+
+    /// Drives GPUI's own clock and the real wall clock together, one poll at a time, until
+    /// `arrived` holds or [`PTY_ROUND_TRIP`] elapses. Both are needed: the pane's poll loop only
+    /// advances on the simulated executor clock, while the pty reader is an ordinary OS thread
+    /// that only makes progress in real time. `test_support::wait_until` is the workspace's one
+    /// sanctioned wall-clock wait (`docs/testing.md`).
+    fn pump_until(
         cx: &mut gpui::VisualTestContext,
-        deadline: std::time::Instant,
-        mut has_arrived: impl FnMut(&mut gpui::VisualTestContext) -> bool,
+        mut arrived: impl FnMut(&mut gpui::VisualTestContext) -> bool,
     ) -> bool {
-        loop {
+        test_support::wait_until(PTY_ROUND_TRIP, || {
             cx.background_executor
                 .advance_clock(std::time::Duration::from_millis(8));
             cx.run_until_parked();
-            if has_arrived(cx) {
-                return true;
-            }
-            if std::time::Instant::now() >= deadline {
-                return false;
-            }
-            std::thread::sleep(std::time::Duration::from_millis(5));
-        }
+            arrived(cx)
+        })
     }
 
     /// Places `text` at a fixed, addressed grid position in the active agent's pane, well below
@@ -4855,33 +4507,91 @@ mod terminal_clipboard_action_tests {
     }
 
     #[gpui::test]
-    fn dispatching_terminal_copy_puts_the_real_selection_on_the_real_clipboard(
-        cx: &mut TestAppContext,
-    ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
-        cx.run_until_parked();
+    fn dispatching_terminal_clear_signals_only_the_active_agents_pty(cx: &mut TestAppContext) {
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
-        cx.update(|_window, cx| {
-            cx.write_to_clipboard(gpui::ClipboardItem::new_string("stale".into()))
+        let (first_id, second_id) = app.update_in(cx, |app, window, cx| {
+            let first = app.agents.spawn(
+                ProcessKind::Shell,
+                repo.path().to_path_buf(),
+                12.0,
+                None,
+                None,
+                window,
+                cx,
+            );
+            let second = app.agents.spawn(
+                ProcessKind::Shell,
+                repo.path().to_path_buf(),
+                12.0,
+                None,
+                None,
+                window,
+                cx,
+            );
+            (first, second)
         });
-        seed_active_pane(&app, cx, "ade-selected-text");
-
-        cx.dispatch_action(TerminalCopy);
-
-        let text = cx.update(|_window, cx| cx.read_from_clipboard().and_then(|item| item.text()));
+        cx.run_until_parked();
         assert_eq!(
-            text.as_deref(),
-            Some("ade-selected-text"),
-            "TerminalCopy must reach the active agent's pane and write its real selection to \
-             the real system clipboard"
+            app.read_with(cx, |app, _| app.agents.active_id()),
+            Some(second_id),
+            "sanity check: spawning a second agent must make it the active one"
+        );
+
+        cx.dispatch_action(TerminalClear);
+
+        let saw_real_output_on_second = pump_until(cx, |cx| {
+            let second_lines = app.read_with(cx, |app, cx| {
+                app.agents
+                    .iter()
+                    .find(|agent| agent.id == second_id)
+                    .expect("second agent")
+                    .pane
+                    .read(cx)
+                    .visible_text_lines()
+            });
+            // `TerminalPane::clear` wipes its own local grid *first*, synchronously, before it
+            // ever writes the real Ctrl-L byte to the pty - so any real, non-blank content that
+            // reappears here can only be this real round trip's own echo. That echo can
+            // honestly take either shape: a raw `^L` (ECHOCTL, if the shell's own readline
+            // hasn't taken over the tty yet - the common case for a just-spawned shell) or a
+            // redrawn prompt (readline's own real `clear-screen` binding, once it has) - see
+            // `title_bar::render::agent_state_chip_live_tests`'s own docs for the identical real
+            // ambiguity, live-observed there first. Searching for the literal `^L` text alone
+            // made this test racy against exactly which one a real shell happens to pick under
+            // real full-suite load, where the extra real time before Ctrl-L is dispatched can
+            // let a freshly spawned shell's readline win a race it would usually lose on an
+            // otherwise-idle machine.
+            second_lines.iter().any(|line| !line.trim().is_empty())
+        });
+        assert!(
+            saw_real_output_on_second,
+            "expected the active (second) agent's real pty to echo something back after \
+             TerminalClear's real Ctrl-L byte reached it"
+        );
+
+        let first_lines = app.read_with(cx, |app, cx| {
+            app.agents
+                .iter()
+                .find(|agent| agent.id == first_id)
+                .expect("first agent")
+                .pane
+                .read(cx)
+                .visible_text_lines()
+        });
+        assert!(
+            !first_lines.iter().any(|line| line.contains("^L")),
+            "the inactive (first) agent must never receive the clear signal - only the active \
+             agent, matching handle_close_focused_tab_action's own 'act on whichever tab is \
+             genuinely showing right now' target"
         );
     }
 
     #[gpui::test]
     fn dispatching_terminal_copy_uses_only_the_active_agents_selection(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         // The window's own initial agent gets a selection first, then a second agent (which
@@ -4911,8 +4621,8 @@ mod terminal_clipboard_action_tests {
     fn the_real_copy_keystroke_over_a_focused_terminal_copies_instead_of_typing(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         cx.update(|_window, cx| {
@@ -4946,8 +4656,8 @@ mod terminal_clipboard_action_tests {
 
     #[gpui::test]
     fn the_real_paste_keystroke_over_a_focused_terminal_reaches_the_pty(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         cx.update(|_window, cx| {
@@ -4968,8 +4678,7 @@ mod terminal_clipboard_action_tests {
             "ctrl-shift-v"
         });
 
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(45);
-        let saw_pasted_text = wait_for_real_pty_output(cx, deadline, |cx| {
+        let saw_pasted_text = pump_until(cx, |cx| {
             let lines = app.read_with(cx, |app, cx| {
                 app.agents
                     .active()
@@ -4987,36 +4696,6 @@ mod terminal_clipboard_action_tests {
             "the real paste keystroke over a focused terminal must reach TerminalPaste"
         );
     }
-
-    #[gpui::test]
-    fn dispatching_terminal_paste_reaches_the_active_agents_real_pty(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
-        cx.run_until_parked();
-
-        cx.update(|_window, cx| {
-            cx.write_to_clipboard(gpui::ClipboardItem::new_string("ade-pasted-marker".into()))
-        });
-        cx.dispatch_action(TerminalPaste);
-
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(45);
-        let saw_pasted_text = wait_for_real_pty_output(cx, deadline, |cx| {
-            let lines = app.read_with(cx, |app, cx| {
-                app.agents
-                    .active()
-                    .expect("an active agent")
-                    .pane
-                    .read(cx)
-                    .visible_text_lines()
-            });
-            lines.iter().any(|line| line.contains("ade-pasted-marker"))
-        });
-        assert!(
-            saw_pasted_text,
-            "expected the active agent's real pty to echo back the clipboard text \
-             TerminalPaste's handler writes"
-        );
-    }
 }
 
 /// The reported "clicking an agent from another worktree/repo, the tab bar does not appear" -
@@ -5031,42 +4710,17 @@ mod terminal_clipboard_action_tests {
 #[cfg(test)]
 mod select_agent_cross_repo_tests {
     use super::*;
-    use crate::root::focus::palette_focus_tests;
     use crate::work_surface::agents::ProcessKind;
     use gpui::TestAppContext;
-
-    fn git(dir: &std::path::Path, args: &[&str]) {
-        let output = std::process::Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {args:?} failed: {}",
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
-    fn init_repo() -> tempfile::TempDir {
-        let dir = tempfile::tempdir().expect("tempdir");
-        git(dir.path(), &["init", "-b", "main"]);
-        git(dir.path(), &["config", "user.email", "test@example.com"]);
-        git(dir.path(), &["config", "user.name", "Test User"]);
-        std::fs::write(dir.path().join("README.md"), "hello\n").expect("write");
-        git(dir.path(), &["add", "README.md"]);
-        git(dir.path(), &["commit", "-m", "initial"]);
-        dir
-    }
 
     #[gpui::test]
     fn selecting_an_agent_in_a_non_focused_repo_switches_to_it_and_shows_its_tab(
         cx: &mut TestAppContext,
     ) {
-        let repo_a = init_repo();
-        let repo_b = init_repo();
+        let repo_a = crate::test_support::temp_repo();
+        let repo_b = crate::test_support::temp_repo();
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo_a.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo_a.path().to_path_buf());
         cx.run_until_parked();
 
         app.update(cx, |app, cx| {
@@ -5135,28 +4789,7 @@ mod select_agent_cross_repo_tests {
 mod agent_pane_readout_tests {
     use super::*;
     use crate::rail::worktrees::WorktreeItem;
-    use crate::root::focus::palette_focus_tests;
     use gpui::TestAppContext;
-
-    fn git(dir: &std::path::Path, args: &[&str]) {
-        let status = std::process::Command::new("git")
-            .args(args)
-            .current_dir(dir)
-            .status()
-            .expect("run git");
-        assert!(status.success(), "git {args:?} failed in {}", dir.display());
-    }
-
-    fn init_repo() -> tempfile::TempDir {
-        let repo = tempfile::tempdir().expect("tempdir");
-        git(repo.path(), &["init", "-b", "main"]);
-        git(repo.path(), &["config", "user.email", "test@example.com"]);
-        git(repo.path(), &["config", "user.name", "Test User"]);
-        std::fs::write(repo.path().join("base.txt"), "base\n").expect("write");
-        git(repo.path(), &["add", "base.txt"]);
-        git(repo.path(), &["commit", "-m", "initial"]);
-        repo
-    }
 
     /// Spawns one real shell agent in `cwd` (optionally under a `shell_override` that exits by
     /// itself) and selects it, so the centre pane really is that agent's pty surface.
@@ -5182,26 +4815,27 @@ mod agent_pane_readout_tests {
         id
     }
 
-    /// Waits for a real child process to genuinely exit - the same real-clock-plus-advance loop
-    /// `crate::sidebar::render`'s own `/bin/false` test uses, not an assumption that it has.
+    /// Waits for a real child process to genuinely exit. Both clocks advance together, one poll
+    /// at a time: the pane only notices an exit on a simulated-clock poll tick, while the child
+    /// itself only exits in real time. `test_support::wait_until` is the workspace's one
+    /// sanctioned wall-clock wait (`docs/testing.md`).
+    ///
+    /// `#[cfg(unix)]` to match its only caller, which spawns a real `/bin/false`.
+    #[cfg(unix)]
     fn wait_for_exit(app: &gpui::Entity<AdeApp>, cx: &mut gpui::VisualTestContext, id: AgentId) {
-        for _ in 0..200 {
+        let exited = test_support::wait_until(std::time::Duration::from_secs(30), || {
             app.update(cx, |_app, cx| cx.notify());
             cx.run_until_parked();
-            let exited = app.read_with(cx, |app, cx| {
+            cx.executor()
+                .advance_clock(std::time::Duration::from_millis(50));
+            app.read_with(cx, |app, cx| {
                 app.agents
                     .iter()
                     .find(|agent| agent.id == id)
                     .is_some_and(|agent| !agent.pane.read(cx).is_running())
-            });
-            if exited {
-                return;
-            }
-            std::thread::sleep(std::time::Duration::from_millis(20));
-            cx.executor()
-                .advance_clock(std::time::Duration::from_millis(50));
-        }
-        panic!("premise: the spawned child must really have exited");
+            })
+        });
+        assert!(exited, "premise: the spawned child must really have exited");
     }
 
     /// A real, non-bare worktree row for `path`. Seeded explicitly because a test app whose
@@ -5227,8 +4861,8 @@ mod agent_pane_readout_tests {
 
     #[gpui::test]
     fn the_context_bar_ends_at_the_status_pill_with_no_merge_or_archive(cx: &mut TestAppContext) {
-        let repo = init_repo();
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_repo();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
         app.update_in(cx, |app, window, cx| {
             app.worktrees = vec![worktree_row(repo.path().to_path_buf(), "main")];
@@ -5272,8 +4906,8 @@ mod agent_pane_readout_tests {
 
     #[gpui::test]
     fn a_running_agents_strip_still_paints_and_carries_its_own_cost(cx: &mut TestAppContext) {
-        let repo = init_repo();
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_repo();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
         let id = spawn_and_select(&app, cx, repo.path().to_path_buf(), None);
         app.update(cx, |app, cx| {
@@ -5319,8 +4953,8 @@ mod agent_pane_readout_tests {
 
     #[gpui::test]
     fn a_shell_tab_paints_the_info_footer_and_not_the_agent_readout_strip(cx: &mut TestAppContext) {
-        let repo = init_repo();
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_repo();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
         let id = spawn_and_select(&app, cx, repo.path().to_path_buf(), None);
 
@@ -5358,8 +4992,8 @@ mod agent_pane_readout_tests {
     fn an_agent_tab_paints_only_the_readout_strip_and_keeps_its_pid_in_the_header(
         cx: &mut TestAppContext,
     ) {
-        let repo = init_repo();
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_repo();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
         let id = spawn_and_select(&app, cx, repo.path().to_path_buf(), None);
         app.update(cx, |app, cx| {
@@ -5401,8 +5035,8 @@ mod agent_pane_readout_tests {
     fn header_content_and_footer_bands_sum_to_the_real_pane_height_on_a_long_transcript(
         cx: &mut TestAppContext,
     ) {
-        let repo = init_repo();
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_repo();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
         let id = spawn_and_select(&app, cx, repo.path().to_path_buf(), None);
         app.update(cx, |app, cx| {
@@ -5535,8 +5169,8 @@ mod agent_pane_readout_tests {
 
     #[gpui::test]
     fn a_shell_tab_beside_a_real_agent_gets_no_identity_bar(cx: &mut TestAppContext) {
-        let repo = init_repo();
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_repo();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
         app.update_in(cx, |app, window, cx| {
             app.worktrees = vec![worktree_row(repo.path().to_path_buf(), "main")];
@@ -5577,8 +5211,8 @@ mod agent_pane_readout_tests {
 
     #[gpui::test]
     fn the_cost_readout_is_blank_for_an_agent_that_is_not_running(cx: &mut TestAppContext) {
-        let repo = init_repo();
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_repo();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         app.read_with(cx, |app, _| {
@@ -5593,13 +5227,21 @@ mod agent_pane_readout_tests {
         });
     }
 
+    /// §4e/§4r's one surviving pair, and its two-click safety: `failed` keeps `Retry` and
+    /// `Discard worktree`, and the discard really arms before it destroys.
+    ///
+    /// Driven through the genuinely painted button (`debug_bounds` + `simulate_click`), not
+    /// through `request_discard_worktree` directly - the point is that this strip still offers
+    /// those two, and that `Open terminal` (which used to sit between them) does not paint.
+    /// `#[cfg(unix)]`: the failed run below is a real `/bin/false` child, which needs a `/bin`.
+    #[cfg(unix)]
     #[gpui::test]
     fn a_failed_run_keeps_retry_and_a_two_click_discard_and_nothing_else(cx: &mut TestAppContext) {
-        let repo = init_repo();
-        let worktree_container = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_repo();
+        let worktree_container = crate::test_support::temp_root();
         let worktree_path = worktree_container.path().join("feature-wt");
         drop(worktree_container);
-        git(
+        test_support::git(
             repo.path(),
             &[
                 "worktree",
@@ -5610,7 +5252,7 @@ mod agent_pane_readout_tests {
             ],
         );
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
         // `/bin/false` is a real child that really exits non-zero, so `Status::Fail` is derived
         // from a genuine `ProcessSignal::Exited { success: false }` rather than being set.
@@ -5659,8 +5301,8 @@ mod agent_pane_readout_tests {
 
     #[gpui::test]
     fn the_no_agent_empty_state_really_starts_a_terminal(cx: &mut TestAppContext) {
-        let repo = init_repo();
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_repo();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         let startup: Vec<AgentId> = app.read_with(cx, |app, _| {
@@ -5706,8 +5348,8 @@ mod agent_pane_readout_tests {
 
     #[gpui::test]
     fn a_bare_worktree_keeps_its_start_an_agent_button(cx: &mut TestAppContext) {
-        let repo = init_repo();
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_repo();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
         spawn_and_select(&app, cx, repo.path().to_path_buf(), None);
 
@@ -5749,13 +5391,12 @@ mod agent_pane_readout_tests {
 #[cfg(test)]
 mod tab_strip_overflow_scroll_tests {
     use super::*;
-    use crate::root::focus::palette_focus_tests;
     use gpui::TestAppContext;
 
     #[gpui::test]
     fn scrolling_the_tab_strip_reaches_a_tab_that_overflowed_it(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         // Deliberately narrow (`VisualTestContext::simulate_resize`'s own docs) rather than the
         // default maximized 1920×1080 `TestDisplay`: twenty real tabs overflow a maximized test
         // window too, but only past several dozen, which would mean this test paying for several
@@ -5875,7 +5516,6 @@ mod tab_strip_overflow_scroll_tests {
 #[cfg(test)]
 mod tab_strip_trailing_margin_tests {
     use super::*;
-    use crate::root::focus::palette_focus_tests;
     use gpui::TestAppContext;
 
     /// Opens `names` as real file tabs in a real window, then selects the app's own initial shell
@@ -5892,7 +5532,7 @@ mod tab_strip_trailing_margin_tests {
         for name in names {
             std::fs::write(repo.join(name), "// x\n").expect("write");
         }
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.to_path_buf());
         cx.simulate_resize(window_size);
         let shell_id = app
             .read_with(cx, |app, _| app.active_agent_pane_id())
@@ -5911,7 +5551,7 @@ mod tab_strip_trailing_margin_tests {
 
     #[gpui::test]
     fn the_tab_strips_tabs_run_flush_into_the_panes_real_right_edge(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
         // The live screenshots' own tabs, plus enough more of the same to genuinely overflow a
         // deliberately narrow window rather than a maximized one (the same 900px
         // `simulate_resize` `tab_strip_overflow_scroll_tests` uses, and for the same reason: real
@@ -5972,7 +5612,7 @@ mod tab_strip_trailing_margin_tests {
 
     #[gpui::test]
     fn the_plus_button_sits_immediately_after_the_last_tab(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
         let names = ["state.rs", "lib.rs"];
         // Maximized (the default 1920x1080 `TestDisplay`), so two short tabs come nowhere near
         // filling the strip - the precondition under which PR #403's pusher relocated the `+`.

--- a/crates/app/src/work_surface/session.rs
+++ b/crates/app/src/work_surface/session.rs
@@ -226,40 +226,12 @@ mod session_restore_tests {
     use crate::rail::status::Status;
     use crate::settings::store as settings_store;
     use gpui::TestAppContext;
-    use std::process::Command;
-    use tempfile::TempDir;
-
-    fn git(dir: &Path, args: &[&str]) {
-        let output = Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(output.status.success(), "git {args:?} failed in {dir:?}");
-    }
-
-    /// A real repo with a real initial commit, so `git worktree list --porcelain` reports a real
-    /// main-worktree row for the app to select - and so `git worktree add` below works at all.
-    /// Returns the *canonicalized* path, because every one of this app's per-worktree lookups is an
-    /// exact comparison against git's own fully-resolved answers (see
-    /// `crate::rail::repo::canonical_repo_path`'s own docs).
-    fn init_repo() -> (TempDir, PathBuf) {
-        let dir = TempDir::new().expect("tempdir");
-        git(dir.path(), &["init", "-b", "main"]);
-        git(dir.path(), &["config", "user.email", "test@example.com"]);
-        git(dir.path(), &["config", "user.name", "Test User"]);
-        std::fs::write(dir.path().join("README.md"), "hello\n").expect("write");
-        git(dir.path(), &["add", "README.md"]);
-        git(dir.path(), &["commit", "-m", "initial"]);
-        let canonical = std::fs::canonicalize(dir.path()).expect("canonicalize");
-        (dir, canonical)
-    }
 
     /// A real linked worktree of `repo`, created under `container` (worktrees live outside the
     /// repo - `crate::rail::repo::Repo::path`'s own docs).
     fn add_worktree(repo: &Path, container: &Path, branch: &str) -> PathBuf {
         let path = container.join(branch);
-        git(
+        test_support::git(
             repo,
             &[
                 "worktree",
@@ -344,10 +316,11 @@ mod session_restore_tests {
     fn a_relaunch_reopens_every_file_and_terminal_tab_in_its_real_drag_order(
         cx: &mut TestAppContext,
     ) {
-        let (_repo, repo_path) = init_repo();
-        let container = TempDir::new().expect("tempdir");
+        let repo = crate::test_support::temp_repo();
+        let repo_path = repo.to_path_buf();
+        let container = crate::test_support::temp_root();
         let feature = add_worktree(&repo_path, container.path(), "feature");
-        let settings_dir = TempDir::new().expect("tempdir");
+        let settings_dir = crate::test_support::temp_root();
         let settings_path = settings_dir.path().join("settings.toml");
 
         std::fs::write(repo_path.join("a.txt"), "a\n").expect("write");
@@ -435,10 +408,11 @@ mod session_restore_tests {
     fn an_unvisited_worktrees_session_costs_nothing_until_it_is_really_selected(
         cx: &mut TestAppContext,
     ) {
-        let (_repo, repo_path) = init_repo();
-        let container = TempDir::new().expect("tempdir");
+        let repo = crate::test_support::temp_repo();
+        let repo_path = repo.to_path_buf();
+        let container = crate::test_support::temp_root();
         let feature = add_worktree(&repo_path, container.path(), "feature");
-        let settings_dir = TempDir::new().expect("tempdir");
+        let settings_dir = crate::test_support::temp_root();
         let settings_path = settings_dir.path().join("settings.toml");
 
         {
@@ -500,8 +474,9 @@ mod session_restore_tests {
 
     #[gpui::test]
     fn a_file_deleted_between_sessions_is_skipped_with_a_real_reason(cx: &mut TestAppContext) {
-        let (_repo, repo_path) = init_repo();
-        let settings_dir = TempDir::new().expect("tempdir");
+        let repo = crate::test_support::temp_repo();
+        let repo_path = repo.to_path_buf();
+        let settings_dir = crate::test_support::temp_root();
         let settings_path = settings_dir.path().join("settings.toml");
         std::fs::write(repo_path.join("kept.txt"), "kept\n").expect("write");
         std::fs::write(repo_path.join("gone.txt"), "gone\n").expect("write");
@@ -542,8 +517,9 @@ mod session_restore_tests {
     fn a_claude_agent_is_restored_by_a_real_resume_carrying_its_own_session_id(
         cx: &mut TestAppContext,
     ) {
-        let (_repo, repo_path) = init_repo();
-        let settings_dir = TempDir::new().expect("tempdir");
+        let repo = crate::test_support::temp_repo();
+        let repo_path = repo.to_path_buf();
+        let settings_dir = crate::test_support::temp_root();
         let settings_path = settings_dir.path().join("settings.toml");
         let session_id = "5af4c210-34fa-4ab2-9c35-f6ceab76551c";
 
@@ -623,8 +599,9 @@ mod session_restore_tests {
 
     #[gpui::test]
     fn an_agent_with_no_resumable_session_is_refused_honestly_and_alone(cx: &mut TestAppContext) {
-        let (_repo, repo_path) = init_repo();
-        let settings_dir = TempDir::new().expect("tempdir");
+        let repo = crate::test_support::temp_repo();
+        let repo_path = repo.to_path_buf();
+        let settings_dir = crate::test_support::temp_root();
         let settings_path = settings_dir.path().join("settings.toml");
         std::fs::write(repo_path.join("kept.txt"), "kept\n").expect("write");
 
@@ -692,10 +669,11 @@ mod session_restore_tests {
     fn relaunching_with_no_cli_argument_lands_back_in_the_last_worktree_with_its_tabs(
         cx: &mut TestAppContext,
     ) {
-        let (_repo, repo_path) = init_repo();
-        let container = TempDir::new().expect("tempdir");
+        let repo = crate::test_support::temp_repo();
+        let repo_path = repo.to_path_buf();
+        let container = crate::test_support::temp_root();
         let feature = add_worktree(&repo_path, container.path(), "feature");
-        let settings_dir = TempDir::new().expect("tempdir");
+        let settings_dir = crate::test_support::temp_root();
         let settings_path = settings_dir.path().join("settings.toml");
         std::fs::write(feature.join("only-here.txt"), "hi\n").expect("write");
 
@@ -731,10 +709,11 @@ mod session_restore_tests {
 
     #[gpui::test]
     fn an_explicitly_named_path_still_wins_over_the_remembered_worktree(cx: &mut TestAppContext) {
-        let (_repo, repo_path) = init_repo();
-        let container = TempDir::new().expect("tempdir");
+        let repo = crate::test_support::temp_repo();
+        let repo_path = repo.to_path_buf();
+        let container = crate::test_support::temp_root();
         let feature = add_worktree(&repo_path, container.path(), "feature");
-        let settings_dir = TempDir::new().expect("tempdir");
+        let settings_dir = crate::test_support::temp_root();
         let settings_path = settings_dir.path().join("settings.toml");
 
         {
@@ -759,9 +738,11 @@ mod session_restore_tests {
 
     #[gpui::test]
     fn both_repos_tab_sessions_survive_a_relaunch(cx: &mut TestAppContext) {
-        let (_repo_a, repo_a) = init_repo();
-        let (_repo_b, repo_b) = init_repo();
-        let settings_dir = TempDir::new().expect("tempdir");
+        let repo_a = crate::test_support::temp_repo();
+        let repo_a = repo_a.to_path_buf();
+        let repo_b = crate::test_support::temp_repo();
+        let repo_b = repo_b.to_path_buf();
+        let settings_dir = crate::test_support::temp_root();
         let settings_path = settings_dir.path().join("settings.toml");
         std::fs::write(repo_a.join("in-a.txt"), "a\n").expect("write");
         std::fs::write(repo_b.join("in-b.txt"), "b\n").expect("write");
@@ -820,8 +801,9 @@ mod session_restore_tests {
 
     #[gpui::test]
     fn a_deliberately_closed_tab_stays_closed_across_a_relaunch(cx: &mut TestAppContext) {
-        let (_repo, repo_path) = init_repo();
-        let settings_dir = TempDir::new().expect("tempdir");
+        let repo = crate::test_support::temp_repo();
+        let repo_path = repo.to_path_buf();
+        let settings_dir = crate::test_support::temp_root();
         let settings_path = settings_dir.path().join("settings.toml");
         std::fs::write(repo_path.join("kept.txt"), "kept\n").expect("write");
         std::fs::write(repo_path.join("closed.txt"), "closed\n").expect("write");

--- a/crates/app/src/work_surface/state.rs
+++ b/crates/app/src/work_surface/state.rs
@@ -538,81 +538,53 @@ mod tests {
         assert!(same(colors.bg, theme::lang::RS.1.into()));
     }
 
+    /// Inactive is one neutral for every chip kind - agent, shell and file tab alike - so a
+    /// background tab never advertises its own identity colour.
     #[test]
-    fn an_inactive_file_tab_chip_is_dimmed_to_the_same_neutral_a_agent_tab_chip_uses() {
+    fn an_inactive_chip_is_always_the_same_neutral_whatever_kind_it_is() {
         let rs = LangChip {
             label: "rs",
             fg: theme::lang::RS.0.into(),
             bg: theme::lang::RS.1.into(),
         };
-        let file_colors = file_tab_chip_colors(rs, false);
-        let agent_colors = tab_chip_colors(ProcessKind::Shell, false);
-        assert!(same(file_colors.bg, agent_colors.bg));
-        assert!(same(file_colors.fg, agent_colors.fg));
-    }
-
-    #[test]
-    fn an_inactive_chip_is_always_dimmed_to_the_same_neutral_regardless_of_kind() {
-        let claude = tab_chip_colors(ProcessKind::claude(), false);
         let shell = tab_chip_colors(ProcessKind::Shell, false);
-        assert!(same(claude.bg, shell.bg));
-        assert!(same(claude.fg, shell.fg));
-        assert!(same(claude.bg, theme::border::ZONE.into()));
+        for other in [
+            tab_chip_colors(ProcessKind::claude(), false),
+            file_tab_chip_colors(rs, false),
+        ] {
+            assert!(same(other.bg, shell.bg));
+            assert!(same(other.fg, shell.fg));
+        }
+        assert!(same(shell.bg, theme::border::ZONE.into()));
     }
 
+    /// An active tab's underline matches its own background - that is how it visually merges
+    /// into the surface below it (`design_handoff_jerry_ade/README.md`) - while an inactive one
+    /// is transparent and carries a different underline entirely.
     #[test]
-    fn active_tab_background_and_underline_are_the_same_colour_so_it_merges_into_the_surface() {
+    fn an_active_tab_merges_into_the_surface_and_an_inactive_one_does_not() {
         let active = tab_colors(true);
-        assert!(
-            same(active.bg, active.underline),
-            "an active tab's underline must match its own background - that's how it visually \
-             merges into the surface below it, per design_handoff_jerry_ade/README.md"
-        );
-    }
-
-    #[test]
-    fn inactive_tab_background_is_transparent_not_the_active_colour() {
         let inactive = tab_colors(false);
+        assert!(same(active.bg, active.underline));
         assert!(same(inactive.bg, TRANSPARENT));
-        assert!(!same(inactive.underline, tab_colors(true).underline));
+        assert!(!same(inactive.underline, active.underline));
     }
 
+    /// Every state a pty footer can honestly report, in one table: never started, exited with
+    /// its real code, and the three attached states the status drives.
     #[test]
-    fn a_process_that_never_started_reports_not_started_not_a_false_exit() {
-        assert_eq!(pty_state_label(false, Status::Idle, None), "not started");
-    }
-
-    #[test]
-    fn an_exited_process_always_reports_its_real_exit_code() {
-        assert_eq!(
-            pty_state_label(false, Status::Fail, Some(101)),
-            "exited 101"
-        );
-        assert_eq!(pty_state_label(false, Status::Review, Some(0)), "exited 0");
-    }
-
-    #[test]
-    fn a_running_agent_past_the_ask_threshold_reports_waiting_on_stdin() {
-        assert_eq!(
-            pty_state_label(true, Status::Ask, None),
-            "attached \u{b7} waiting on stdin"
-        );
-    }
-
-    #[test]
-    fn a_running_and_recently_active_agent_reports_streaming() {
-        assert_eq!(
-            pty_state_label(true, Status::Run, None),
-            "attached \u{b7} streaming"
-        );
-    }
-
-    #[test]
-    fn a_running_idle_shell_reports_idle_not_streaming_or_exited() {
-        assert_eq!(
-            pty_state_label(true, Status::Idle, None),
-            "attached \u{b7} idle"
-        );
+    fn the_pty_state_label_names_each_real_state_it_can_be_in() {
+        let cases: &[(bool, Status, Option<u32>, &str)] = &[
+            (false, Status::Idle, None, "not started"),
+            (false, Status::Fail, Some(101), "exited 101"),
+            (false, Status::Review, Some(0), "exited 0"),
+            (true, Status::Ask, None, "attached \u{b7} waiting on stdin"),
+            (true, Status::Run, None, "attached \u{b7} streaming"),
+            (true, Status::Idle, None, "attached \u{b7} idle"),
+        ];
+        for (running, status, code, expected) in cases {
+            assert_eq!(pty_state_label(*running, *status, *code), *expected);
+        }
     }
 
     #[test]
@@ -629,19 +601,20 @@ mod tests {
         }
     }
 
+    /// §4r, verbatim: "a finished transcript is a record; its actions live where their object
+    /// lives" - `Review` keeps none of `Keep all`, `Review`, `Open in editor`, `Discard
+    /// worktree`. §4e: `Interrupt` on an agent that is *waiting for you* has nothing to
+    /// interrupt, and `Open terminal` opens a *different* terminal, which does not answer the
+    /// question the agent is asking. §4t: `⌃C` in the focused pty is the interrupt, so the
+    /// button duplicating it is deleted from `Run` too.
     #[test]
-    fn a_finished_agent_offers_no_footer_actions_at_all() {
-        assert!(footer_actions(Status::Review).is_empty());
-    }
-
-    #[test]
-    fn an_asking_agent_offers_no_footer_actions_at_all() {
-        assert!(footer_actions(Status::Ask).is_empty());
-    }
-
-    #[test]
-    fn a_running_agent_offers_no_footer_actions_at_all() {
-        assert!(footer_actions(Status::Run).is_empty());
+    fn a_finished_asking_or_running_agent_offers_no_footer_actions_at_all() {
+        for status in [Status::Review, Status::Ask, Status::Run] {
+            assert!(
+                footer_actions(status).is_empty(),
+                "{status:?} must offer no footer action at all"
+            );
+        }
     }
 
     #[test]
@@ -696,27 +669,21 @@ mod tests {
     }
 
     #[test]
-    fn a_live_title_is_the_whole_tab_label_with_nothing_appended() {
-        assert_eq!(
-            live_tab_label(Some("\u{2733} Claude Code"), "claude"),
-            "\u{2733} Claude Code"
-        );
-        assert_eq!(live_tab_label(Some("~/src/jerry"), "zsh"), "~/src/jerry");
-    }
-
-    #[test]
-    fn a_pane_whose_process_has_set_no_title_falls_back_to_its_program_name() {
-        assert_eq!(live_tab_label(None, "zsh"), "zsh");
-    }
-
-    #[test]
-    fn an_empty_or_whitespace_title_falls_back_rather_than_rendering_a_blank_tab() {
-        assert_eq!(live_tab_label(Some(""), "bash"), "bash");
-        assert_eq!(live_tab_label(Some("   "), "bash"), "bash");
-    }
-
-    #[test]
-    fn two_panes_reporting_the_same_title_get_the_same_label() {
+    fn a_tab_label_is_the_live_title_verbatim_or_the_program_name() {
+        let cases: &[(Option<&str>, &str, &str)] = &[
+            (
+                Some("\u{2733} Claude Code"),
+                "claude",
+                "\u{2733} Claude Code",
+            ),
+            (Some("~/src/jerry"), "zsh", "~/src/jerry"),
+            (None, "zsh", "zsh"),
+            (Some(""), "bash", "bash"),
+            (Some("   "), "bash", "bash"),
+        ];
+        for (title, program, expected) in cases {
+            assert_eq!(live_tab_label(*title, program), *expected);
+        }
         assert_eq!(
             live_tab_label(Some("nvim"), "zsh"),
             live_tab_label(Some("nvim"), "bash"),
@@ -727,17 +694,13 @@ mod tests {
     fn the_new_agent_menu_row_shows_the_real_branch_never_a_model_name() {
         assert_eq!(
             new_agent_menu_secondary_text(Some("feature/real-branch")),
-            "runs in feature/real-branch"
+            "runs in feature/real-branch",
         );
         assert_ne!(
             new_agent_menu_secondary_text(Some("feature/real-branch")),
             "Claude",
             "must never show a model/agent-kind label in place of the branch"
         );
-    }
-
-    #[test]
-    fn the_new_agent_menu_row_falls_back_to_detached_with_no_recorded_branch() {
         assert_eq!(new_agent_menu_secondary_text(None), "runs in (detached)");
     }
 
@@ -833,46 +796,38 @@ mod tests {
         );
     }
 
+    /// The three payload-free singleton tabs - the graph (GitHub issue #93), the review tab
+    /// (#225) and the run transcript (#227) - are ordinary members of the same order every other
+    /// kind is in: appended last when freshly opened rather than pinned to a hardcoded position,
+    /// kept wherever a real drag put them, and dropped when closed rather than left dangling for
+    /// `crate::root::AdeApp::render_tab_strip` to render a tab that no longer exists.
     #[test]
-    fn reconcile_appends_a_freshly_opened_graph_tab() {
-        let order = reconcile_tab_order(&[], &[1], &[], true, None, false);
-        assert_eq!(order, vec![TabRef::Agent(1), TabRef::Graph]);
-    }
+    fn reconcile_treats_every_singleton_tab_kind_like_any_other() {
+        let kinds: &[(TabRef, bool, Option<AgentId>, bool)] = &[
+            (TabRef::Graph, true, None, false),
+            (TabRef::Review(1), false, Some(1), false),
+            (TabRef::Run, false, None, true),
+        ];
+        for (tab, graph_open, review_open, run_open) in kinds {
+            assert_eq!(
+                reconcile_tab_order(&[], &[1], &[], *graph_open, *review_open, *run_open),
+                vec![TabRef::Agent(1), tab.clone()],
+                "a freshly opened {tab:?} lands last, like every other new tab"
+            );
 
-    #[test]
-    fn reconcile_preserves_a_stored_graph_tab_position() {
-        let stored = vec![TabRef::Graph, TabRef::Agent(1)];
-        let order = reconcile_tab_order(&stored, &[1], &[], true, None, false);
-        assert_eq!(order, stored);
-    }
+            let stored = vec![tab.clone(), TabRef::Agent(1)];
+            assert_eq!(
+                reconcile_tab_order(&stored, &[1], &[], *graph_open, *review_open, *run_open),
+                stored,
+                "and a dragged position for {tab:?} is honoured rather than re-appended"
+            );
 
-    #[test]
-    fn reconcile_drops_a_closed_graph_tab() {
-        let stored = vec![TabRef::Agent(1), TabRef::Graph];
-        let order = reconcile_tab_order(&stored, &[1], &[], false, None, false);
-        assert_eq!(order, vec![TabRef::Agent(1)]);
-    }
-
-    #[test]
-    fn reconcile_appends_a_freshly_opened_review_tab() {
-        let order = reconcile_tab_order(&[], &[1], &[], false, Some(1), false);
-        assert_eq!(order, vec![TabRef::Agent(1), TabRef::Review(1)]);
-    }
-
-    #[test]
-    fn reconcile_preserves_a_stored_review_tab_position() {
-        let stored = vec![TabRef::Review(1), TabRef::Agent(1)];
-        assert_eq!(
-            reconcile_tab_order(&stored, &[1], &[], false, Some(1), false),
-            stored
-        );
-    }
-
-    #[test]
-    fn reconcile_drops_a_closed_review_tab() {
-        let stored = vec![TabRef::Agent(1), TabRef::Review(1)];
-        let order = reconcile_tab_order(&stored, &[1], &[], false, None, false);
-        assert_eq!(order, vec![TabRef::Agent(1)]);
+            assert_eq!(
+                reconcile_tab_order(&stored, &[1], &[], false, None, false),
+                vec![TabRef::Agent(1)],
+                "a closed {tab:?} is dropped, not left dangling in the strip"
+            );
+        }
     }
 
     #[test]
@@ -1014,7 +969,7 @@ mod tests {
     }
 
     #[test]
-    fn tab_slide_offsets_is_empty_when_the_drop_lands_on_the_tabs_own_already_adjacent_slot() {
+    fn tab_slide_offsets_is_empty_for_every_real_no_op() {
         let order = vec![
             TabRef::Agent(1),
             TabRef::Agent(2),
@@ -1023,27 +978,23 @@ mod tests {
         ];
         let width = px(25.0);
 
-        let slides = tab_slide_offsets(&order, &TabRef::Agent(1), &TabRef::Agent(2), false, width);
-
-        assert!(slides.is_empty());
-    }
-
-    #[test]
-    fn tab_slide_offsets_is_empty_for_every_move_tab_order_no_op() {
-        let order = vec![TabRef::Agent(1), TabRef::Agent(2)];
-        let width = px(40.0);
-
-        assert!(
-            tab_slide_offsets(&order, &TabRef::Agent(1), &TabRef::Agent(1), false, width)
-                .is_empty()
-        );
-        assert!(
-            tab_slide_offsets(&order, &TabRef::Agent(99), &TabRef::Agent(1), false, width)
-                .is_empty()
-        );
-        assert!(
-            tab_slide_offsets(&order, &TabRef::Agent(1), &TabRef::Agent(99), false, width)
-                .is_empty()
-        );
+        for (dragged, target, after, why) in [
+            (1, 2, false, "the tab's own already-adjacent slot"),
+            (1, 1, false, "a tab dropped onto itself"),
+            (99, 1, false, "an unknown dragged entry"),
+            (1, 99, false, "an unknown target"),
+        ] {
+            assert!(
+                tab_slide_offsets(
+                    &order,
+                    &TabRef::Agent(dragged),
+                    &TabRef::Agent(target),
+                    after,
+                    width
+                )
+                .is_empty(),
+                "{why} must slide nothing"
+            );
+        }
     }
 }

--- a/crates/app/src/work_surface/tab_order_state.rs
+++ b/crates/app/src/work_surface/tab_order_state.rs
@@ -407,6 +407,12 @@ mod tests {
             state.worktrees.is_empty(),
             "closing every file tab must not leave an empty entry behind forever"
         );
+
+        // A session whose every entry is unrecordable (outside the root) encodes to nothing, and
+        // must be forgotten the same way an explicitly empty one is.
+        state.set_session_tabs(root, &file_session(&[root.join("a.rs")]));
+        state.set_session_tabs(root, &file_session(&[PathBuf::from("/etc/passwd")]));
+        assert!(state.worktrees.is_empty());
     }
 
     #[test]
@@ -446,7 +452,7 @@ mod tests {
 
     #[test]
     fn saving_and_reloading_round_trips_through_a_real_file() {
-        let dir = tempfile::tempdir().expect("tempdir");
+        let dir = crate::test_support::temp_root();
         let path = dir.path().join("tab-order.toml");
         let root = Path::new("/repo/worktree-a");
 
@@ -464,7 +470,7 @@ mod tests {
 
     #[test]
     fn saving_merges_with_another_instances_entries_instead_of_erasing_them() {
-        let dir = tempfile::tempdir().expect("tempdir");
+        let dir = crate::test_support::temp_root();
         let path = dir.path().join("tab-order.toml");
         let a = Path::new("/repo/worktree-a");
         let b = Path::new("/repo/worktree-b");
@@ -488,42 +494,24 @@ mod tests {
         assert_eq!(on_disk.file_order(b), vec![b.join("b.rs")]);
     }
 
+    /// Neither a file that is not there nor one that is not valid TOML may fail the load - a
+    /// hand-edited or half-written `tab-order.toml` degrades to the empty state.
     #[test]
-    fn a_missing_file_loads_as_empty_state_rather_than_failing() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let state = TabOrderState::load_at(&dir.path().join("does-not-exist.toml"));
-        assert_eq!(state, TabOrderState::default());
-    }
+    fn a_missing_or_corrupted_file_loads_as_empty_state_rather_than_failing() {
+        let dir = crate::test_support::temp_root();
+        assert_eq!(
+            TabOrderState::load_at(&dir.path().join("does-not-exist.toml")),
+            TabOrderState::default()
+        );
 
-    #[test]
-    fn a_corrupted_file_loads_as_empty_state_rather_than_failing() {
-        let dir = tempfile::tempdir().expect("tempdir");
         let path = dir.path().join("tab-order.toml");
         std::fs::write(&path, "this is not valid toml {{{").expect("write");
         assert_eq!(TabOrderState::load_at(&path), TabOrderState::default());
     }
 
     #[test]
-    fn a_traversal_entry_in_a_hand_edited_file_is_ignored() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let path = dir.path().join("tab-order.toml");
-        std::fs::write(
-            &path,
-            "[worktrees.\"/repo/worktree-a\"]\nfiles = [\"../worktree-b/secret.rs\", \"src/main.rs\"]\n",
-        )
-        .expect("write");
-
-        let state = TabOrderState::load_at(&path);
-        assert_eq!(
-            state.file_order(Path::new("/repo/worktree-a")),
-            vec![PathBuf::from("/repo/worktree-a/src/main.rs")],
-            "the `..` entry must be silently dropped, and the good one kept"
-        );
-    }
-
-    #[test]
     fn saving_leaves_no_temp_file_behind_and_the_result_parses() {
-        let dir = tempfile::tempdir().expect("tempdir");
+        let dir = crate::test_support::temp_root();
         let path = dir.path().join("nested").join("tab-order.toml");
         let root = Path::new("/repo/worktree-a");
         let mut state = TabOrderState::default();
@@ -547,7 +535,7 @@ mod tests {
 
     #[test]
     fn a_mixed_session_round_trips_through_a_real_file_with_its_order_intact() {
-        let dir = tempfile::tempdir().expect("tempdir");
+        let dir = crate::test_support::temp_root();
         let path = dir.path().join("tab-order.toml");
         let root = Path::new("/repo/worktree-a");
         let session = vec![
@@ -617,7 +605,7 @@ mod tests {
 
     #[test]
     fn a_file_written_before_sessions_existed_still_restores_its_file_tabs() {
-        let dir = tempfile::tempdir().expect("tempdir");
+        let dir = crate::test_support::temp_root();
         let path = dir.path().join("tab-order.toml");
         std::fs::write(
             &path,
@@ -637,7 +625,7 @@ mod tests {
 
     #[test]
     fn an_unrecognised_record_is_skipped_without_losing_the_real_tabs_around_it() {
-        let dir = tempfile::tempdir().expect("tempdir");
+        let dir = crate::test_support::temp_root();
         let path = dir.path().join("tab-order.toml");
         std::fs::write(
             &path,
@@ -665,7 +653,7 @@ mod tests {
 
     #[test]
     fn a_traversal_session_entry_in_a_hand_edited_file_is_ignored() {
-        let dir = tempfile::tempdir().expect("tempdir");
+        let dir = crate::test_support::temp_root();
         let path = dir.path().join("tab-order.toml");
         std::fs::write(
             &path,
@@ -686,14 +674,16 @@ mod tests {
                 "/repo/worktree-a/src/main.rs"
             ))],
         );
-    }
 
-    #[test]
-    fn a_session_that_encodes_to_nothing_forgets_the_worktree() {
-        let root = Path::new("/repo/worktree-a");
-        let mut state = TabOrderState::default();
-        state.set_session_tabs(root, &file_session(&[root.join("a.rs")]));
-        state.set_session_tabs(root, &file_session(&[PathBuf::from("/etc/passwd")]));
-        assert!(state.worktrees.is_empty());
+        std::fs::write(
+            &path,
+            "[worktrees.\"/repo/worktree-a\"]\nfiles = [\"../worktree-b/secret.rs\", \"src/main.rs\"]\n",
+        )
+        .expect("write");
+        assert_eq!(
+            TabOrderState::load_at(&path).file_order(Path::new("/repo/worktree-a")),
+            vec![PathBuf::from("/repo/worktree-a/src/main.rs")],
+            "the legacy `files` list drops its `..` entry and keeps the good one too"
+        );
     }
 }

--- a/crates/app/src/worktree_history/flow.rs
+++ b/crates/app/src/worktree_history/flow.rs
@@ -225,53 +225,30 @@ impl AdeApp {
 mod worktree_history_regression_tests {
     use super::*;
     use crate::root::focus::palette_focus_tests;
+    use crate::test_support::{temp_repo_with, TempRoot};
     use gpui::{Entity, TestAppContext};
     use std::fs;
-    use std::process::Command;
     use tempfile::TempDir;
+    use test_support::{git, git_output};
 
-    fn git(dir: &Path, args: &[&str]) {
-        let output = Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {:?} failed in {:?}:\nstdout: {}\nstderr: {}",
-            args,
-            dir,
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
-    fn git_output(dir: &Path, args: &[&str]) -> String {
-        let output = Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(output.status.success(), "git {args:?} failed in {dir:?}");
-        String::from_utf8_lossy(&output.stdout).trim().to_string()
-    }
-
-    fn init_repo() -> TempDir {
-        let dir = TempDir::new().expect("tempdir");
-        git(dir.path(), &["init", "-b", "main"]);
-        git(dir.path(), &["config", "user.email", "test@example.com"]);
-        git(dir.path(), &["config", "user.name", "Test User"]);
-        fs::write(dir.path().join("base.txt"), "base\n").expect("write");
-        git(dir.path(), &["add", "base.txt"]);
-        git(dir.path(), &["commit", "-m", "initial"]);
-        dir
+    fn init_repo() -> TempRoot {
+        temp_repo_with(|root| {
+            test_support::seed_empty_repo_at(root);
+            test_support::commit(root, "base.txt", "base\n", "initial");
+        })
     }
 
     /// Same linked-worktree idiom `merge::flow`/`rail::render`'s own test modules use.
     fn add_worktree(repo_path: &Path, branch: &str, name: &str) -> PathBuf {
         let container = TempDir::new().expect("tempdir");
-        let path = container.path().join(name);
-        drop(container);
+        // `keep()`, not `drop()`: dropping the container deleted the directory and freed its
+        // random name for reuse, so under the parallel suite another fixture could be handed the
+        // same name and create `<name>` inside it first - `git worktree add` then failed with
+        // "already exists". Reproduced directly: 1 run in ~7 of the merge module under load.
+        // Keeping the (empty) directory costs nothing the old code did not already leak, since
+        // git recreated the path afterwards and nothing ever removed it.
+        let root = container.keep();
+        let path = root.join(name);
         git(
             repo_path,
             &[

--- a/crates/lsp-core/Cargo.toml
+++ b/crates/lsp-core/Cargo.toml
@@ -57,14 +57,25 @@ pty-core = { path = "../pty-core" }
 # fn canonicalize(path) { fs::canonicalize(path) }`), so this is zero behavioral change there.
 dunce = "1.0.5"
 
-# Process-tree kill (SIGTERM-then-SIGKILL, plus a `/proc` descendant sweep so a `cargo
-# check`/`rustc` child rust-analyzer spawned while indexing doesn't survive as an orphan) -
-# unix-only, mirroring `pty-core`'s own kill implementation (see `src/client.rs`'s module
-# docs for the differences: SIGTERM instead of SIGHUP, no process-group/`setsid` handling
-# since rust-analyzer is spawned as a plain `std::process::Command` child, not a pty session
-# leader). Pinned to the exact version `pty-core/Cargo.toml` already pins.
+# Process-tree kill (SIGTERM-then-SIGKILL, plus a descendant sweep so a `cargo check`/`rustc`
+# child rust-analyzer spawned while indexing doesn't survive as an orphan, and `kill(pid, 0)`
+# as the liveness check the grace loop polls) - unix-only, mirroring `pty-core`'s own kill
+# implementation (see `src/client.rs`'s module docs for the differences: SIGTERM instead of
+# SIGHUP, no process-group/`setsid` handling since rust-analyzer is spawned as a plain
+# `std::process::Command` child, not a pty session leader). Pinned to the exact version
+# `pty-core/Cargo.toml` already pins.
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.28", default-features = false, features = ["fs", "poll", "signal"] }
 
+# macOS only, and for the exact same reason as `pty-core/Cargo.toml`'s own entry: `/proc` does
+# not exist there, so `crate::proc::child_pids_of`'s descendant walk goes through `libproc`'s
+# `proc_listchildpids` instead. Already resolved in this workspace's lock file.
+[target.'cfg(target_os = "macos")'.dependencies]
+libc = "0.2"
+
 [dev-dependencies]
 tempfile = "3"
+# Shared fixtures - `ChildGuard`'s kill-on-drop teardown for the real `cat` child the
+# `handle_incoming` harness borrows a `ChildStdin` from. Usable here precisely because
+# `test-support` carries no `gpui` (docs/architecture/decisions.md §1).
+test-support = { path = "../test-support" }

--- a/crates/lsp-core/src/client.rs
+++ b/crates/lsp-core/src/client.rs
@@ -1251,6 +1251,10 @@ fn run_stderr_drain_loop(stderr: std::process::ChildStderr, server: &'static str
 mod tests {
     use super::*;
     use std::time::Instant;
+    // Only `IncomingHarness` uses this, and it is `#[cfg(unix)]` - the import has to carry the
+    // same gate or it is an unused import on Windows.
+    #[cfg(unix)]
+    use test_support::ChildGuard;
 
     #[test]
     fn canonicalize_resolves_a_real_directory() {
@@ -1462,29 +1466,35 @@ mod tests {
         );
     }
 
-    /// [`handle_incoming`]'s collaborators without spawning a language server. The `ChildStdin`
-    /// comes from a `cat` child, since it has no constructor and the branches under test never
-    /// write to it; the child is returned so the caller keeps it alive and kills it.
+    /// The real collaborators [`handle_incoming`] needs, built without spawning a language server:
+    /// a genuine `ChildStdin` (taken from a real, trivial `cat` child, since `ChildStdin` has no
+    /// constructor of its own and the notification branches under test never write to it), plus
+    /// the same real `Arc<Mutex<..>>` sinks [`LspClient::spawn`] wires up. Returns the child too,
+    /// so the caller keeps it alive - and kills it - for the duration of the test.
+    #[cfg(unix)]
     struct IncomingHarness {
-        child: Child,
+        /// Kept alive for the test's duration, and killed on drop by the guard itself.
+        _child: ChildGuard,
         sinks: IncomingSinks,
         wake_rx: Receiver<()>,
     }
 
+    #[cfg(unix)]
     impl IncomingHarness {
         /// `subscribed` is the real [`ServerSpawnConfig::custom_notification_methods`] list this
         /// harness's `handle_incoming` calls are driven with.
         fn new(subscribed: &[&'static str]) -> Self {
-            let mut child = Command::new("cat")
-                .stdin(Stdio::piped())
-                .stdout(Stdio::piped())
-                .stderr(Stdio::null())
-                .spawn()
-                .expect("spawning a real `cat` for its stdin handle");
+            let mut child = ChildGuard::spawn(
+                Command::new("cat")
+                    .stdin(Stdio::piped())
+                    .stdout(Stdio::piped())
+                    .stderr(Stdio::null()),
+            )
+            .expect("spawning a real `cat` for its stdin handle");
             let stdin = child.stdin.take().expect("piped stdin");
             let (wake_tx, wake_rx) = mpsc::sync_channel::<()>(WAKE_CHANNEL_CAPACITY);
             Self {
-                child,
+                _child: child,
                 sinks: IncomingSinks {
                     pending: Arc::new(Mutex::new(HashMap::new())),
                     diagnostics: Arc::new(Mutex::new(HashMap::new())),
@@ -1508,13 +1518,10 @@ mod tests {
         }
     }
 
-    impl Drop for IncomingHarness {
-        fn drop(&mut self) {
-            let _ = self.child.kill();
-            let _ = self.child.wait();
-        }
-    }
-
+    /// The real capability `crate::client`'s notification branch gained so a server's own custom
+    /// protocol extension stops being invisible: a subscribed method is queued verbatim, method
+    /// and raw params both intact, in real arrival order.
+    #[cfg(unix)]
     #[test]
     fn a_subscribed_notification_is_queued_verbatim_for_draining() {
         let harness = IncomingHarness::new(&["tsserver/request", "server/other"]);
@@ -1548,6 +1555,12 @@ mod tests {
         );
     }
 
+    /// The real "no added cost for the servers that were already working" guarantee: a client that
+    /// subscribed to nothing (rust-analyzer, typescript-language-server, pyright - all three of
+    /// this app's pre-existing servers) queues nothing at all, no matter how much unrelated
+    /// notification traffic its server produces. Behaviorally identical to before this capability
+    /// existed.
+    #[cfg(unix)]
     #[test]
     fn a_client_that_subscribed_to_nothing_queues_nothing_at_all() {
         let harness = IncomingHarness::new(&[]);
@@ -1568,6 +1581,9 @@ mod tests {
         );
     }
 
+    /// Subscription is per-method, not all-or-nothing: an un-subscribed method is still ignored
+    /// even on a client that subscribed to something else.
+    #[cfg(unix)]
     #[test]
     fn an_unsubscribed_method_is_ignored_even_when_other_methods_are_subscribed() {
         let harness = IncomingHarness::new(&["tsserver/request"]);
@@ -1579,6 +1595,10 @@ mod tests {
         assert!(harness.drain_custom().is_empty());
     }
 
+    /// The other half of the partition: `publishDiagnostics` keeps going only to its own real,
+    /// typed sink and must never *also* appear on the custom-notification path, which would give
+    /// callers two disagreeing sources for the same real data.
+    #[cfg(unix)]
     #[test]
     fn publish_diagnostics_never_appears_on_the_custom_notification_path() {
         let harness = IncomingHarness::new(&["textDocument/publishDiagnostics"]);
@@ -1611,6 +1631,9 @@ mod tests {
         assert_eq!(recorded[0].message, "mismatched types");
     }
 
+    /// Both paths send the same real wake signal, so the `app` crate's single existing poll loop
+    /// notices either without new polling machinery.
+    #[cfg(unix)]
     #[test]
     fn a_custom_notification_sends_the_same_real_wake_signal_diagnostics_do() {
         let harness = IncomingHarness::new(&["tsserver/request"]);
@@ -1630,6 +1653,10 @@ mod tests {
         );
     }
 
+    /// A server that sends a subscribed notification faster than anything drains it must not grow
+    /// this queue without limit - the *oldest* entry is dropped, so the newest, most relevant ones
+    /// are the ones that survive.
+    #[cfg(unix)]
     #[test]
     fn the_custom_notification_queue_is_bounded_and_drops_the_oldest_first() {
         let harness = IncomingHarness::new(&["server/custom"]);
@@ -1659,6 +1686,9 @@ mod tests {
         );
     }
 
+    /// A server-initiated *request* (an `id` alongside the `method`) still takes the real
+    /// reply path and must not leak onto the notification queue, which has no way to answer one.
+    #[cfg(unix)]
     #[test]
     fn a_server_initiated_request_is_not_treated_as_a_custom_notification() {
         let harness = IncomingHarness::new(&["client/registerCapability"]);
@@ -1675,6 +1705,7 @@ mod tests {
     }
 
     #[cfg(unix)]
+    #[ignore = "external: rust-analyzer; see docs/testing.md"]
     #[test]
     fn spawn_performs_a_real_handshake_and_shutdown_leaves_no_orphan() {
         let project = write_scratch_project("fn main() {}\n");
@@ -1707,6 +1738,7 @@ mod tests {
     }
 
     #[cfg(unix)]
+    #[ignore = "external: rust-analyzer; see docs/testing.md"]
     #[test]
     fn drop_without_shutdown_does_not_leave_an_orphaned_process() {
         let project = write_scratch_project("fn main() {}\n");
@@ -1731,6 +1763,7 @@ mod tests {
         }
     }
 
+    #[ignore = "external: rust-analyzer; see docs/testing.md"]
     #[test]
     fn a_second_request_after_the_connection_closes_fails_fast_not_after_the_full_timeout() {
         let project = write_scratch_project("fn main() {}\n");
@@ -1756,6 +1789,30 @@ mod tests {
         );
     }
 
+    /// The real, practical end-to-end proof this phase exists to deliver: a real
+    /// `rust-analyzer` process, spawned against a real (tiny, dependency-free) scratch cargo
+    /// project containing a genuine type error, performs a real `initialize`/`initialized`
+    /// handshake, receives a real `textDocument/didOpen`, and - asynchronously, on its own
+    /// timeline - pushes back a real `textDocument/publishDiagnostics` notification that
+    /// actually references the introduced mismatch. This is a genuinely slow test (real process
+    /// startup plus real sysroot/std indexing, even for a trivial crate) - no artificial sleep
+    /// stands in for that real wait, and no diagnostic is fabricated if the wait were to time
+    /// out (the assertion below would simply fail honestly).
+    ///
+    /// Observed real behavior worth documenting (found while writing this test, via a temporary
+    /// debug harness that logged every real `publishDiagnostics` payload with its arrival time):
+    /// rust-analyzer publishes **twice** for a freshly-opened file - an initial, near-instant
+    /// (~0.6s here) publish with an *empty* diagnostics array (its syntax-only pass, before
+    /// semantic type-checking has run), immediately followed (~0.1s later, for this tiny fixture)
+    /// by a second publish carrying the real `E0308` mismatch. This is real, correct, eventually-
+    /// consistent LSP behavior (the same thing VS Code/any other real LSP client observes) - not
+    /// a bug in this crate - so the wait loop below deliberately keeps waiting for a real
+    /// *non-empty* result (which this fixture is deterministically known to eventually produce),
+    /// rather than stopping at the first `has_diagnostics_result` flip - see that method's own
+    /// docs, and the step report's "indexing state" section, for why `has_diagnostics_result`
+    /// itself is still the right, honest signal for the UI layer even though it can be `true`
+    /// with a since-superseded empty result for a brief real window like this one.
+    #[ignore = "external: rust-analyzer; see docs/testing.md"]
     #[test]
     fn rust_analyzer_reports_a_real_diagnostic_for_a_real_type_error() {
         let project = write_scratch_project(
@@ -1826,6 +1883,24 @@ mod tests {
         client.shutdown().expect("shutdown should succeed");
     }
 
+    /// The real, live proof Revision R8.5b's `LspClient::did_change_full`/`LspClient::
+    /// pull_diagnostics` exist to deliver: a real rust-analyzer, opened against a clean file,
+    /// gets a real *unsaved* edit (via `did_change_full` alone - no `did_open`/re-spawn, no file
+    /// ever written to disk) that introduces a genuine `E0308` type mismatch, and a real,
+    /// specifically *pulled* `textDocument/diagnostic` request reports it.
+    ///
+    /// This is the direct, load-bearing regression test for a real, live-discovered protocol
+    /// fact this crate's original design got wrong: a real, installed rust-analyzer was found,
+    /// by live probing while building this feature, to publish `publishDiagnostics` via *push*
+    /// only once - immediately after `didOpen` - and never again on its own initiative after a
+    /// subsequent `didChange`, despite advertising `textDocumentSync` support for it; real,
+    /// updated diagnostics must be actively *pulled* instead (see `LspClient::
+    /// supports_diagnostic_pull`'s own docs). An earlier version of this test (and of the `app`
+    /// crate's own end-to-end wiring test) asserted purely on the *push* sink
+    /// (`Self::diagnostics_for`) after a `did_change_full` call and hung for the full real 60s+
+    /// deadline every time - a genuine, live-reproduced correctness gap this fix closes, not a
+    /// hypothetical one.
+    #[ignore = "external: rust-analyzer; see docs/testing.md"]
     #[test]
     fn did_change_full_then_a_real_pull_reports_a_real_new_diagnostic() {
         let project = write_scratch_project(
@@ -1924,6 +1999,21 @@ mod tests {
         );
     }
 
+    /// Revision R8.5b audit finding 5's direct regression test: a real, *late-arriving* pull
+    /// result tagged with an older document version must never clobber a real, *already-landed*
+    /// result for a newer one - the exact race `LspClient::diagnostics_version` exists to close
+    /// (see that field's own docs). Reproduced against a real rust-analyzer, not simulated: a
+    /// real `did_change_full` introduces a genuine type error, a real pull at version 10 records
+    /// it, then a real second pull against the *same, still-erroring* live content is issued but
+    /// deliberately mislabeled with version 3 (lower than what's already recorded) - standing in
+    /// for "this response, though arriving now, actually corresponds to an older edit that was
+    /// slow to answer". Real `pull_diagnostics` must still return `Ok(())` (a real answer *was*
+    /// obtained, just discarded as stale) but must not overwrite the real version-10 result: the
+    /// diagnostics this call left in place are checked directly by pre-emptively clearing what's
+    /// there (via a version-0 sync-independent probe is not available, so a distinguishing
+    /// baseline is used instead - see inline comments) rather than merely re-observing identical
+    /// content.
+    #[ignore = "external: rust-analyzer; see docs/testing.md"]
     #[test]
     fn a_stale_lower_version_pull_never_clobbers_an_already_landed_newer_one() {
         let project = write_scratch_project(
@@ -2017,6 +2107,7 @@ mod tests {
     }
 
     #[cfg(unix)]
+    #[ignore = "external: rust-analyzer; see docs/testing.md"]
     #[test]
     fn killing_the_real_process_flips_is_connection_alive_to_false() {
         let project = write_scratch_project("fn main() {}\n");
@@ -2045,6 +2136,7 @@ mod tests {
     }
 
     #[cfg(unix)]
+    #[ignore = "external: rust-analyzer; see docs/testing.md"]
     #[test]
     fn a_real_but_frozen_server_fails_the_write_within_the_budget_instead_of_hanging_forever() {
         let project = write_scratch_project("fn main() {\n    let x: i32 = 1;\n}\n");
@@ -2095,6 +2187,7 @@ mod tests {
     }
 
     #[cfg(unix)]
+    #[ignore = "external: rust-analyzer; see docs/testing.md"]
     #[test]
     fn a_connection_already_known_dead_fails_further_writes_immediately() {
         let project = write_scratch_project("fn main() {}\n");
@@ -2146,6 +2239,7 @@ mod tests {
     }
 
     #[cfg(unix)]
+    #[ignore = "external: rust-analyzer; see docs/testing.md"]
     #[test]
     fn a_writer_queued_behind_one_that_gives_up_is_refused_rather_than_corrupting_the_stream() {
         let project = write_scratch_project("fn main() {}\n");
@@ -2248,6 +2342,14 @@ mod tests {
         dir
     }
 
+    /// The real, practical end-to-end proof for TypeScript (mirrors
+    /// [`rust_analyzer_reports_a_real_diagnostic_for_a_real_type_error`] above exactly): a real
+    /// `typescript-language-server`, spawned via the same generalized [`LspClient::spawn`] every
+    /// other language now shares, against a real scratch project with a genuine
+    /// `const bad: number = "not a number";` type mismatch, performs a real handshake, receives
+    /// a real `didOpen` tagged with the real `"typescript"` language id, and asynchronously
+    /// pushes back a real `textDocument/publishDiagnostics` referencing the introduced mismatch.
+    #[ignore = "external: typescript-language-server; see docs/testing.md"]
     #[test]
     fn typescript_language_server_reports_a_real_diagnostic_for_a_real_type_error() {
         let project =
@@ -2300,6 +2402,9 @@ mod tests {
         client.shutdown().expect("shutdown should succeed");
     }
 
+    /// A real end-to-end proof of hover for TypeScript, mirroring
+    /// [`rust_analyzer_returns_a_real_hover_for_a_documented_function`] above.
+    #[ignore = "external: typescript-language-server; see docs/testing.md"]
     #[test]
     fn typescript_language_server_returns_a_real_hover_for_a_documented_function() {
         let project = write_scratch_ts_project(
@@ -2412,6 +2517,13 @@ mod tests {
         dir
     }
 
+    /// The real, practical end-to-end proof for Python: a real `pyright-langserver`, spawned
+    /// with the real, non-`null` `initializationOptions`/`workspace/configuration` answers this
+    /// generalization added specifically because Pyright (unlike rust-analyzer/
+    /// typescript-language-server) needs them to behave well, against a real scratch file with a
+    /// genuine `x: int = "not a number"` type error, performs a real handshake, receives a real
+    /// `didOpen` tagged `"python"`, and asynchronously pushes back a real diagnostic.
+    #[ignore = "external: pyright-langserver; see docs/testing.md"]
     #[test]
     fn pyright_reports_a_real_diagnostic_for_a_real_type_error() {
         let project = write_scratch_py_project(
@@ -2467,6 +2579,9 @@ mod tests {
         client.shutdown().expect("shutdown should succeed");
     }
 
+    /// A real end-to-end proof of hover for Python, mirroring the TypeScript/rust-analyzer
+    /// hover tests above.
+    #[ignore = "external: pyright-langserver; see docs/testing.md"]
     #[test]
     fn pyright_returns_a_real_hover_for_a_documented_function() {
         let project = write_scratch_py_project(
@@ -2569,6 +2684,17 @@ mod tests {
         );
     }
 
+    /// A real, second end-to-end proof against a genuinely running `rust-analyzer`: a real
+    /// `textDocument/hover` request at a real, byte-accurate position (a documented function's
+    /// own call site) returns the function's real signature and real doc-comment prose - not a
+    /// placeholder. This is the exact real fixture/technique
+    /// [`rust_analyzer_reports_a_real_diagnostic_for_a_real_type_error`] above already
+    /// established for diagnostics, reused here for hover: a real, tiny, dependency-free scratch
+    /// crate (so indexing is fast and needs no network), a real spawn/`didOpen`, and a bounded,
+    /// generous real wait - `rust-analyzer` needs to finish enough of its own real indexing to
+    /// answer a hover query, which (like diagnostics) is not instantaneous even for a trivial
+    /// fixture, so this polls with real retries rather than a single immediate request.
+    #[ignore = "external: rust-analyzer; see docs/testing.md"]
     #[test]
     fn rust_analyzer_returns_a_real_hover_for_a_documented_function() {
         let project = write_scratch_project(
@@ -2642,6 +2768,11 @@ mod tests {
         client.shutdown().expect("shutdown should succeed");
     }
 
+    /// A real end-to-end proof of go-to-definition: a real `textDocument/definition` request at
+    /// the same real call-site position the hover test above uses returns a real
+    /// `GotoDefinitionResponse` whose location genuinely points back at the function's own real
+    /// definition line in the same file - not a placeholder location.
+    #[ignore = "external: rust-analyzer; see docs/testing.md"]
     #[test]
     fn rust_analyzer_returns_a_real_definition_location_for_a_call_site() {
         let project = write_scratch_project(

--- a/crates/lsp-core/src/proc.rs
+++ b/crates/lsp-core/src/proc.rs
@@ -9,14 +9,18 @@
 //! orphans, since a process-tree kill there needs job objects and their `unsafe` FFI.
 
 use std::collections::HashSet;
+#[cfg(all(unix, not(target_os = "macos")))]
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
 /// Depth cap for the descendant walk, defensive against a pathological process tree.
 const TREE_WALK_MAX_DEPTH: usize = 8;
 
-/// The direct children of `pid`. Best-effort: an unreadable file is an empty list, not an error.
-#[cfg(unix)]
+/// Reads the current direct children of `pid` from Linux's `/proc/<pid>/task/<pid>/children`.
+/// Best-effort: returns an empty list if the file can't be read (process already gone,
+/// a unix without procfs, permissions, ...) rather than erroring - used only for teardown
+/// cleanup, where "found nothing else to clean up" is an acceptable fallback.
+#[cfg(all(unix, not(target_os = "macos")))]
 fn child_pids_of(pid: u32) -> Vec<u32> {
     let path = PathBuf::from(format!("/proc/{pid}/task/{pid}/children"));
     std::fs::read_to_string(&path)
@@ -29,10 +33,58 @@ fn child_pids_of(pid: u32) -> Vec<u32> {
         .unwrap_or_default()
 }
 
-/// Breadth-first, depth-capped walk of `root_pid`'s descendants.
+/// Reads the current direct children of `pid` from macOS's `libproc`, which has no `/proc` for
+/// the branch above to read. Best-effort in exactly the same way: an empty list, never an
+/// error, when the process is already gone or cannot be queried.
 ///
-/// Must run *before* any signal: reading it once a process is dying races the kernel reparenting
-/// its children out from under the file.
+/// `proc_listchildpids` returns the number of pids it wrote and truncates *silently* when the
+/// buffer is too small - it reports the capacity it filled with no error of any kind - so a
+/// completely full buffer is retried at double the capacity rather than trusted to be complete.
+#[cfg(target_os = "macos")]
+#[allow(unsafe_code)]
+fn child_pids_of(pid: u32) -> Vec<u32> {
+    // A parent with more direct children than this is pathological, not a real rust-analyzer
+    // process tree; the doubling below stops here rather than growing without bound.
+    const MAX_CAPACITY: usize = 4096;
+
+    let Ok(ppid) = libc::pid_t::try_from(pid) else {
+        return Vec::new();
+    };
+
+    let mut capacity = 64usize;
+    loop {
+        let mut buffer: Vec<libc::pid_t> = vec![0; capacity];
+        let buffer_bytes = capacity * std::mem::size_of::<libc::pid_t>();
+
+        // SAFETY: `proc_listchildpids` writes at most `buffersize` bytes through the buffer
+        // pointer, which addresses a live, uniquely borrowed `Vec` allocation of exactly
+        // `buffer_bytes` bytes for the whole call and is not retained by the callee. The cast
+        // is the one Apple's own header requires - the parameter is a bare `void *`. It reports
+        // how many pids it wrote, or 0 on failure, and never a negative count.
+        let written = unsafe {
+            libc::proc_listchildpids(
+                ppid,
+                buffer.as_mut_ptr().cast::<libc::c_void>(),
+                buffer_bytes as libc::c_int,
+            )
+        };
+
+        let written = usize::try_from(written).unwrap_or(0).min(capacity);
+        if written < capacity || capacity == MAX_CAPACITY {
+            buffer.truncate(written);
+            return buffer
+                .into_iter()
+                .filter_map(|child| u32::try_from(child).ok())
+                .collect();
+        }
+        capacity = (capacity * 2).min(MAX_CAPACITY);
+    }
+}
+
+/// Breadth-first, depth-capped walk of `root_pid`'s descendant tree via [`child_pids_of`]. Must
+/// be called *before* signaling anything - reading it after a process starts dying races against
+/// the kernel reparenting its children out from under it (the same real ordering
+/// requirement `pty-core::collect_descendant_pids`'s own docs describe).
 #[cfg(unix)]
 pub fn collect_descendant_pids(root_pid: u32) -> Vec<u32> {
     let mut discovered = Vec::new();
@@ -61,7 +113,13 @@ pub fn collect_descendant_pids(root_pid: u32) -> Vec<u32> {
 /// A direct `/proc/<pid>` existence check.
 #[cfg(unix)]
 pub fn pid_exists(pid: u32) -> bool {
-    PathBuf::from(format!("/proc/{pid}")).exists()
+    let Ok(raw) = i32::try_from(pid) else {
+        return false;
+    };
+    match nix::sys::signal::kill(nix::unistd::Pid::from_raw(raw), None) {
+        Ok(()) => true,
+        Err(errno) => errno == nix::errno::Errno::EPERM,
+    }
 }
 
 /// Sends `signal` to one pid. Callers ignore the error: the job is reaching every discovered pid,
@@ -106,30 +164,65 @@ pub fn terminate_tree(root_pid: u32, grace: Duration) {
 mod tests {
     use super::*;
     use std::process::{Command, Stdio};
+    use test_support::ChildGuard;
 
+    /// The two answers [`pid_exists`] has to get right for [`terminate_tree`]'s grace loop to
+    /// mean anything: a process that is genuinely running, and one that has already been
+    /// reaped.
     #[test]
-    fn collect_descendant_pids_finds_a_real_child_process() {
-        let mut child = Command::new("sh")
-            .arg("-c")
-            .arg("sleep 30")
+    fn pid_exists_separates_a_live_process_from_a_reaped_one() {
+        assert!(
+            pid_exists(std::process::id()),
+            "this very test process is unambiguously alive"
+        );
+
+        let mut child = Command::new("true")
             .stdin(Stdio::null())
             .stdout(Stdio::null())
             .stderr(Stdio::null())
             .spawn()
-            .expect("spawning `sh -c 'sleep 30'` should succeed");
+            .expect("spawning `true` should succeed");
+        let pid = child.id();
+        child.wait().expect("reaping `true` should succeed");
+
+        assert!(
+            !pid_exists(pid),
+            "pid {pid} was reaped, so it should read as gone rather than alive"
+        );
+    }
+
+    /// `sleep 30 & wait`, not a bare `sleep 30`: macOS's `/bin/sh` `exec`s a lone final command
+    /// in place rather than forking for it, so `sh -c 'sleep 30'` leaves a process *named*
+    /// `sleep` at the shell's own pid and no child at all for this walk to find. Backgrounding
+    /// forces a real fork on every shell - the same form the sibling test below already uses.
+    #[test]
+    fn collect_descendant_pids_finds_a_real_child_process() {
+        // `ChildGuard`: the assertion below used to sit between the spawn and the manual kill,
+        // so a failing walk left a real 30-second `sleep` tree behind.
+        let mut child = ChildGuard::spawn(
+            Command::new("sh")
+                .arg("-c")
+                .arg("sleep 30 & wait")
+                .stdin(Stdio::null())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null()),
+        )
+        .expect("spawning `sh -c 'sleep 30 & wait'` should succeed");
         let sh_pid = child.id();
 
-        // Give the shell a moment to actually exec `sleep` as its own child.
-        std::thread::sleep(Duration::from_millis(200));
-
-        let descendants = collect_descendant_pids(sh_pid);
+        // The shell forks `sleep` asynchronously, so poll for it rather than guessing how long
+        // that takes on a loaded machine.
+        let mut descendants = Vec::new();
+        let forked = test_support::wait_until(Duration::from_secs(5), || {
+            descendants = collect_descendant_pids(sh_pid);
+            !descendants.is_empty()
+        });
         assert!(
-            !descendants.is_empty(),
-            "expected `sh -c 'sleep 30'` to have spawned a real, discoverable `sleep` child"
+            forked,
+            "expected `sh -c 'sleep 30 & wait'` to have spawned a real, discoverable `sleep` child"
         );
 
-        let _ = child.kill();
-        let _ = child.wait();
+        child.kill_and_wait().expect("reap the shell");
         for pid in descendants {
             signal_pid(pid, nix::sys::signal::Signal::SIGKILL);
         }
@@ -137,19 +230,25 @@ mod tests {
 
     #[test]
     fn terminate_tree_kills_a_real_process_and_its_real_child() {
-        let mut child = Command::new("sh")
-            .arg("-c")
-            .arg("sleep 30 & wait")
-            .stdin(Stdio::null())
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .spawn()
-            .expect("spawning the shell pipeline should succeed");
+        let mut child = ChildGuard::spawn(
+            Command::new("sh")
+                .arg("-c")
+                .arg("sleep 30 & wait")
+                .stdin(Stdio::null())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null()),
+        )
+        .expect("spawning the shell pipeline should succeed");
         let sh_pid = child.id();
-        std::thread::sleep(Duration::from_millis(200));
 
-        let descendants = collect_descendant_pids(sh_pid);
-        assert!(!descendants.is_empty(), "expected a real sleep grandchild");
+        let mut descendants = Vec::new();
+        assert!(
+            test_support::wait_until(Duration::from_secs(5), || {
+                descendants = collect_descendant_pids(sh_pid);
+                !descendants.is_empty()
+            }),
+            "expected a real sleep grandchild"
+        );
 
         terminate_tree(sh_pid, Duration::from_millis(500));
         let _ = child.wait();

--- a/crates/pty-core/Cargo.toml
+++ b/crates/pty-core/Cargo.toml
@@ -20,15 +20,30 @@ anyhow = { workspace = true }
 # crate-level "Platform scope" docs for why non-unix has no self-pipe/poll shutdown signal.
 filedescriptor = "0.8"
 
-# Process-group signals and the `/proc` descendant walk are unix-only; see the crate-level
-# doc comment in src/lib.rs for why non-unix instead calls `portable_pty::Child::kill()`
-# directly. Already a transitive dep of `portable-pty` 0.9.0 on unix (pinned here to the
-# exact version already resolved in Cargo.lock, so this adds no new version surface).
+# Process-group signals, the `kill(pid, 0)` liveness check and the descendant walk are
+# unix-only; see the crate-level doc comment in src/lib.rs for why non-unix instead calls
+# `portable_pty::Child::kill()` directly. Already a transitive dep of `portable-pty` 0.9.0 on
+# unix (pinned here to the exact version already resolved in Cargo.lock, so this adds no new
+# version surface).
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.28", default-features = false, features = ["signal"] }
+
+# macOS only: there is no `/proc` there, so `child_pids_of`'s descendant walk goes through
+# `libproc`'s `proc_listchildpids` (declared in `<libproc.h>`, implemented in libSystem, which
+# every macOS binary already links) instead. Raw `libc` rather than the `libproc` crate for the
+# reasons `crates/app/src/status_bar/process_stats/macos.rs` already sets out: `libc` declares
+# the call with the exact signature used, and it is already resolved in this workspace's lock
+# file, so this adds no new build surface.
+[target.'cfg(target_os = "macos")'.dependencies]
+libc = "0.2"
 
 [dev-dependencies]
 # Test-only: `resolve_on_path_skips_a_same_named_directory` needs a real, isolated temporary
 # directory to prepend to `$PATH` (see that test's docs). Matches the exact version
 # `crates/app/Cargo.toml`/`crates/wt-core/Cargo.toml` already pin.
 tempfile = "3"
+# The workspace's shared fixtures: `wait_until` (the one sanctioned wall-clock wait, replacing
+# this crate's hand-rolled poll loops) and `ChildGuard` (kill-on-drop teardown for a test that
+# spawns a real process outside a `PtySession`). Deliberately `gpui`-free, so depending on it
+# here cannot violate `docs/architecture/decisions.md` §1.
+test-support = { path = "../test-support" }

--- a/crates/pty-core/src/lib.rs
+++ b/crates/pty-core/src/lib.rs
@@ -701,9 +701,11 @@ impl Drop for PtySession {
     }
 }
 
-/// The direct children of `pid`, from Linux's `/proc`. Best-effort: an unreadable file - a gone
-/// process, a non-Linux unix - is an empty list rather than an error.
-#[cfg(unix)]
+/// Reads the current direct children of `pid` from Linux's `/proc/<pid>/task/<pid>/children`.
+/// Best-effort: returns an empty list if the file can't be read (process already gone,
+/// a unix without procfs, permissions, etc.) rather than erroring - this is used for cleanup,
+/// where "found nothing to additionally clean up" is an acceptable fallback.
+#[cfg(all(unix, not(target_os = "macos")))]
 fn child_pids_of(pid: u32) -> Vec<u32> {
     let path = PathBuf::from(format!("/proc/{pid}/task/{pid}/children"));
     std::fs::read_to_string(&path)
@@ -716,10 +718,57 @@ fn child_pids_of(pid: u32) -> Vec<u32> {
         .unwrap_or_default()
 }
 
-/// Breadth-first, depth-capped walk of `root_pid`'s descendants.
+/// Reads the current direct children of `pid` from macOS's `libproc`, which has no `/proc` for
+/// the branch above to read. Best-effort in exactly the same way: an empty list, never an
+/// error, when the process is already gone or cannot be queried.
 ///
-/// Must run *before* any signal: reading it once a process is dying races the kernel reparenting
-/// its children out from under the file.
+/// `proc_listchildpids` returns the number of pids it wrote and truncates *silently* when the
+/// buffer is too small - it reports the capacity it filled with no error of any kind - so a
+/// completely full buffer is retried at double the capacity rather than trusted to be complete.
+#[cfg(target_os = "macos")]
+#[allow(unsafe_code)]
+fn child_pids_of(pid: u32) -> Vec<u32> {
+    // A parent with more direct children than this is pathological, not a real agent process
+    // tree; the doubling below stops here rather than growing without bound.
+    const MAX_CAPACITY: usize = 4096;
+
+    let Ok(ppid) = libc::pid_t::try_from(pid) else {
+        return Vec::new();
+    };
+
+    let mut capacity = 64usize;
+    loop {
+        let mut buffer: Vec<libc::pid_t> = vec![0; capacity];
+        let buffer_bytes = capacity * std::mem::size_of::<libc::pid_t>();
+
+        // SAFETY: `proc_listchildpids` writes at most `buffersize` bytes through the buffer
+        // pointer, which addresses a live, uniquely borrowed `Vec` allocation of exactly
+        // `buffer_bytes` bytes for the whole call and is not retained by the callee. The cast
+        // is the one Apple's own header requires - the parameter is a bare `void *`. It reports
+        // how many pids it wrote, or 0 on failure, and never a negative count.
+        let written = unsafe {
+            libc::proc_listchildpids(
+                ppid,
+                buffer.as_mut_ptr().cast::<libc::c_void>(),
+                buffer_bytes as libc::c_int,
+            )
+        };
+
+        let written = usize::try_from(written).unwrap_or(0).min(capacity);
+        if written < capacity || capacity == MAX_CAPACITY {
+            buffer.truncate(written);
+            return buffer
+                .into_iter()
+                .filter_map(|child| u32::try_from(child).ok())
+                .collect();
+        }
+        capacity = (capacity * 2).min(MAX_CAPACITY);
+    }
+}
+
+/// Breadth-first, depth-capped walk of `root_pid`'s descendant tree via [`child_pids_of`]. Must
+/// be called *before* signaling anything: reading it after a process starts dying races
+/// against the kernel reparenting its children out from under it.
 #[cfg(unix)]
 fn collect_descendant_pids(root_pid: u32) -> Vec<u32> {
     let mut discovered = Vec::new();
@@ -745,9 +794,21 @@ fn collect_descendant_pids(root_pid: u32) -> Vec<u32> {
     discovered
 }
 
+/// Whether `pid` is still a live (or zombie-but-unreaped) process, via the portable POSIX
+/// `kill(pid, 0)` existence probe - no procfs, so this answers the same on every unix.
+///
+/// `EPERM` counts as "exists": the kernel only reports it for a process that is genuinely
+/// there but not signalable by this user, and treating that as gone would make
+/// [`terminate_process_tree`]'s grace loop declare victory over something still running.
 #[cfg(unix)]
 fn pid_exists(pid: u32) -> bool {
-    PathBuf::from(format!("/proc/{pid}")).exists()
+    let Ok(raw) = i32::try_from(pid) else {
+        return false;
+    };
+    match nix::sys::signal::kill(nix::unistd::Pid::from_raw(raw), None) {
+        Ok(()) => true,
+        Err(errno) => errno == nix::errno::Errno::EPERM,
+    }
 }
 
 /// Terminates `root_pid`'s process group *and* any descendants that escaped it: `SIGHUP`, up to
@@ -789,12 +850,27 @@ fn terminate_process_tree(root_pid: u32, grace: Duration) {
 }
 
 #[cfg(test)]
-mod tests {
+mod pty_session_tests {
     use super::*;
     use std::sync::mpsc::RecvTimeoutError;
     use std::time::{Duration, Instant};
 
-    /// Reads until `needle` appears or `timeout` elapses, returning what was collected either way.
+    /// How long a real child process is given to reach a state before a test calls it a
+    /// failure. Generous: it has to survive a full-suite run where other tests' own child
+    /// processes are competing for the same cores. `test_support::wait_until` returns as soon as
+    /// the condition holds, so an idle machine pays none of it.
+    ///
+    /// `#[cfg(unix)]` because every one of its use sites is: the process-tree teardown and
+    /// SIGSTOP/SIGCONT state assertions this bounds have no Windows twin (see this module's own
+    /// header). Without the gate it is dead code on Windows - which nothing caught until clippy
+    /// started running on that target.
+    #[cfg(unix)]
+    const TEARDOWN_DEADLINE: Duration = Duration::from_secs(5);
+
+    /// Reads from `session.output()` until `needle` appears in the accumulated (lossy
+    /// UTF-8) output or `timeout` elapses, returning whatever was collected either way.
+    /// Returns as soon as the needle is found rather than always waiting out the full
+    /// timeout, so tests aren't needlessly slow.
     fn drain_until_contains(session: &PtySession, needle: &str, timeout: Duration) -> Vec<u8> {
         let mut collected = Vec::new();
         let deadline = Instant::now() + timeout;
@@ -883,7 +959,7 @@ mod tests {
         }
 
         let text = String::from_utf8(collected).expect("`seq` output is plain ASCII");
-        let normalized = text.replace("\r\n", "\n");
+        let normalized = text.replace('\r', "");
         let lines: Vec<&str> = normalized.trim_end_matches('\n').split('\n').collect();
 
         assert_eq!(
@@ -905,6 +981,41 @@ mod tests {
         }
     }
 
+    /// The two answers [`pid_exists`] has to get right for every teardown assertion below to
+    /// mean anything: a process that is genuinely running, and one that has already been
+    /// reaped.
+    ///
+    /// unix-only: uses `pid_exists` directly, which is a `#[cfg(unix)]` helper function (see
+    /// the crate-level "Platform scope" docs).
+    #[cfg(unix)]
+    #[test]
+    fn pid_exists_separates_a_live_process_from_a_reaped_one() {
+        assert!(
+            pid_exists(std::process::id()),
+            "this very test process is unambiguously alive"
+        );
+
+        // `ChildGuard` even though this child is expected to exit on its own and is reaped
+        // explicitly below: if the assertion above ever fails, the unwind must still not leave a
+        // process behind (`docs/testing.md`'s teardown rule).
+        let mut command = std::process::Command::new("true");
+        command
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null());
+        let mut child =
+            test_support::ChildGuard::spawn(&mut command).expect("spawning `true` should succeed");
+        let pid = child.id();
+        child.wait().expect("reaping `true` should succeed");
+
+        assert!(
+            !pid_exists(pid),
+            "pid {pid} was reaped, so it should read as gone rather than alive"
+        );
+    }
+
+    // unix-only: uses pid_exists/is_executable directly, which are #[cfg(unix)]
+    // helper functions (see the crate-level "Platform scope" docs).
     #[cfg(unix)]
     #[test]
     fn drop_kills_child_and_it_does_not_become_an_orphan() {
@@ -922,15 +1033,11 @@ mod tests {
 
         drop(session);
 
-        let deadline = Instant::now() + Duration::from_secs(5);
-        while pid_exists(pid) {
-            assert!(
-                Instant::now() < deadline,
-                "child pid {pid} was still alive {:?} after PtySession was dropped - orphaned process",
-                deadline.elapsed()
-            );
-            std::thread::sleep(Duration::from_millis(20));
-        }
+        assert!(
+            test_support::wait_until(TEARDOWN_DEADLINE, || !pid_exists(pid)),
+            "child pid {pid} was still alive {TEARDOWN_DEADLINE:?} after PtySession was dropped \
+             - orphaned process"
+        );
     }
 
     #[cfg(unix)]
@@ -941,7 +1048,7 @@ mod tests {
         let session = spawn(
             SpawnOptions::new("sh")
                 .arg("-c")
-                .arg("setsid sleep 100 & echo GRANDCHILD:$!; exec sleep 300"),
+                .arg("set -m; sleep 100 & echo GRANDCHILD:$!; exec sleep 300"),
         )
         .expect("spawning the shell pipeline should succeed");
 
@@ -962,18 +1069,23 @@ mod tests {
             pid_exists(grandchild_pid),
             "detached grandchild {grandchild_pid} should be alive before drop"
         );
+        // `pid_exists` alone would also be satisfied by an unreaped zombie, which is what this
+        // test degraded into on macOS before; the walk only lists a pid the kernel still
+        // reports as a child, and it is the mechanism actually under test here.
+        assert!(
+            collect_descendant_pids(direct_pid).contains(&grandchild_pid),
+            "the descendant walk should discover the detached grandchild {grandchild_pid} \
+             under direct child {direct_pid} - without it, `Drop` has no way to reach it"
+        );
 
         drop(session);
 
-        let deadline = Instant::now() + Duration::from_secs(5);
-        while pid_exists(direct_pid) || pid_exists(grandchild_pid) {
-            assert!(
-                Instant::now() < deadline,
-                "direct child ({direct_pid}) or its escaped grandchild ({grandchild_pid}) was \
-                 still alive after PtySession was dropped - orphaned process"
-            );
-            std::thread::sleep(Duration::from_millis(20));
-        }
+        assert!(
+            test_support::wait_until(TEARDOWN_DEADLINE, || !pid_exists(direct_pid)
+                && !pid_exists(grandchild_pid)),
+            "direct child ({direct_pid}) or its escaped grandchild ({grandchild_pid}) was still \
+             alive {TEARDOWN_DEADLINE:?} after PtySession was dropped - orphaned process"
+        );
     }
 
     #[cfg(unix)]
@@ -1012,44 +1124,34 @@ mod tests {
             .process_id()
             .expect("a spawned unix child should report a pid");
 
-        let deadline = Instant::now() + Duration::from_secs(5);
-        while !proc_state(pid).starts_with('S') && !proc_state(pid).starts_with('R') {
-            assert!(
-                Instant::now() < deadline,
-                "process never reached a steady state"
-            );
-            std::thread::sleep(Duration::from_millis(20));
-        }
+        let steady = |pid| {
+            let state = proc_state(pid);
+            state.starts_with('S') || state.starts_with('R')
+        };
+
+        // Give the kernel a moment to settle the freshly spawned process into a steady
+        // running/sleeping state before asserting anything about it.
+        assert!(
+            test_support::wait_until(TEARDOWN_DEADLINE, || steady(pid)),
+            "process {pid} never reached a steady state - last observed state: {:?}",
+            proc_state(pid)
+        );
 
         session.pause().expect("pause should succeed");
-        let deadline = Instant::now() + Duration::from_secs(5);
-        loop {
-            let state = proc_state(pid);
-            if state.starts_with('T') {
-                break;
-            }
-            assert!(
-                Instant::now() < deadline,
-                "process {pid} never reached the real kernel-reported stopped state \
-                 (State: T) after pause() - last observed state: {state:?}"
-            );
-            std::thread::sleep(Duration::from_millis(20));
-        }
+        assert!(
+            test_support::wait_until(TEARDOWN_DEADLINE, || proc_state(pid).starts_with('T')),
+            "process {pid} never reached the real kernel-reported stopped state (State: T) after \
+             pause() - last observed state: {:?}",
+            proc_state(pid)
+        );
 
         session.resume().expect("resume should succeed");
-        let deadline = Instant::now() + Duration::from_secs(5);
-        loop {
-            let state = proc_state(pid);
-            if state.starts_with('S') || state.starts_with('R') {
-                break;
-            }
-            assert!(
-                Instant::now() < deadline,
-                "process {pid} never left the real kernel-reported stopped state after \
-                 resume() - last observed state: {state:?}"
-            );
-            std::thread::sleep(Duration::from_millis(20));
-        }
+        assert!(
+            test_support::wait_until(TEARDOWN_DEADLINE, || steady(pid)),
+            "process {pid} never left the real kernel-reported stopped state after resume() - \
+             last observed state: {:?}",
+            proc_state(pid)
+        );
     }
 
     #[cfg(target_os = "linux")]
@@ -1066,18 +1168,11 @@ mod tests {
         }
 
         fn wait_for_state(pid: u32, prefix: char, what: &str) {
-            let deadline = Instant::now() + Duration::from_secs(5);
-            loop {
-                let state = proc_state(pid);
-                if state.starts_with(prefix) {
-                    return;
-                }
-                assert!(
-                    Instant::now() < deadline,
-                    "process {pid} never reached {what} - last observed state: {state:?}"
-                );
-                std::thread::sleep(Duration::from_millis(20));
-            }
+            assert!(
+                test_support::wait_until(TEARDOWN_DEADLINE, || proc_state(pid).starts_with(prefix)),
+                "process {pid} never reached {what} - last observed state: {:?}",
+                proc_state(pid)
+            );
         }
 
         let session = spawn(
@@ -1119,15 +1214,13 @@ mod tests {
     #[test]
     fn pause_and_resume_are_a_harmless_no_op_once_the_child_has_already_exited() {
         let mut session = spawn(SpawnOptions::new("true")).expect("spawning `true`");
-        let deadline = Instant::now() + Duration::from_secs(5);
-        while session
-            .try_wait()
-            .expect("try_wait should not error")
-            .is_none()
-        {
-            assert!(Instant::now() < deadline, "`true` never exited");
-            std::thread::sleep(Duration::from_millis(20));
-        }
+        assert!(
+            test_support::wait_until(TEARDOWN_DEADLINE, || session
+                .try_wait()
+                .expect("try_wait should not error")
+                .is_some()),
+            "`true` never exited"
+        );
         session
             .pause()
             .expect("pause on an already-exited child must be a harmless no-op");
@@ -1177,18 +1270,24 @@ mod tests {
         let _session = spawn(SpawnOptions::new("yes")).expect("spawning `yes` should succeed");
 
         let rss_before = read_self_rss_kb();
-        // Deliberately undrained while `yes` floods the pty. Unbounded, this measured ~3.4MB ->
-        // ~127MB of RSS in 3s; bounded, the reader blocks in `send`, which backpressures its
-        // `read`, fills the kernel buffer, and blocks `yes`'s `write`.
-        std::thread::sleep(Duration::from_millis(500));
-        let rss_after = read_self_rss_kb();
-
-        let growth_kb = rss_after.saturating_sub(rss_before);
+        // Deliberately don't drain `session.output()` while `yes` floods the pty as
+        // fast as it can. With an unbounded channel this measurably grows RSS (an
+        // earlier version of this crate measured ~3.4MB -> ~127MB in 3s against a
+        // comparable undrained producer); with the bounded `sync_channel`, the reader
+        // thread blocks in `send` once the channel fills, which backpressures its
+        // `read`, which fills the kernel pty buffer, which blocks `yes`'s `write` - so
+        // growth should stay small and bounded.
+        //
+        // `stays_false` rather than a bare sleep-then-measure: it holds the same 500ms window
+        // open while asserting the bound *continuously*, so a transient spike is caught too.
         assert!(
-            growth_kb < 20_000,
-            "RSS grew by {growth_kb} kB while an undrained `yes` pipe ran for 500ms - \
-             the output channel does not appear to be backpressuring (expected growth \
-             bounded by the channel capacity, well under 20MB)"
+            test_support::stays_false(Duration::from_millis(500), || {
+                read_self_rss_kb().saturating_sub(rss_before) >= 20_000
+            }),
+            "RSS grew by {} kB while an undrained `yes` pipe ran for 500ms - the output channel \
+             does not appear to be backpressuring (expected growth bounded by the channel \
+             capacity, well under 20MB)",
+            read_self_rss_kb().saturating_sub(rss_before)
         );
     }
 

--- a/crates/test-support/Cargo.toml
+++ b/crates/test-support/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "test-support"
+version = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
+license = { workspace = true }
+description = "Shared, gpui-free test fixtures for this workspace: real git repositories, bounded waits, process teardown"
+
+[lints]
+workspace = true
+
+[dependencies]
+# The one dependency this crate is allowed: `seed_repo`/`seed_bare_remote` hand back a live
+# temp directory, so `TempDir` is part of the public signature rather than an implementation
+# detail. Same major version every consuming crate already dev-depends on.
+tempfile = "3"

--- a/crates/test-support/src/child.rs
+++ b/crates/test-support/src/child.rs
@@ -1,0 +1,154 @@
+//! RAII teardown for a test that spawns a real process.
+//!
+//! A test that returns early — or fails an assertion, which unwinds — must not leave its child
+//! behind: leaked children are what make a full-suite run peg a machine (`docs/testing.md`'s
+//! hard rules).
+
+use std::io;
+use std::ops::{Deref, DerefMut};
+use std::process::{Child, Command, ExitStatus};
+
+/// A [`Child`] that is killed and reaped when it goes out of scope, however the test exits.
+///
+/// Derefs to the wrapped [`Child`], so `guard.stdin`, `guard.id()` and `guard.try_wait()` work
+/// unchanged.
+pub struct ChildGuard {
+    // `Option` only so `into_inner` can hand the child back without `Drop` also killing it.
+    child: Option<Child>,
+}
+
+impl ChildGuard {
+    /// Takes ownership of an already-spawned child.
+    pub fn new(child: Child) -> Self {
+        Self { child: Some(child) }
+    }
+
+    /// Spawns `command` and guards the result.
+    pub fn spawn(command: &mut Command) -> io::Result<Self> {
+        command.spawn().map(Self::new)
+    }
+
+    /// Whether the process is still running, without blocking on it.
+    pub fn is_running(&mut self) -> bool {
+        matches!(self.child_mut().try_wait(), Ok(None))
+    }
+
+    /// Kills the process now and waits for it, rather than at end of scope. `Ok(None)` means it
+    /// had already exited.
+    pub fn kill_and_wait(&mut self) -> io::Result<Option<ExitStatus>> {
+        let child = self.child_mut();
+        if let Ok(Some(_)) = child.try_wait() {
+            return Ok(None);
+        }
+        child.kill()?;
+        child.wait().map(Some)
+    }
+
+    /// Gives up the guard's ownership — the caller becomes responsible for teardown.
+    pub fn into_inner(mut self) -> Child {
+        self.child.take().expect("child guard already consumed")
+    }
+
+    fn child_mut(&mut self) -> &mut Child {
+        self.child.as_mut().expect("child guard already consumed")
+    }
+}
+
+impl Deref for ChildGuard {
+    type Target = Child;
+
+    fn deref(&self) -> &Child {
+        self.child.as_ref().expect("child guard already consumed")
+    }
+}
+
+impl DerefMut for ChildGuard {
+    fn deref_mut(&mut self) -> &mut Child {
+        self.child.as_mut().expect("child guard already consumed")
+    }
+}
+
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        if let Some(child) = self.child.as_mut() {
+            // Both results are deliberately discarded: an already-exited child reports "no such
+            // process" here, and panicking inside `Drop` during an assertion failure's unwind
+            // would replace the real failure message with an abort.
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+    }
+}
+
+#[cfg(test)]
+mod child_teardown_tests {
+    use crate::ChildGuard;
+    use std::process::{Command, Stdio};
+
+    /// A process that genuinely blocks until it is killed, using a binary every machine running
+    /// this suite already needs: `git hash-object --stdin` reads until EOF, which never comes
+    /// while the test holds the write end of the pipe.
+    fn blocked_child() -> ChildGuard {
+        let mut command = Command::new("git");
+        command
+            .args(["hash-object", "--stdin"])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        ChildGuard::spawn(&mut command).expect("spawn git hash-object")
+    }
+
+    #[test]
+    fn kill_and_wait_stops_a_running_process() {
+        let mut guard = blocked_child();
+        assert!(
+            guard.is_running(),
+            "the fixture child must start out blocked"
+        );
+
+        let status = guard.kill_and_wait().expect("kill_and_wait");
+
+        assert!(
+            status.is_some(),
+            "a running child must report the status it was killed with"
+        );
+        assert!(
+            !guard.is_running(),
+            "after kill_and_wait the process must really be gone, not merely signalled"
+        );
+    }
+
+    #[test]
+    fn kill_and_wait_is_a_no_op_for_a_child_that_already_exited() {
+        let mut guard =
+            ChildGuard::spawn(Command::new("git").arg("--version").stdout(Stdio::null()))
+                .expect("spawn git --version");
+        guard.wait().expect("wait for git --version");
+
+        assert!(
+            guard.kill_and_wait().expect("kill_and_wait").is_none(),
+            "an already-exited child is not an error to tear down"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn dropping_the_guard_kills_the_process() {
+        let pid = {
+            let guard = blocked_child();
+            guard.id().to_string()
+        };
+
+        let alive = Command::new("kill")
+            .args(["-0", &pid])
+            .stderr(Stdio::null())
+            .status()
+            .expect("spawn kill -0")
+            .success();
+        assert!(
+            !alive,
+            "the guard drops at the end of its scope, so pid {pid} must be killed and reaped by \
+             the time the test reaches this line"
+        );
+    }
+}

--- a/crates/test-support/src/git.rs
+++ b/crates/test-support/src/git.rs
@@ -1,0 +1,182 @@
+//! Real `git` CLI invocation for tests.
+//!
+//! Every entry point takes an argument vector, never an interpolated shell string, so a fixture
+//! path containing a space or a quote behaves the same as any other (CLAUDE.md's git rule).
+//! This module owns running git and writing files; deciding *what* a fixture repository
+//! contains belongs to [`crate::repo`].
+
+use std::path::Path;
+use std::process::{Command, Output};
+
+/// Runs `git` in `dir` and panics with both output streams if it fails.
+pub fn git(dir: &Path, args: &[&str]) {
+    assert_success(dir, args, git_try(dir, args));
+}
+
+/// Runs `git` in `dir` with extra environment variables (`GIT_AUTHOR_DATE`, `GIT_EDITOR`, …).
+pub fn git_with_env(dir: &Path, args: &[&str], env: &[(&str, &str)]) {
+    let mut command = Command::new("git");
+    command.current_dir(dir).args(args);
+    for (key, value) in env {
+        command.env(key, value);
+    }
+    let output = command.output().expect("failed to spawn git");
+    assert_success(dir, args, output);
+}
+
+/// The trimmed stdout of a successful `git` invocation.
+pub fn git_output(dir: &Path, args: &[&str]) -> String {
+    let output = git_try(dir, args);
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    assert_success(dir, args, output);
+    stdout
+}
+
+/// Runs `git` without asserting anything — for the tests whose subject *is* a failing git
+/// command (a conflicted merge, a rejected push).
+pub fn git_try(dir: &Path, args: &[&str]) -> Output {
+    // `.output()`, not `.status()`: `status()` inherits stdout/stderr, so seeding a repository
+    // dumps git's per-file chatter into the test runner's output.
+    Command::new("git")
+        .current_dir(dir)
+        .args(args)
+        .output()
+        .expect("failed to spawn git")
+}
+
+/// Writes `contents` to `dir`-relative `relative_path`, creating parent directories.
+pub fn write_file(dir: &Path, relative_path: impl AsRef<Path>, contents: &str) {
+    let path = dir.join(relative_path);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).expect("create parent directories");
+    }
+    std::fs::write(&path, contents).expect("write fixture file");
+}
+
+/// Writes a file and commits it — the two-step every fixture repeats.
+pub fn commit(dir: &Path, relative_path: impl AsRef<Path>, contents: &str, message: &str) {
+    let relative_path = relative_path.as_ref();
+    write_file(dir, relative_path, contents);
+    git(dir, &["add", path_arg(relative_path)]);
+    git(dir, &["commit", "-m", message]);
+}
+
+/// Like [`commit`], but with an explicit author/committer timestamp instead of "whenever this
+/// line happened to run" — what a test asserting on commit order or on rendered dates needs.
+pub fn commit_at(
+    dir: &Path,
+    relative_path: impl AsRef<Path>,
+    contents: &str,
+    message: &str,
+    unix_seconds: i64,
+) {
+    let relative_path = relative_path.as_ref();
+    write_file(dir, relative_path, contents);
+    git(dir, &["add", path_arg(relative_path)]);
+    let date = format!("{unix_seconds} +0000");
+    git_with_env(
+        dir,
+        &["commit", "-m", message],
+        &[("GIT_AUTHOR_DATE", &date), ("GIT_COMMITTER_DATE", &date)],
+    );
+}
+
+fn path_arg(path: &Path) -> &str {
+    path.to_str().expect("fixture paths are UTF-8")
+}
+
+fn assert_success(dir: &Path, args: &[&str], output: Output) {
+    assert!(
+        output.status.success(),
+        "git {args:?} failed in {dir:?}:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[cfg(test)]
+mod git_invocation_tests {
+    use crate::{commit, commit_at, git, git_output, git_try, seed_empty_repo, seed_repo};
+
+    #[test]
+    fn git_output_returns_trimmed_stdout() {
+        let repo = seed_repo();
+
+        let branch = git_output(repo.path(), &["rev-parse", "--abbrev-ref", "HEAD"]);
+
+        assert_eq!(
+            branch, "main",
+            "git_output must hand back stdout with the trailing newline stripped"
+        );
+    }
+
+    #[test]
+    fn git_try_reports_a_failure_instead_of_panicking() {
+        let repo = seed_repo();
+
+        let output = git_try(repo.path(), &["rev-parse", "definitely-not-a-ref"]);
+
+        assert!(
+            !output.status.success(),
+            "git_try is the escape hatch for tests whose subject is a failing git command, so \
+             it must report the failure rather than abort the test"
+        );
+    }
+
+    #[test]
+    fn a_path_containing_a_space_survives_the_argument_vector() {
+        let repo = seed_empty_repo();
+
+        commit(repo.path(), "a file.txt", "x\n", "spaces");
+
+        let tracked = git_output(repo.path(), &["ls-files"]);
+        assert_eq!(
+            tracked, "a file.txt",
+            "argv, not an interpolated shell string: the space must never split the argument"
+        );
+    }
+
+    #[test]
+    fn commit_creates_missing_parent_directories() {
+        let repo = seed_empty_repo();
+
+        commit(
+            repo.path(),
+            "src/nested/deep.rs",
+            "fn main() {}\n",
+            "nested",
+        );
+
+        assert!(
+            repo.path().join("src/nested/deep.rs").is_file(),
+            "a fixture naming a nested path must not have to mkdir it first"
+        );
+    }
+
+    #[test]
+    fn commit_at_uses_the_timestamp_it_was_given() {
+        let repo = seed_empty_repo();
+
+        commit_at(repo.path(), "a.txt", "1\n", "dated", 1_700_000_000);
+
+        assert_eq!(
+            git_output(repo.path(), &["log", "-1", "--format=%at"]),
+            "1700000000",
+            "an explicitly dated commit is what lets a test assert on ordering deterministically"
+        );
+    }
+
+    #[test]
+    fn git_runs_in_the_directory_it_is_given_not_the_process_cwd() {
+        let outer = seed_repo();
+        let inner = seed_empty_repo();
+
+        git(inner.path(), &["checkout", "-b", "side"]);
+
+        assert_eq!(
+            git_output(outer.path(), &["rev-parse", "--abbrev-ref", "HEAD"]),
+            "main",
+            "each call is scoped to its own `dir`, so parallel fixtures never collide"
+        );
+    }
+}

--- a/crates/test-support/src/lib.rs
+++ b/crates/test-support/src/lib.rs
@@ -1,0 +1,31 @@
+//! Shared test fixtures for this workspace: real git repositories, bounded waits, and RAII
+//! teardown for spawned processes.
+//!
+//! Every crate here may dev-depend on this one, so it stays free of `gpui`
+//! (`docs/architecture/decisions.md` §1) — including behind a Cargo feature, since workspace
+//! feature unification would leak `gpui` back into the core crates' dev graph. GPUI-flavoured
+//! helpers live in `crates/app/src/test_support.rs` instead.
+//!
+//! The policy these fixtures serve — the three tiers, what deserves a test, and what gets
+//! deleted — is [`docs/testing.md`](../../../docs/testing.md).
+
+// Every function here runs inside a consumer's `#[cfg(test)]` code, where a broken fixture must
+// abort the test with a diagnostic rather than propagate a `Result` nobody can act on.
+#![allow(clippy::expect_used)]
+
+mod child;
+mod git;
+mod repo;
+mod wait;
+
+pub use child::ChildGuard;
+pub use git::{commit, commit_at, git, git_output, git_try, git_with_env, write_file};
+pub use repo::{
+    add_worktree, seed_bare_remote, seed_commits, seed_empty_repo, seed_empty_repo_at, seed_repo,
+    seed_repo_at, seed_three_commits,
+};
+pub use wait::{stays_false, wait_until, wait_until_every};
+
+/// Re-exported so a consumer can name the type [`seed_repo`] returns without repeating the
+/// `tempfile` dependency in its own manifest.
+pub use tempfile::TempDir;

--- a/crates/test-support/src/repo.rs
+++ b/crates/test-support/src/repo.rs
@@ -1,0 +1,241 @@
+//! Fixture repositories: what a seeded repo *contains*, built out of [`crate::git`].
+//!
+//! Each `seed_*` function has an `_at` sibling that takes an existing directory, for the tests
+//! that need the repository somewhere specific (a worktree, a nested path) rather than in a
+//! throwaway temp directory.
+
+use crate::git::{commit, git};
+use std::path::Path;
+use tempfile::TempDir;
+
+/// The identity every fixture commit carries. A repository with no `user.email`/`user.name`
+/// cannot commit at all, and inheriting the developer's own identity would make fixtures differ
+/// between machines.
+const AUTHOR_EMAIL: &str = "test@example.com";
+const AUTHOR_NAME: &str = "Test User";
+
+/// A git repository on branch `main` with a configured identity and **no commits**.
+pub fn seed_empty_repo() -> TempDir {
+    let dir = TempDir::new().expect("tempdir");
+    seed_empty_repo_at(dir.path());
+    dir
+}
+
+/// [`seed_empty_repo`] into an existing directory.
+pub fn seed_empty_repo_at(dir: &Path) {
+    git(dir, &["init", "-b", "main"]);
+    git(dir, &["config", "user.email", AUTHOR_EMAIL]);
+    git(dir, &["config", "user.name", AUTHOR_NAME]);
+    // A machine with commit signing configured globally would otherwise block every fixture
+    // commit on a passphrase prompt that never arrives in a test runner.
+    git(dir, &["config", "commit.gpgsign", "false"]);
+    // Git for Windows ships `core.autocrlf=true`, which would materialize CRLF in every fixture
+    // checkout and put `\r` into content, diff-hunk and blame assertions the fixture wrote with
+    // `\n`. Pinned here so a fixture behaves identically on all three platforms (#440, finding 2).
+    git(dir, &["config", "core.autocrlf", "false"]);
+    // Every `git commit` runs an auto-gc check, which can fork a real background repack. A fixture
+    // that seeds hundreds of commits and then hands the repository straight to `gix` can have its
+    // objects moved from loose to packed *while* that walk is opening them - which surfaces as a
+    // genuinely intermittent `An object with id <sha> could not be found`, observed twice on the
+    // Linux runner in `crate::graph_view::render::graph_virtualization_tests`. Fixtures are
+    // short-lived and thrown away, so they gain nothing from packing in the first place.
+    git(dir, &["config", "gc.auto", "0"]);
+    git(dir, &["config", "maintenance.auto", "false"]);
+}
+
+/// A git repository on branch `main` with one commit (`file.txt`) and a clean working tree.
+pub fn seed_repo() -> TempDir {
+    let dir = TempDir::new().expect("tempdir");
+    seed_repo_at(dir.path());
+    dir
+}
+
+/// [`seed_repo`] into an existing directory.
+pub fn seed_repo_at(dir: &Path) {
+    seed_empty_repo_at(dir);
+    commit(dir, "file.txt", "hello\n", "initial commit");
+}
+
+/// Three commits (`first`, `second`, `third`) each rewriting `a.txt`, clean working tree at the
+/// end — so a graph built from this has exactly three rows (newest first) and no "Working tree"
+/// row shifting the indices a test names by literal position.
+///
+/// Not `seed_commits(dir, 3)`: these three carry real content changes, which is what a test
+/// asserting on a diff, a blame or a commit message needs.
+pub fn seed_three_commits(dir: &Path) {
+    seed_empty_repo_at(dir);
+    commit(dir, "a.txt", "1\n", "first");
+    commit(dir, "a.txt", "2\n", "second");
+    commit(dir, "a.txt", "3\n", "third");
+}
+
+/// `count` commits, clean working tree at the end. The first touches `a.txt`; the rest are
+/// `--allow-empty`, which keeps a large seed cheap — an empty commit is as real a graph row as
+/// any other. Use [`seed_three_commits`] when the *content* of each commit matters.
+pub fn seed_commits(dir: &Path, count: usize) {
+    seed_empty_repo_at(dir);
+    if count == 0 {
+        return;
+    }
+    commit(dir, "a.txt", "1\n", "first");
+    for index in 1..count {
+        git(
+            dir,
+            &["commit", "--allow-empty", "-m", &format!("commit {index}")],
+        );
+    }
+}
+
+/// A bare repository on branch `main` — the push/fetch target for remote-facing tests.
+pub fn seed_bare_remote() -> TempDir {
+    let dir = TempDir::new().expect("tempdir");
+    git(dir.path(), &["init", "--bare", "-b", "main"]);
+    // Same reason as `seed_empty_repo_at`'s pair: a receiving repository runs its own auto-gc
+    // after a push, and a fixture never benefits from being packed.
+    git(dir.path(), &["config", "gc.auto", "0"]);
+    git(dir.path(), &["config", "maintenance.auto", "false"]);
+    dir
+}
+
+/// Adds a real worktree for a new `branch` at `worktree_path`, which must not exist yet.
+pub fn add_worktree(repo_path: &Path, branch: &str, worktree_path: &Path) {
+    let path = worktree_path
+        .to_str()
+        .expect("fixture worktree paths are UTF-8");
+    git(repo_path, &["worktree", "add", "-b", branch, path]);
+}
+
+#[cfg(test)]
+mod repo_seed_tests {
+    use crate::{
+        add_worktree, git_output, seed_bare_remote, seed_commits, seed_empty_repo, seed_repo,
+        seed_repo_at, seed_three_commits,
+    };
+    use tempfile::TempDir;
+
+    fn commit_count(dir: &std::path::Path) -> usize {
+        git_output(dir, &["rev-list", "--count", "HEAD"])
+            .parse()
+            .expect("rev-list --count is a number")
+    }
+
+    #[test]
+    fn seed_repo_leaves_one_commit_and_a_clean_tree() {
+        let repo = seed_repo();
+
+        assert_eq!(commit_count(repo.path()), 1);
+        assert_eq!(
+            git_output(repo.path(), &["status", "--porcelain"]),
+            "",
+            "a fixture that starts dirty makes every downstream status assertion ambiguous"
+        );
+    }
+
+    #[test]
+    fn seed_empty_repo_has_a_branch_but_no_commits() {
+        let repo = seed_empty_repo();
+
+        // `symbolic-ref`, not `rev-parse --abbrev-ref`: the latter needs HEAD to resolve to a
+        // commit, which is exactly what this fixture does not have.
+        assert_eq!(
+            git_output(repo.path(), &["symbolic-ref", "--short", "HEAD"]),
+            "main",
+            "the unborn branch must still be `main`, not the machine's init.defaultBranch"
+        );
+        assert!(
+            git_output(repo.path(), &["rev-list", "--all"]).is_empty(),
+            "seed_empty_repo is the fixture for code paths that must cope with no commits"
+        );
+    }
+
+    #[test]
+    fn seed_three_commits_leaves_three_commits_and_a_clean_tree() {
+        let dir = TempDir::new().expect("tempdir");
+
+        seed_three_commits(dir.path());
+
+        assert_eq!(commit_count(dir.path()), 3);
+        assert_eq!(
+            git_output(dir.path(), &["log", "--format=%s"]),
+            "third\nsecond\nfirst",
+            "the three messages are part of the fixture's contract - tests assert on them"
+        );
+        assert_eq!(
+            git_output(dir.path(), &["show", "HEAD:a.txt"]),
+            "3",
+            "each of the three commits must carry a real content change, not be empty"
+        );
+        assert_eq!(
+            git_output(dir.path(), &["status", "--porcelain"]),
+            "",
+            "graph tests index rows by position, which a stray working-tree row would shift"
+        );
+    }
+
+    #[test]
+    fn seed_commits_makes_exactly_the_number_asked_for() {
+        let dir = TempDir::new().expect("tempdir");
+
+        seed_commits(dir.path(), 7);
+
+        assert_eq!(commit_count(dir.path()), 7);
+    }
+
+    /// A seeded repository must never run a background repack. A fixture that seeds hundreds of
+    /// commits and hands the result straight to `gix` otherwise races git's auto-gc, which moves
+    /// objects from loose to packed mid-walk and produces an intermittent
+    /// `An object with id <sha> could not be found` - twice observed on the Linux runner. Pinned
+    /// as a real assertion because a silent config line is exactly the kind of thing a later
+    /// change drops without noticing.
+    #[test]
+    fn a_seeded_repo_never_runs_a_background_gc() {
+        let repo = seed_repo();
+
+        assert_eq!(git_output(repo.path(), &["config", "gc.auto"]), "0");
+        assert_eq!(
+            git_output(repo.path(), &["config", "maintenance.auto"]),
+            "false"
+        );
+    }
+
+    #[test]
+    fn seed_repo_at_works_inside_an_existing_directory() {
+        let parent = TempDir::new().expect("tempdir");
+        let nested = parent.path().join("nested/repo");
+        std::fs::create_dir_all(&nested).expect("mkdir");
+
+        seed_repo_at(&nested);
+
+        assert_eq!(commit_count(&nested), 1);
+    }
+
+    #[test]
+    fn seed_bare_remote_is_really_bare() {
+        let remote = seed_bare_remote();
+
+        assert_eq!(
+            git_output(remote.path(), &["rev-parse", "--is-bare-repository"]),
+            "true",
+            "a non-bare push target rejects pushes to its checked-out branch"
+        );
+    }
+
+    #[test]
+    fn add_worktree_creates_a_real_second_working_copy() {
+        let repo = seed_repo();
+        let container = TempDir::new().expect("tempdir");
+        let worktree = container.path().join("feature");
+
+        add_worktree(repo.path(), "feature", &worktree);
+
+        assert!(
+            worktree.join("file.txt").is_file(),
+            "the added worktree must be a real checkout, not just a registered path"
+        );
+        assert_eq!(
+            git_output(&worktree, &["rev-parse", "--abbrev-ref", "HEAD"]),
+            "feature",
+            "the worktree must be on the branch it was created for"
+        );
+    }
+}

--- a/crates/test-support/src/wait.rs
+++ b/crates/test-support/src/wait.rs
@@ -1,0 +1,182 @@
+//! Bounded waits for conditions only a real OS thread can satisfy — a file watcher's callback,
+//! a spawned process reaching a state.
+//!
+//! This module is the *only* sanctioned wall-clock wait in the workspace (`docs/testing.md`).
+//! Anything a GPUI executor drives waits with `cx.run_until_parked()` instead, and nothing waits
+//! with a bare `thread::sleep`: a fixed sleep is simultaneously too short on a loaded machine
+//! and pure dead time on an idle one.
+
+use std::thread;
+use std::time::{Duration, Instant};
+
+/// How often `condition` is re-checked. Short enough that a satisfied condition is noticed
+/// almost immediately, long enough not to spin a core while waiting.
+const POLL_INTERVAL: Duration = Duration::from_millis(10);
+
+/// Polls `condition` until it returns `true` or `deadline` elapses; the return value says which,
+/// so the caller supplies the assertion message.
+///
+/// ```no_run
+/// # use std::time::Duration;
+/// # let watcher_fired = || true;
+/// assert!(
+///     test_support::wait_until(Duration::from_secs(3), watcher_fired),
+///     "the watcher must observe a real file write within the tier's budget"
+/// );
+/// ```
+pub fn wait_until(deadline: Duration, condition: impl FnMut() -> bool) -> bool {
+    wait_until_every(POLL_INTERVAL, deadline, condition)
+}
+
+/// [`wait_until`] with an explicit poll interval, for a condition whose *check* perturbs the very
+/// thing it measures — a probe that takes a connection slot in the server it is asking about, a
+/// check that contends for the lock the subject needs. At [`POLL_INTERVAL`] such a probe measures
+/// its own polling rate rather than the subject; pick an interval coarse enough that it doesn't.
+///
+/// Prefer plain [`wait_until`] everywhere else: a coarse interval buys nothing when the check is
+/// free, and costs up to `interval` of dead time on a condition that has already been satisfied.
+///
+/// ```no_run
+/// # use std::time::Duration;
+/// # let served = || true;
+/// assert!(
+///     test_support::wait_until_every(Duration::from_millis(250), Duration::from_secs(20), served),
+///     "the server must recover once it gives up on the clients holding every slot"
+/// );
+/// ```
+pub fn wait_until_every(
+    interval: Duration,
+    deadline: Duration,
+    mut condition: impl FnMut() -> bool,
+) -> bool {
+    let expiry = Instant::now() + deadline;
+    loop {
+        if condition() {
+            return true;
+        }
+        let remaining = expiry.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            return false;
+        }
+        thread::sleep(interval.min(remaining));
+    }
+}
+
+/// The inverse of [`wait_until`]: `true` if `condition` stayed false for the whole `window`.
+///
+/// For proving something is genuinely filtered out rather than merely slow to arrive — the case
+/// that would otherwise be written as a bare `thread::sleep` followed by one assertion.
+pub fn stays_false(window: Duration, condition: impl FnMut() -> bool) -> bool {
+    !wait_until(window, condition)
+}
+
+#[cfg(test)]
+mod bounded_wait_tests {
+    use crate::{stays_false, wait_until, wait_until_every};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::{Duration, Instant};
+
+    #[test]
+    fn wait_until_returns_as_soon_as_the_condition_holds() {
+        let polls = AtomicUsize::new(0);
+        let started = Instant::now();
+
+        let satisfied = wait_until(Duration::from_secs(30), || {
+            polls.fetch_add(1, Ordering::SeqCst) >= 2
+        });
+
+        assert!(
+            satisfied,
+            "the condition became true well inside the deadline"
+        );
+        assert!(
+            started.elapsed() < Duration::from_secs(1),
+            "a satisfied wait must return immediately, not sit out its deadline - it took {:?}",
+            started.elapsed()
+        );
+    }
+
+    #[test]
+    fn wait_until_gives_up_after_the_deadline() {
+        let started = Instant::now();
+
+        let satisfied = wait_until(Duration::from_millis(50), || false);
+
+        assert!(
+            !satisfied,
+            "a condition that never holds must report failure"
+        );
+        assert!(
+            started.elapsed() >= Duration::from_millis(50),
+            "the full deadline must really be waited out before giving up"
+        );
+    }
+
+    #[test]
+    fn wait_until_checks_the_condition_before_sleeping() {
+        let started = Instant::now();
+
+        assert!(wait_until(Duration::from_secs(30), || true));
+        assert!(
+            started.elapsed() < Duration::from_millis(10),
+            "an already-satisfied condition must cost no wall-clock time at all"
+        );
+    }
+
+    #[test]
+    fn wait_until_every_polls_at_the_interval_it_was_given_rather_than_the_default() {
+        let polls = AtomicUsize::new(0);
+        let started = Instant::now();
+
+        let satisfied =
+            wait_until_every(Duration::from_millis(100), Duration::from_secs(30), || {
+                polls.fetch_add(1, Ordering::SeqCst) >= 3
+            });
+
+        assert!(
+            satisfied,
+            "the condition became true well inside the deadline"
+        );
+        // Four checks at 100ms is at least 300ms of sleeping; at `wait_until`'s own 10ms it would
+        // be ~30ms, which is what this distinguishes.
+        assert!(
+            started.elapsed() >= Duration::from_millis(300),
+            "a coarse interval must really be waited out between checks - it took {:?}",
+            started.elapsed()
+        );
+    }
+
+    #[test]
+    fn wait_until_every_never_sleeps_past_the_deadline() {
+        let started = Instant::now();
+
+        assert!(!wait_until_every(
+            Duration::from_secs(30),
+            Duration::from_millis(50),
+            || false
+        ));
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "the interval must be clamped to what is left of the deadline, not slept in full - it \
+             took {:?}",
+            started.elapsed()
+        );
+    }
+
+    #[test]
+    fn stays_false_reports_a_condition_that_never_fires() {
+        assert!(stays_false(Duration::from_millis(30), || false));
+    }
+
+    #[test]
+    fn stays_false_reports_a_condition_that_does_fire() {
+        let polls = AtomicUsize::new(0);
+
+        assert!(
+            !stays_false(Duration::from_secs(30), || polls
+                .fetch_add(1, Ordering::SeqCst)
+                >= 1),
+            "a condition that becomes true inside the window must fail the quiet-period check"
+        );
+    }
+}

--- a/crates/wt-core/Cargo.toml
+++ b/crates/wt-core/Cargo.toml
@@ -21,3 +21,8 @@ tempfile = "3"
 # outright. Already present in this workspace's lockfile via other dependencies, so this adds no
 # new crate to the build graph.
 sha2 = "0.10"
+
+[dev-dependencies]
+# Shared fixtures (real seeded repositories, argv-only `git`) - see `docs/testing.md`. Usable
+# here precisely because it carries no `gpui` (docs/architecture/decisions.md §1).
+test-support = { path = "../test-support" }

--- a/crates/wt-core/src/blame.rs
+++ b/crates/wt-core/src/blame.rs
@@ -192,30 +192,7 @@ mod tests {
     use std::fs;
     use std::process::Command;
     use tempfile::TempDir;
-
-    fn git(dir: &Path, args: &[&str]) {
-        let output = Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {:?} failed in {:?}:\nstdout: {}\nstderr: {}",
-            args,
-            dir,
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
-    fn init_repo() -> TempDir {
-        let dir = TempDir::new().expect("tempdir");
-        git(dir.path(), &["init", "-b", "main"]);
-        git(dir.path(), &["config", "user.email", "test@example.com"]);
-        git(dir.path(), &["config", "user.name", "Test User"]);
-        dir
-    }
+    use test_support::{git, seed_empty_repo};
 
     #[test]
     fn not_a_repo_is_graceful() {
@@ -227,7 +204,7 @@ mod tests {
 
     #[test]
     fn untracked_file_is_graceful() {
-        let repo = init_repo();
+        let repo = seed_empty_repo();
         fs::write(repo.path().join("untracked.txt"), "hello\n").expect("write");
         let outcome = blame_file(repo.path(), Path::new("untracked.txt")).expect("blame_file");
         assert_eq!(outcome, BlameOutcome::NotTracked);
@@ -235,7 +212,7 @@ mod tests {
 
     #[test]
     fn nonexistent_path_is_graceful() {
-        let repo = init_repo();
+        let repo = seed_empty_repo();
         fs::write(repo.path().join("file.txt"), "hello\n").expect("write");
         git(repo.path(), &["add", "file.txt"]);
         git(repo.path(), &["commit", "-m", "initial"]);
@@ -245,7 +222,7 @@ mod tests {
 
     #[test]
     fn committed_lines_are_attributed_to_the_real_commit() {
-        let repo = init_repo();
+        let repo = seed_empty_repo();
         fs::write(repo.path().join("file.txt"), "line one\nline two\n").expect("write");
         git(repo.path(), &["add", "file.txt"]);
         git(
@@ -277,7 +254,7 @@ mod tests {
 
     #[test]
     fn uncommitted_local_modification_is_flagged() {
-        let repo = init_repo();
+        let repo = seed_empty_repo();
         fs::write(repo.path().join("file.txt"), "line one\nline two\n").expect("write");
         git(repo.path(), &["add", "file.txt"]);
         git(repo.path(), &["commit", "-m", "initial"]);
@@ -299,7 +276,7 @@ mod tests {
 
     #[test]
     fn commit_message_returns_the_real_full_body() {
-        let repo = init_repo();
+        let repo = seed_empty_repo();
         fs::write(repo.path().join("file.txt"), "hello\n").expect("write");
         git(repo.path(), &["add", "file.txt"]);
         git(
@@ -328,14 +305,14 @@ mod tests {
 
     #[test]
     fn commit_message_is_none_for_the_synthetic_uncommitted_sha() {
-        let repo = init_repo();
+        let repo = seed_empty_repo();
         let message = commit_message(repo.path(), &"0".repeat(40)).expect("commit_message");
         assert_eq!(message, None);
     }
 
     #[test]
     fn commit_message_rejects_non_hex_input_without_spawning_a_bad_argument() {
-        let repo = init_repo();
+        let repo = seed_empty_repo();
         let message =
             commit_message(repo.path(), "--not-a-sha").expect("commit_message should not error");
         assert_eq!(message, None);
@@ -343,7 +320,7 @@ mod tests {
 
     #[test]
     fn blame_file_reports_the_real_current_head_commit() {
-        let repo = init_repo();
+        let repo = seed_empty_repo();
         fs::write(repo.path().join("file.txt"), "hello\n").expect("write");
         git(repo.path(), &["add", "file.txt"]);
         git(repo.path(), &["commit", "-m", "initial"]);

--- a/crates/wt-core/src/checkout.rs
+++ b/crates/wt-core/src/checkout.rs
@@ -106,42 +106,7 @@ pub fn reset(worktree_path: &Path, mode: ResetMode, commit: &str) -> Result<(), 
 mod tests {
     use super::*;
     use std::fs;
-    use std::process::Command;
-    use tempfile::TempDir;
-
-    fn git(dir: &Path, args: &[&str]) {
-        let output = Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {:?} failed in {:?}:\nstdout: {}\nstderr: {}",
-            args,
-            dir,
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
-    fn git_output(dir: &Path, args: &[&str]) -> String {
-        let output = Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(output.status.success(), "git {args:?} failed in {dir:?}");
-        String::from_utf8_lossy(&output.stdout).trim().to_string()
-    }
-
-    fn init_repo() -> TempDir {
-        let dir = TempDir::new().expect("tempdir");
-        git(dir.path(), &["init", "-b", "main"]);
-        git(dir.path(), &["config", "user.email", "test@example.com"]);
-        git(dir.path(), &["config", "user.name", "Test User"]);
-        dir
-    }
+    use test_support::{git, git_output, seed_empty_repo};
 
     fn commit(dir: &Path, file: &str, contents: &str, message: &str) -> String {
         fs::write(dir.join(file), contents).expect("write file");
@@ -160,7 +125,7 @@ mod tests {
 
     #[test]
     fn checkout_really_moves_head_to_the_target_commit_detached() {
-        let repo = init_repo();
+        let repo = seed_empty_repo();
         let base = commit(repo.path(), "a.txt", "base", "base");
         let tip = commit(repo.path(), "a.txt", "changed", "second commit");
         assert_eq!(head_sha(repo.path()), tip);
@@ -181,7 +146,7 @@ mod tests {
 
     #[test]
     fn checkout_on_a_dirty_worktree_with_a_real_conflict_surfaces_gits_own_refusal() {
-        let repo = init_repo();
+        let repo = seed_empty_repo();
         commit(repo.path(), "a.txt", "base", "base");
         git(repo.path(), &["checkout", "-b", "other"]);
         commit(repo.path(), "a.txt", "other branch content", "other change");
@@ -217,7 +182,7 @@ mod tests {
 
     #[test]
     fn create_branch_at_really_creates_the_branch_at_the_commit_and_switches_to_it() {
-        let repo = init_repo();
+        let repo = seed_empty_repo();
         let base = commit(repo.path(), "a.txt", "base", "base");
         commit(repo.path(), "a.txt", "changed again", "second commit");
 
@@ -242,7 +207,7 @@ mod tests {
 
     #[test]
     fn create_branch_at_with_a_colliding_name_surfaces_gits_own_real_error() {
-        let repo = init_repo();
+        let repo = seed_empty_repo();
         let base = commit(repo.path(), "a.txt", "base", "base");
         git(repo.path(), &["branch", "existing-branch"]);
 
@@ -264,7 +229,7 @@ mod tests {
 
     #[test]
     fn checkout_branch_really_switches_with_head_attached_not_detached() {
-        let repo = init_repo();
+        let repo = seed_empty_repo();
         commit(repo.path(), "a.txt", "base", "base");
         git(repo.path(), &["checkout", "-b", "feature"]);
         commit(repo.path(), "a.txt", "on feature", "feature commit");
@@ -282,7 +247,7 @@ mod tests {
 
     #[test]
     fn checkout_branch_refuses_a_nonexistent_branch_with_gits_own_real_error() {
-        let repo = init_repo();
+        let repo = seed_empty_repo();
         commit(repo.path(), "a.txt", "base", "base");
 
         let result = checkout_branch(repo.path(), "no-such-branch");
@@ -301,7 +266,7 @@ mod tests {
 
     #[test]
     fn checkout_branch_refuses_a_flag_shaped_name_instead_of_parsing_it_as_an_option() {
-        let repo = init_repo();
+        let repo = seed_empty_repo();
         commit(repo.path(), "a.txt", "base", "base");
 
         let result = checkout_branch(repo.path(), "--orphan");
@@ -324,7 +289,7 @@ mod tests {
 
     #[test]
     fn rename_branch_really_moves_the_ref_to_the_new_name_and_leaves_no_old_one() {
-        let repo = init_repo();
+        let repo = seed_empty_repo();
         let base = commit(repo.path(), "a.txt", "base", "base");
         git(repo.path(), &["branch", "old-name"]);
 
@@ -348,7 +313,7 @@ mod tests {
 
     #[test]
     fn rename_branch_onto_an_existing_name_surfaces_gits_own_real_error() {
-        let repo = init_repo();
+        let repo = seed_empty_repo();
         commit(repo.path(), "a.txt", "base", "base");
         git(repo.path(), &["branch", "old-name"]);
         git(repo.path(), &["branch", "taken"]);
@@ -377,7 +342,7 @@ mod tests {
 
     #[test]
     fn renaming_the_currently_checked_out_branch_really_moves_head_onto_the_new_name() {
-        let repo = init_repo();
+        let repo = seed_empty_repo();
         let tip = commit(repo.path(), "a.txt", "base", "base");
         assert_eq!(
             current_branch(repo.path()),
@@ -401,7 +366,7 @@ mod tests {
 
     #[test]
     fn rename_branch_refuses_a_flag_shaped_name_instead_of_destroying_two_refs() {
-        let repo = init_repo();
+        let repo = seed_empty_repo();
         let main_tip = commit(repo.path(), "a.txt", "base", "base");
         git(repo.path(), &["branch", "feature"]);
 
@@ -440,7 +405,7 @@ mod tests {
 
     #[test]
     fn delete_branch_treats_a_flag_shaped_name_as_a_branch_name_not_an_option() {
-        let repo = init_repo();
+        let repo = seed_empty_repo();
         commit(repo.path(), "a.txt", "base", "base");
         git(repo.path(), &["branch", "keepme"]);
 
@@ -464,7 +429,7 @@ mod tests {
 
     #[test]
     fn delete_branch_really_removes_a_fully_merged_branch() {
-        let repo = init_repo();
+        let repo = seed_empty_repo();
         commit(repo.path(), "a.txt", "base", "base");
         // A branch at the current tip: fully merged by construction, which is exactly
         // what `git branch -d` is willing to remove.
@@ -481,7 +446,7 @@ mod tests {
 
     #[test]
     fn delete_branch_refuses_an_unmerged_branch_with_gits_own_real_refusal() {
-        let repo = init_repo();
+        let repo = seed_empty_repo();
         commit(repo.path(), "a.txt", "base", "base");
         git(repo.path(), &["checkout", "-b", "unmerged"]);
         commit(repo.path(), "b.txt", "work", "work only on unmerged");
@@ -510,7 +475,7 @@ mod tests {
 
     #[test]
     fn delete_branch_refuses_the_branch_checked_out_in_this_worktree() {
-        let repo = init_repo();
+        let repo = seed_empty_repo();
         commit(repo.path(), "a.txt", "base", "base");
 
         let result = delete_branch(repo.path(), "main");
@@ -536,7 +501,7 @@ mod tests {
 
     #[test]
     fn reset_soft_keeps_the_index_and_working_tree_and_only_moves_the_branch_tip() {
-        let repo = init_repo();
+        let repo = seed_empty_repo();
         let base = commit(repo.path(), "a.txt", "base", "base");
         commit(repo.path(), "a.txt", "changed", "second commit");
 
@@ -561,7 +526,7 @@ mod tests {
 
     #[test]
     fn reset_mixed_unstages_but_keeps_the_working_tree_content() {
-        let repo = init_repo();
+        let repo = seed_empty_repo();
         let base = commit(repo.path(), "a.txt", "base", "base");
         commit(repo.path(), "a.txt", "changed", "second commit");
 
@@ -587,7 +552,7 @@ mod tests {
 
     #[test]
     fn reset_hard_discards_the_working_tree_change_entirely() {
-        let repo = init_repo();
+        let repo = seed_empty_repo();
         let base = commit(repo.path(), "a.txt", "base", "base");
         commit(repo.path(), "a.txt", "changed", "second commit");
 

--- a/crates/wt-core/src/diff.rs
+++ b/crates/wt-core/src/diff.rs
@@ -1169,37 +1169,11 @@ mod tests {
     use std::fs;
     use std::process::Command;
     use tempfile::TempDir;
-
-    fn git(dir: &Path, args: &[&str]) {
-        let output = Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {:?} failed in {:?}:\nstdout: {}\nstderr: {}",
-            args,
-            dir,
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
-    fn init_repo() -> TempDir {
-        let dir = TempDir::new().expect("tempdir");
-        git(dir.path(), &["init", "-b", "main"]);
-        git(dir.path(), &["config", "user.email", "test@example.com"]);
-        git(dir.path(), &["config", "user.name", "Test User"]);
-        fs::write(dir.path().join("file.txt"), "hello\n").expect("write file");
-        git(dir.path(), &["add", "file.txt"]);
-        git(dir.path(), &["commit", "-m", "initial commit"]);
-        dir
-    }
+    use test_support::{git, seed_repo};
 
     #[test]
     fn on_default_branch_with_nothing_uncommitted_yields_an_empty_diff() {
-        let repo = init_repo();
+        let repo = seed_repo();
         let result = diff_against_base(repo.path()).expect("diff_against_base");
         let DiffBase::NoBase {
             branch,
@@ -1217,7 +1191,7 @@ mod tests {
 
     #[test]
     fn on_default_branch_with_real_uncommitted_changes_shows_them() {
-        let repo = init_repo();
+        let repo = seed_repo();
         fs::write(repo.path().join("file.txt"), "hello\nedited on main\n").expect("write");
         fs::write(repo.path().join("new.txt"), "brand new\n").expect("write");
 
@@ -1306,7 +1280,7 @@ mod tests {
 
     #[test]
     fn feature_branch_diffs_modified_added_and_deleted_files() {
-        let repo = init_repo();
+        let repo = seed_repo();
         fs::write(repo.path().join("keep.txt"), "keep\n").expect("write");
         git(repo.path(), &["add", "keep.txt"]);
         git(repo.path(), &["commit", "-m", "add keep.txt"]);
@@ -1359,7 +1333,7 @@ mod tests {
 
     #[test]
     fn committed_changes_since_branch_point_are_included() {
-        let repo = init_repo();
+        let repo = seed_repo();
         git(repo.path(), &["checkout", "-b", "feature"]);
         fs::write(repo.path().join("file.txt"), "hello\ncommitted change\n").expect("write");
         git(repo.path(), &["commit", "-am", "a real commit on feature"]);
@@ -1382,7 +1356,7 @@ mod tests {
 
     #[test]
     fn clean_feature_branch_has_no_changes() {
-        let repo = init_repo();
+        let repo = seed_repo();
         git(repo.path(), &["checkout", "-b", "feature"]);
         let result = diff_against_base(repo.path()).expect("diff_against_base");
         let DiffBase::Diff(diff) = result else {
@@ -1393,7 +1367,9 @@ mod tests {
 
     #[test]
     fn rename_is_detected() {
-        let repo = init_repo();
+        let repo = seed_repo();
+        // `-M`'s similarity threshold needs enough content to recognize a rename rather than
+        // a delete+add; a single short line is not always enough, so pad the file.
         let content = "line\n".repeat(50);
         fs::write(repo.path().join("file.txt"), &content).expect("write");
         git(repo.path(), &["commit", "-am", "pad file.txt"]);
@@ -1417,7 +1393,7 @@ mod tests {
 
     #[test]
     fn binary_file_is_flagged_without_hunks() {
-        let repo = init_repo();
+        let repo = seed_repo();
         git(repo.path(), &["checkout", "-b", "feature"]);
         fs::write(repo.path().join("data.bin"), [0u8, 159, 146, 0, 1, 2]).expect("write");
         git(repo.path(), &["add", "data.bin"]);
@@ -1438,7 +1414,7 @@ mod tests {
 
     #[test]
     fn detached_head_still_diffs_against_default_branch() {
-        let repo = init_repo();
+        let repo = seed_repo();
         fs::write(repo.path().join("file.txt"), "hello\nchanged\n").expect("write");
         git(repo.path(), &["commit", "-am", "a change"]);
         let head_sha = {
@@ -1457,9 +1433,11 @@ mod tests {
 
     #[test]
     fn deleted_sql_style_comment_line_is_not_misparsed_as_file_header() {
-        // A removed line starting `-- ` renders as `--- <text>`, identical to a `--- <path>`
-        // header line.
-        let repo = init_repo();
+        // A removed line whose own text starts with `-- ` renders in unified diff output as
+        // `--- <that text>` (marker `-` prepended to the real content) - textually identical
+        // to a `--- <path>` old-file header line. Before this fix, the parser matched that
+        // prefix unconditionally, truncating the rest of this hunk right after it.
+        let repo = seed_repo();
         let content = "line one\n-- a real sql comment\nline three\nline four\n";
         fs::write(repo.path().join("file.txt"), content).expect("write");
         git(
@@ -1502,9 +1480,12 @@ mod tests {
 
     #[test]
     fn added_line_looking_like_a_file_header_does_not_misattribute_the_file() {
-        // An added line starting `++ ` renders as `+++ <text>`, identical to a `+++ <path>`
-        // header line - which would misattribute the change to a path parsed out of content.
-        let repo = init_repo();
+        // An added line whose own text starts with `++ ` renders as `+++ <that text>` -
+        // textually identical to a `+++ <path>` new-file header line. Before this fix, the
+        // parser matched that prefix unconditionally, overwriting `new_path` with a bogus
+        // path parsed out of the line's *content* - misattributing the change to the wrong
+        // file, exactly the "worst case" scenario the checker flagged.
+        let repo = seed_repo();
         git(repo.path(), &["checkout", "-b", "feature"]);
         fs::write(
             repo.path().join("file.txt"),
@@ -1588,9 +1569,11 @@ mod tests {
 
     #[test]
     fn untracked_file_appears_in_diff_as_an_addition() {
-        // `git diff <merge-base>` alone never sees untracked files; the shadow index's
-        // `--intent-to-add` pass is what surfaces them.
-        let repo = init_repo();
+        // `git diff <merge-base>` alone never sees genuinely untracked (never `git add`ed)
+        // files, no matter what - the single most common thing an agent produces in a fresh
+        // worktree. `prepare_shadow_index`'s `--intent-to-add` trick is what makes this
+        // show up at all.
+        let repo = seed_repo();
         git(repo.path(), &["checkout", "-b", "feature"]);
         fs::write(repo.path().join("brand_new.txt"), "content nobody staged\n").expect("write");
 
@@ -1625,10 +1608,16 @@ mod tests {
 
     #[test]
     fn a_missing_or_unreadable_real_index_does_not_fail_the_whole_diff() {
-        // `GIT_INDEX_FILE` at a nonexistent path is a fresh empty index and `git add` succeeds;
-        // at an existing 0-byte file it fails with `index file smaller than expected`. Leaving
-        // the placeholder in place therefore breaks the whole Changes panel.
-        let repo = init_repo();
+        // Reproduces a real, confirmed bug: `prepare_shadow_index` used to fall back to an
+        // empty *existing* temp file when the real index couldn't be read, on the (wrong)
+        // assumption that this "mirrors git's own missing index == empty index behavior."
+        // Verified directly with real git commands that it does not: `GIT_INDEX_FILE`
+        // pointed at a genuinely nonexistent path is treated as a fresh empty index (real
+        // `git add` succeeds), but pointed at an existing 0-byte file it fails outright
+        // (`fatal: ... index file smaller than expected`, exit 128) - a completely
+        // different, fatal code path. `diff_against_base` surfaced that fatal to the whole
+        // Changes panel as "failed to compute diff: ...".
+        let repo = seed_repo();
         git(repo.path(), &["checkout", "-b", "feature"]);
         fs::write(repo.path().join("brand_new.txt"), "content nobody staged\n").expect("write");
 
@@ -1749,7 +1738,7 @@ mod tests {
 
     #[test]
     fn prepare_shadow_index_closes_its_own_file_handle_before_returning() {
-        let repo = init_repo();
+        let repo = seed_repo();
         fs::write(repo.path().join("untracked.txt"), "nobody staged this\n").expect("write");
 
         let shadow = prepare_shadow_index(repo.path(), ShadowIndexContent::IntentToAdd)
@@ -1777,7 +1766,7 @@ mod tests {
 
     #[test]
     fn the_shadow_index_lives_in_the_git_directory_not_the_os_temp_directory() {
-        let repo = init_repo();
+        let repo = seed_repo();
         fs::write(repo.path().join("untracked.txt"), "nobody staged this\n").expect("write");
 
         let shadow = prepare_shadow_index(repo.path(), ShadowIndexContent::IntentToAdd)
@@ -1815,7 +1804,7 @@ mod tests {
 
     #[test]
     fn a_linked_worktrees_shadow_index_lives_in_that_worktrees_own_git_directory() {
-        let repo = init_repo();
+        let repo = seed_repo();
         let holder = TempDir::new().expect("tempdir");
         let wt_path = holder.path().join("linked");
         drop(holder);
@@ -1848,7 +1837,7 @@ mod tests {
 
     #[test]
     fn an_embedded_git_repository_in_the_worktree_does_not_fail_the_diff() {
-        let repo = init_repo();
+        let repo = seed_repo();
         git(repo.path(), &["checkout", "-b", "feature"]);
         fs::write(repo.path().join("brand_new.txt"), "content nobody staged\n").expect("write");
 
@@ -1892,7 +1881,7 @@ mod tests {
         // Combines all three kinds of change the diff is supposed to surface in one pass -
         // the exact workflow this feature exists for (check everything an agent did before
         // merge, in one view).
-        let repo = init_repo();
+        let repo = seed_repo();
         fs::write(repo.path().join("keep.txt"), "keep\n").expect("write");
         git(repo.path(), &["add", "keep.txt"]);
         git(repo.path(), &["commit", "-m", "add keep.txt"]);
@@ -1939,7 +1928,7 @@ mod tests {
         // diff's `a/`/`b/` prefixes to `i/`/`w/`/`c/`. `diff_against_base` must pin this
         // config explicitly (rather than relying on defaults) so path parsing is unaffected
         // by whatever the repo's own config happens to be.
-        let repo = init_repo();
+        let repo = seed_repo();
         git(repo.path(), &["config", "diff.mnemonicPrefix", "true"]);
         git(repo.path(), &["checkout", "-b", "feature"]);
         fs::write(repo.path().join("file.txt"), "hello\nchanged\n").expect("write");
@@ -2002,7 +1991,7 @@ mod tests {
         // `diff_against_base` surfaces as `DiffBase::NoBase` (GitHub issue #108: real
         // uncommitted changes are still worth showing, even with no comparable base branch)
         // rather than an `Err` or a fabricated `NoBaseFound`.
-        let repo = init_repo();
+        let repo = seed_repo();
         git(repo.path(), &["checkout", "--orphan", "unrelated"]);
         git(repo.path(), &["rm", "-rf", "--cached", "."]);
         fs::remove_file(repo.path().join("file.txt")).expect("remove");
@@ -2028,6 +2017,9 @@ mod tests {
         assert_eq!(uncommitted.files[0].path, Path::new("other.txt"));
     }
 
+    /// `#[cfg(unix)]`: the child is `sh -c` over `head`, `/dev/zero` and `tr`. The draining
+    /// behaviour it proves is platform-free, but reproducing the full-pipe deadlock needs them.
+    #[cfg(unix)]
     #[test]
     fn stdout_and_stderr_are_drained_concurrently_without_deadlocking() {
         // A child that writes well past a typical OS pipe buffer (64KB on Linux) to stderr
@@ -2086,7 +2078,7 @@ mod tests {
 
     #[test]
     fn linked_worktree_diffs_against_main_repo_default_branch() {
-        let repo = init_repo();
+        let repo = seed_repo();
         let linked_dir = TempDir::new().expect("tempdir");
         let linked_path = linked_dir.path().join("linked-wt");
         drop(linked_dir);
@@ -2206,7 +2198,7 @@ index 0000000..fedcba9
 
     #[test]
     fn merge_status_reports_merged_true_for_a_worktree_fully_contained_in_base() {
-        let repo = init_repo();
+        let repo = seed_repo();
         git(repo.path(), &["checkout", "-b", "feature"]);
         git(repo.path(), &["checkout", "main"]);
 
@@ -2235,7 +2227,7 @@ index 0000000..fedcba9
 
     #[test]
     fn merge_status_reports_merged_false_for_a_worktree_with_unique_commits() {
-        let repo = init_repo();
+        let repo = seed_repo();
         git(repo.path(), &["checkout", "-b", "feature"]);
         fs::write(repo.path().join("feature.txt"), "feature work\n").expect("write");
         git(repo.path(), &["add", "feature.txt"]);
@@ -2274,7 +2266,7 @@ index 0000000..fedcba9
 
     #[test]
     fn merge_status_on_the_default_branch_itself_is_trivially_merged() {
-        let repo = init_repo();
+        let repo = seed_repo();
         let status = merge_status_against_base(repo.path())
             .expect("merge_status_against_base")
             .expect("main itself has a detectable base (itself)");
@@ -2282,19 +2274,27 @@ index 0000000..fedcba9
         assert!(status.merged);
     }
 
+    /// Both real "nothing has diverged" states: the default branch itself (whose base is
+    /// itself), and a branch just cut from it.
     #[test]
-    fn ahead_behind_on_default_branch_is_zero_and_zero() {
-        let repo = init_repo();
-        let result = ahead_behind_against_base(repo.path())
-            .expect("ahead_behind_against_base")
-            .expect("main itself has a detectable base (itself)");
-        assert_eq!(
-            result,
-            AheadBehind {
-                ahead: 0,
-                behind: 0
+    fn a_branch_that_has_not_diverged_is_zero_ahead_and_zero_behind() {
+        for branch in [None, Some("feature")] {
+            let repo = seed_repo();
+            if let Some(branch) = branch {
+                git(repo.path(), &["checkout", "-b", branch]);
             }
-        );
+            let result = ahead_behind_against_base(repo.path())
+                .expect("ahead_behind_against_base")
+                .unwrap_or_else(|| panic!("{branch:?} must have a detectable base"));
+            assert_eq!(
+                result,
+                AheadBehind {
+                    ahead: 0,
+                    behind: 0
+                },
+                "{branch:?} has no commits of its own and none it is missing"
+            );
+        }
     }
 
     #[test]
@@ -2307,7 +2307,7 @@ index 0000000..fedcba9
 
     #[test]
     fn ahead_behind_counts_real_diverged_commits_on_each_side() {
-        let repo = init_repo();
+        let repo = seed_repo();
         git(repo.path(), &["checkout", "-b", "feature"]);
         fs::write(repo.path().join("feature_one.txt"), "one\n").expect("write");
         git(repo.path(), &["add", "feature_one.txt"]);
@@ -2334,22 +2334,13 @@ index 0000000..fedcba9
         );
     }
 
-    #[test]
-    fn ahead_behind_with_no_divergence_at_all_is_zero_and_zero() {
-        let repo = init_repo();
-        git(repo.path(), &["checkout", "-b", "feature"]);
-        let result = ahead_behind_against_base(repo.path())
-            .expect("ahead_behind_against_base")
-            .expect("feature has a detectable base (main)");
-        assert_eq!(
-            result,
-            AheadBehind {
-                ahead: 0,
-                behind: 0
-            }
-        );
-    }
-
+    /// The audit's exact reproduction of the wrong-ref bug: the detected base comes from
+    /// `refs/remotes/origin/HEAD` (short name `main`), but a *local* `main` branch of the same
+    /// short name also exists and has gone stale relative to `origin/main`. Before this fix,
+    /// `ahead_behind_against_base` handed git the bare short name `main`, which git's own
+    /// disambiguation rules resolve against the stale local branch (`refs/heads/main`) rather
+    /// than the fresh remote-tracking commit that was actually detected as the real base -
+    /// silently reporting `↓0` (up to date) when the real, correct answer is `↓2`.
     #[test]
     fn ahead_behind_is_computed_against_the_detected_base_commit_not_a_stale_local_branch_of_the_same_name(
     ) {
@@ -2439,7 +2430,7 @@ index 0000000..fedcba9
     /// shape that makes the three Changes-panel scopes give three genuinely different answers
     /// (GitHub issue #285).
     fn repo_with_a_commit_and_a_dirty_file() -> TempDir {
-        let repo = init_repo();
+        let repo = seed_repo();
         git(repo.path(), &["checkout", "-b", "feature"]);
         fs::write(repo.path().join("committed.txt"), "one\ntwo\n").expect("write committed");
         git(repo.path(), &["add", "committed.txt"]);
@@ -2495,7 +2486,7 @@ index 0000000..fedcba9
     fn the_uncommitted_scope_includes_a_brand_new_untracked_file() {
         // Untracked files are exactly the kind of dirty an agent produces, and `git diff HEAD`
         // cannot see them without the `--intent-to-add` shadow index.
-        let repo = init_repo();
+        let repo = seed_repo();
         fs::write(repo.path().join("agent_wrote_this.rs"), "fn main() {}\n").expect("write");
 
         let uncommitted = diff_against_head(repo.path())
@@ -2513,7 +2504,7 @@ index 0000000..fedcba9
     fn the_uncommitted_scope_is_empty_not_absent_for_a_clean_worktree() {
         // `Ok(None)` means "HEAD is unborn", never "nothing changed" - a caller must be able to
         // tell a clean checkout from a repository with no commits at all.
-        let repo = init_repo();
+        let repo = seed_repo();
         let uncommitted = diff_against_head(repo.path())
             .expect("diff_against_head")
             .expect("a clean worktree still has a real, empty answer");
@@ -2534,7 +2525,7 @@ index 0000000..fedcba9
 
     #[test]
     fn the_commits_scope_lists_only_this_branch_s_own_commits_newest_first() {
-        let repo = init_repo();
+        let repo = seed_repo();
         git(repo.path(), &["checkout", "-b", "feature"]);
         fs::write(repo.path().join("first.txt"), "a\nb\n").expect("write");
         git(repo.path(), &["add", "first.txt"]);
@@ -2582,7 +2573,7 @@ index 0000000..fedcba9
     fn the_commits_scope_reports_the_net_range_diffstat_not_the_sum_of_its_commits() {
         // A line one commit adds and the next removes is in the per-commit sum twice and in the
         // net answer not at all. "What is written down" is the net answer.
-        let repo = init_repo();
+        let repo = seed_repo();
         git(repo.path(), &["checkout", "-b", "feature"]);
         fs::write(repo.path().join("churn.txt"), "one\ntwo\nthree\n").expect("write");
         git(repo.path(), &["add", "churn.txt"]);
@@ -2614,7 +2605,7 @@ index 0000000..fedcba9
     fn a_worktree_on_its_own_default_branch_has_an_empty_commits_scope_not_all_of_history() {
         // "The commits this branch added" has no answer without a point to have added them from,
         // and listing every commit in the repository would be a different, wrong answer.
-        let repo = init_repo();
+        let repo = seed_repo();
         let commits = commits_since_base(repo.path()).expect("commits_since_base");
         assert!(commits.commits.is_empty());
         assert_eq!(commits.base_branch, None);
@@ -2625,7 +2616,7 @@ index 0000000..fedcba9
     fn a_commit_subject_carrying_the_numstat_separator_is_still_parsed_as_one_commit() {
         // The record/field separators exist so a subject cannot be mistaken for a field boundary
         // or for the start of a numstat line.
-        let repo = init_repo();
+        let repo = seed_repo();
         git(repo.path(), &["checkout", "-b", "feature"]);
         fs::write(repo.path().join("tabbed.txt"), "x\n").expect("write");
         git(repo.path(), &["add", "tabbed.txt"]);
@@ -2649,7 +2640,7 @@ index 0000000..fedcba9
 
     #[test]
     fn a_merge_commit_contributes_no_line_counts_rather_than_invented_ones() {
-        let repo = init_repo();
+        let repo = seed_repo();
         git(repo.path(), &["checkout", "-b", "feature"]);
         fs::write(repo.path().join("feature.txt"), "f\n").expect("write");
         git(repo.path(), &["add", "feature.txt"]);

--- a/crates/wt-core/src/graph.rs
+++ b/crates/wt-core/src/graph.rs
@@ -794,30 +794,7 @@ mod tests {
     use std::fs;
     use std::process::Command;
     use tempfile::TempDir;
-
-    fn git(dir: &Path, args: &[&str]) {
-        let output = Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {:?} failed in {:?}:\nstdout: {}\nstderr: {}",
-            args,
-            dir,
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
-    fn init_repo() -> TempDir {
-        let dir = TempDir::new().expect("tempdir");
-        git(dir.path(), &["init", "-b", "main"]);
-        git(dir.path(), &["config", "user.email", "test@example.com"]);
-        git(dir.path(), &["config", "user.name", "Test User"]);
-        dir
-    }
+    use test_support::{git, git_output, seed_empty_repo};
 
     fn commit(dir: &Path, file: &str, contents: &str, message: &str) {
         fs::write(dir.join(file), contents).expect("write file");
@@ -864,7 +841,7 @@ mod tests {
 
     #[test]
     fn resolve_commit_reports_a_branchs_real_tip_in_both_forms() {
-        let repo = init_repo();
+        let repo = seed_empty_repo();
         commit(repo.path(), "a.txt", "base", "base");
         git(repo.path(), &["checkout", "-b", "feature"]);
         commit(repo.path(), "b.txt", "feature", "feature work");
@@ -894,7 +871,7 @@ mod tests {
 
     #[test]
     fn resolve_commit_refuses_to_fabricate_a_commit_for_a_branch_that_does_not_exist() {
-        let repo = init_repo();
+        let repo = seed_empty_repo();
         commit(repo.path(), "a.txt", "base", "base");
 
         let err = resolve_commit(repo.path(), "no-such-branch").expect_err(
@@ -911,7 +888,7 @@ mod tests {
 
     #[test]
     fn resolve_commit_treats_a_flag_shaped_branch_name_as_an_ordinary_ref_lookup() {
-        let repo = init_repo();
+        let repo = seed_empty_repo();
         commit(repo.path(), "a.txt", "base", "base");
 
         let err = resolve_commit(repo.path(), "--evil").expect_err(
@@ -1226,7 +1203,7 @@ mod tests {
 
     #[test]
     fn build_graph_walks_linear_history_newest_first() {
-        let repo = init_repo();
+        let repo = seed_empty_repo();
         commit(repo.path(), "a.txt", "1", "first");
         commit(repo.path(), "a.txt", "2", "second");
         commit(repo.path(), "a.txt", "3", "third");
@@ -1244,7 +1221,7 @@ mod tests {
 
     #[test]
     fn build_graph_reports_a_real_merge_commit_and_branch_chip() {
-        let repo = init_repo();
+        let repo = seed_empty_repo();
         commit_at(repo.path(), "a.txt", "1", "base", 1_700_000_000);
         git(repo.path(), &["checkout", "-b", "feature"]);
         commit_at(repo.path(), "b.txt", "1", "feature work", 1_700_000_100);
@@ -1288,7 +1265,7 @@ mod tests {
         // rendered as a plain `Head` dot instead. `HEAD` is already shown separately and
         // unambiguously via the branch's own ref-chip styling, so prioritizing `Merge` here
         // loses no real information.
-        let repo = init_repo();
+        let repo = seed_empty_repo();
         commit_at(repo.path(), "a.txt", "1", "base", 1_700_000_000);
         git(repo.path(), &["checkout", "-b", "feature"]);
         commit_at(repo.path(), "b.txt", "1", "feature work", 1_700_000_100);
@@ -1317,7 +1294,7 @@ mod tests {
 
     #[test]
     fn build_graph_current_scope_is_first_parent_only() {
-        let repo = init_repo();
+        let repo = seed_empty_repo();
         commit_at(repo.path(), "a.txt", "1", "base", 1_700_000_000);
         git(repo.path(), &["checkout", "-b", "feature"]);
         commit_at(repo.path(), "b.txt", "1", "feature work", 1_700_000_100);
@@ -1341,7 +1318,7 @@ mod tests {
 
     #[test]
     fn build_graph_ref_chips_reflect_real_branches() {
-        let repo = init_repo();
+        let repo = seed_empty_repo();
         commit(repo.path(), "a.txt", "1", "base");
         git(repo.path(), &["branch", "topic"]);
 
@@ -1367,14 +1344,14 @@ mod tests {
 
     #[test]
     fn build_graph_on_empty_repo_returns_no_rows() {
-        let repo = init_repo();
+        let repo = seed_empty_repo();
         let graph = build_graph(repo.path(), GraphScope::All, 0).expect("build_graph");
         assert!(graph.rows.is_empty());
     }
 
     #[test]
     fn build_graph_worktrees_scope_is_limited_to_checked_out_branches() {
-        let repo = init_repo();
+        let repo = seed_empty_repo();
         commit(repo.path(), "a.txt", "1", "base");
         git(repo.path(), &["checkout", "-b", "no-worktree-branch"]);
         commit(repo.path(), "b.txt", "1", "only on no-worktree-branch");
@@ -1393,7 +1370,7 @@ mod tests {
 
     #[test]
     fn ahead_behind_against_upstream_is_none_without_a_configured_upstream() {
-        let repo = init_repo();
+        let repo = seed_empty_repo();
         commit(repo.path(), "a.txt", "1", "base");
         let result =
             ahead_behind_against_upstream(repo.path()).expect("ahead_behind_against_upstream");
@@ -1402,7 +1379,7 @@ mod tests {
 
     #[test]
     fn ahead_behind_against_upstream_counts_real_divergence() {
-        let remote = init_repo();
+        let remote = seed_empty_repo();
         commit(remote.path(), "a.txt", "1", "base");
 
         let local_dir = TempDir::new().expect("tempdir");
@@ -1426,7 +1403,7 @@ mod tests {
 
     #[test]
     fn commits_already_on_upstream_is_none_without_a_configured_upstream() {
-        let repo = init_repo();
+        let repo = seed_empty_repo();
         commit(repo.path(), "a.txt", "1", "base");
         let head = git_output(repo.path(), &["rev-parse", "HEAD"]);
         let result =
@@ -1436,7 +1413,7 @@ mod tests {
 
     #[test]
     fn commits_already_on_upstream_distinguishes_pushed_from_local_only_commits() {
-        let remote = init_repo();
+        let remote = seed_empty_repo();
         commit(remote.path(), "a.txt", "1", "base");
 
         let local_dir = TempDir::new().expect("tempdir");
@@ -1466,16 +1443,6 @@ mod tests {
         assert!(!result.contains(&local_only));
     }
 
-    fn git_output(dir: &Path, args: &[&str]) -> String {
-        let output = Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(output.status.success(), "git {args:?} failed in {dir:?}");
-        String::from_utf8_lossy(&output.stdout).trim().to_string()
-    }
-
     #[test]
     fn build_graph_row_order_is_stable_even_with_tied_commit_timestamps() {
         // Regression test for a real failure mode found while building this module: with
@@ -1484,7 +1451,7 @@ mod tests {
         // timestamp. The old time-sorted walk could then hand back a parent before one of its
         // own children; the topological walk must instead keep the order sound (and
         // `layout_lanes`'s defense-in-depth must keep even unsound input from panicking).
-        let repo = init_repo();
+        let repo = seed_empty_repo();
         commit(repo.path(), "a.txt", "1", "base");
         git(repo.path(), &["checkout", "-b", "feature"]);
         commit(repo.path(), "b.txt", "1", "feature work");
@@ -1514,7 +1481,7 @@ mod tests {
 
     #[test]
     fn graph_walk_is_prefix_stable_across_caps() {
-        let repo = init_repo();
+        let repo = seed_empty_repo();
         commit_at(repo.path(), "a.txt", "1", "base", 1_700_000_000);
         git(repo.path(), &["checkout", "-b", "feature"]);
         commit_at(repo.path(), "b.txt", "1", "feature 1", 1_700_000_100);
@@ -1609,7 +1576,7 @@ mod tests {
 
     #[test]
     fn a_clock_skewed_branch_still_connects_to_its_parent() {
-        let repo = init_repo();
+        let repo = seed_empty_repo();
         commit_at(repo.path(), "a.txt", "1", "base", 1_700_000_300);
         git(repo.path(), &["branch", "skewed"]);
         commit_at(repo.path(), "a.txt", "2", "main 1", 1_700_000_400);
@@ -1648,7 +1615,7 @@ mod tests {
 
     #[test]
     fn same_second_parent_child_pairs_stay_topologically_ordered() {
-        let repo = init_repo();
+        let repo = seed_empty_repo();
         let t = 1_700_000_000;
         commit_at(repo.path(), "a.txt", "1", "base", t);
         git(repo.path(), &["checkout", "-b", "side"]);
@@ -1667,7 +1634,7 @@ mod tests {
 
     #[test]
     fn graph_walk_prefix_stays_stable_across_caps_on_a_skewed_history() {
-        let repo = init_repo();
+        let repo = seed_empty_repo();
         commit_at(repo.path(), "a.txt", "1", "base", 1_700_000_300);
         git(repo.path(), &["branch", "skewed"]);
         commit_at(repo.path(), "a.txt", "2", "main 1", 1_700_000_400);
@@ -1692,7 +1659,7 @@ mod tests {
 
     #[test]
     fn commit_changed_files_reports_real_add_modify_delete() {
-        let repo = init_repo();
+        let repo = seed_empty_repo();
         commit(repo.path(), "a.txt", "1", "first");
         fs::write(repo.path().join("a.txt"), "2").expect("write");
         fs::write(repo.path().join("b.txt"), "new").expect("write");
@@ -1733,7 +1700,7 @@ mod tests {
 
     #[test]
     fn commit_changed_files_rejects_a_non_hex_commit_id() {
-        let repo = init_repo();
+        let repo = seed_empty_repo();
         commit(repo.path(), "a.txt", "1", "first");
         let err = commit_changed_files(repo.path(), "not-a-sha; rm -rf /")
             .expect_err("must reject a non-hex commit id");
@@ -1742,7 +1709,7 @@ mod tests {
 
     #[test]
     fn commit_changed_files_on_a_merge_is_honestly_empty() {
-        let repo = init_repo();
+        let repo = seed_empty_repo();
         commit_at(repo.path(), "a.txt", "1", "base", 1_700_000_000);
         git(repo.path(), &["checkout", "-b", "feature"]);
         commit_at(repo.path(), "b.txt", "1", "feature work", 1_700_000_100);

--- a/crates/wt-core/src/lib.rs
+++ b/crates/wt-core/src/lib.rs
@@ -453,42 +453,7 @@ mod tests {
     use super::*;
     use std::fs;
     use tempfile::TempDir;
-
-    /// Run `git` with `args` in `dir` and panic with full output on failure. Test-only
-    /// helper, not part of the library's public error handling.
-    fn git(dir: &Path, args: &[&str]) {
-        let output = Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {:?} failed in {:?}:\nstdout: {}\nstderr: {}",
-            args,
-            dir,
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
-    /// Turn a freshly-created directory into a repository with one commit on branch
-    /// `main`.
-    fn init_repo_at(dir: &Path) {
-        git(dir, &["init", "-b", "main"]);
-        git(dir, &["config", "user.email", "test@example.com"]);
-        git(dir, &["config", "user.name", "Test User"]);
-        fs::write(dir.join("file.txt"), "hello\n").expect("write file");
-        git(dir, &["add", "file.txt"]);
-        git(dir, &["commit", "-m", "initial commit"]);
-    }
-
-    /// Initialize a fresh repository in a tempdir with one commit on branch `main`.
-    fn init_repo() -> TempDir {
-        let dir = TempDir::new().expect("tempdir");
-        init_repo_at(dir.path());
-        dir
-    }
+    use test_support::{git, seed_repo, seed_repo_at};
 
     /// `list_worktrees`, asserting the outer call succeeds and every per-worktree entry
     /// succeeds too, for tests where every entry is expected to be readable.
@@ -502,7 +467,7 @@ mod tests {
 
     #[test]
     fn lists_main_worktree_only() {
-        let repo = init_repo();
+        let repo = seed_repo();
         let worktrees = list_ok(repo.path());
         assert_eq!(worktrees.len(), 1);
         let main = &worktrees[0];
@@ -519,7 +484,7 @@ mod tests {
 
     #[test]
     fn lists_main_and_linked_worktrees() {
-        let repo = init_repo();
+        let repo = seed_repo();
         let linked_dir = TempDir::new().expect("tempdir");
         let linked_path = linked_dir.path().join("linked-wt");
         drop(linked_dir);
@@ -558,7 +523,7 @@ mod tests {
 
     #[test]
     fn add_worktree_creates_branch_and_checkout() {
-        let repo = init_repo();
+        let repo = seed_repo();
         let linked_dir = TempDir::new().expect("tempdir");
         let linked_path = linked_dir.path().join("new-wt");
         drop(linked_dir);
@@ -578,7 +543,7 @@ mod tests {
 
     #[test]
     fn add_worktree_checks_out_existing_branch_via_commit_ish() {
-        let repo = init_repo();
+        let repo = seed_repo();
         git(repo.path(), &["branch", "existing-branch"]);
 
         let linked_dir = TempDir::new().expect("tempdir");
@@ -598,7 +563,7 @@ mod tests {
 
     #[test]
     fn add_worktree_rejects_flag_like_commit_ish_as_positional() {
-        let repo = init_repo();
+        let repo = seed_repo();
         let linked_dir = TempDir::new().expect("tempdir");
         let linked_path = linked_dir.path().join("dashy-wt");
         drop(linked_dir);
@@ -622,7 +587,7 @@ mod tests {
 
     #[test]
     fn detached_head_worktree_has_no_branch() {
-        let repo = init_repo();
+        let repo = seed_repo();
         let linked_dir = TempDir::new().expect("tempdir");
         let linked_path = linked_dir.path().join("detached-wt");
         drop(linked_dir);
@@ -650,7 +615,7 @@ mod tests {
 
     #[test]
     fn list_reports_lock_state_with_reason() {
-        let repo = init_repo();
+        let repo = seed_repo();
         let linked_dir = TempDir::new().expect("tempdir");
         let linked_path = linked_dir.path().join("locked-wt");
         drop(linked_dir);
@@ -677,7 +642,7 @@ mod tests {
 
     #[test]
     fn list_reports_lock_without_reason_as_none() {
-        let repo = init_repo();
+        let repo = seed_repo();
         let linked_dir = TempDir::new().expect("tempdir");
         let linked_path = linked_dir.path().join("locked-no-reason-wt");
         drop(linked_dir);
@@ -707,7 +672,7 @@ mod tests {
 
     #[test]
     fn remove_force_removes_locked_worktree() {
-        let repo = init_repo();
+        let repo = seed_repo();
         let linked_dir = TempDir::new().expect("tempdir");
         let linked_path = linked_dir.path().join("locked-remove-wt");
         drop(linked_dir);
@@ -737,7 +702,7 @@ mod tests {
 
     #[test]
     fn list_worktrees_on_bare_repo_skips_main_entry() {
-        let source = init_repo();
+        let source = seed_repo();
         let bare_dir = TempDir::new().expect("tempdir");
         git(
             bare_dir.path(),
@@ -767,7 +732,7 @@ mod tests {
 
     #[test]
     fn remove_clean_worktree_without_force_succeeds() {
-        let repo = init_repo();
+        let repo = seed_repo();
         let linked_dir = TempDir::new().expect("tempdir");
         let linked_path = linked_dir.path().join("clean-wt");
         drop(linked_dir);
@@ -781,7 +746,7 @@ mod tests {
 
     #[test]
     fn remove_refuses_dirty_tracked_file_without_force() {
-        let repo = init_repo();
+        let repo = seed_repo();
         let linked_dir = TempDir::new().expect("tempdir");
         let linked_path = linked_dir.path().join("dirty-wt");
         drop(linked_dir);
@@ -812,7 +777,7 @@ mod tests {
 
     #[test]
     fn remove_refuses_untracked_file_without_force() {
-        let repo = init_repo();
+        let repo = seed_repo();
         let linked_dir = TempDir::new().expect("tempdir");
         let linked_path = linked_dir.path().join("untracked-wt");
         drop(linked_dir);
@@ -841,7 +806,7 @@ mod tests {
         let container = TempDir::new().expect("tempdir");
         let repo_path = container.path().join("repo");
         fs::create_dir(&repo_path).expect("mkdir repo");
-        init_repo_at(&repo_path);
+        seed_repo_at(&repo_path);
 
         let linked_path = container.path().join("linked");
         add_worktree(&repo_path, &linked_path, Some("relative-branch"), None)
@@ -977,7 +942,7 @@ mod tests {
 
     #[test]
     fn list_worktrees_porcelain_reports_main_and_linked() {
-        let repo = init_repo();
+        let repo = seed_repo();
         let linked_dir = TempDir::new().expect("tempdir");
         let linked_path = linked_dir.path().join("porcelain-linked-wt");
         drop(linked_dir);
@@ -1005,7 +970,7 @@ mod tests {
 
     #[test]
     fn list_worktrees_porcelain_reports_detached_head() {
-        let repo = init_repo();
+        let repo = seed_repo();
         let linked_dir = TempDir::new().expect("tempdir");
         let linked_path = linked_dir.path().join("porcelain-detached-wt");
         drop(linked_dir);
@@ -1033,7 +998,7 @@ mod tests {
 
     #[test]
     fn list_worktrees_porcelain_reports_lock_reason() {
-        let repo = init_repo();
+        let repo = seed_repo();
         let linked_dir = TempDir::new().expect("tempdir");
         let linked_path = linked_dir.path().join("porcelain-locked-wt");
         drop(linked_dir);
@@ -1061,7 +1026,7 @@ mod tests {
 
     #[test]
     fn list_worktrees_porcelain_flags_a_manually_deleted_worktree_as_prunable() {
-        let repo = init_repo();
+        let repo = seed_repo();
         let linked_dir = TempDir::new().expect("tempdir");
         let linked_path = linked_dir.path().join("porcelain-prunable-wt");
         drop(linked_dir);
@@ -1091,7 +1056,7 @@ mod tests {
 
     #[test]
     fn git_common_dir_resolves_to_the_dot_git_directory() {
-        let repo = init_repo();
+        let repo = seed_repo();
         let common_dir = git_common_dir(repo.path()).expect("git_common_dir");
         assert_eq!(
             fs::canonicalize(&common_dir).expect("canonicalize"),
@@ -1101,7 +1066,7 @@ mod tests {
 
     #[test]
     fn git_common_dir_from_a_linked_worktree_resolves_to_the_same_shared_directory() {
-        let repo = init_repo();
+        let repo = seed_repo();
         let linked_dir = TempDir::new().expect("tempdir");
         let linked_path = linked_dir.path().join("common-dir-linked-wt");
         drop(linked_dir);

--- a/crates/wt-core/src/merge.rs
+++ b/crates/wt-core/src/merge.rs
@@ -744,31 +744,19 @@ mod tests {
     use std::fs;
     use std::process::Command;
     use tempfile::TempDir;
+    use test_support::{commit, git, seed_empty_repo};
 
-    fn git(dir: &Path, args: &[&str]) {
-        let output = Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {:?} failed in {:?}:\nstdout: {}\nstderr: {}",
-            args,
-            dir,
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
+    /// `seed_empty_repo` plus this module's own base commit: every merge test needs a common
+    /// ancestor to diverge from.
     fn init_repo() -> TempDir {
-        let dir = TempDir::new().expect("tempdir");
-        git(dir.path(), &["init", "-b", "main"]);
-        git(dir.path(), &["config", "user.email", "test@example.com"]);
-        git(dir.path(), &["config", "user.name", "Test User"]);
-        fs::write(dir.path().join("base.txt"), "base\n").expect("write");
-        git(dir.path(), &["add", "base.txt"]);
-        git(dir.path(), &["commit", "-m", "initial"]);
+        let dir = seed_empty_repo();
+        commit(
+            dir.path(),
+            "base.txt",
+            "base
+",
+            "initial",
+        );
         dir
     }
 

--- a/crates/wt-core/src/rebase.rs
+++ b/crates/wt-core/src/rebase.rs
@@ -562,40 +562,7 @@ mod tests {
     use super::*;
     use std::process::Command;
     use tempfile::TempDir;
-
-    fn git(dir: &Path, args: &[&str]) {
-        let output = Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {:?} failed in {:?}:\nstdout: {}\nstderr: {}",
-            args,
-            dir,
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
-    fn git_output(dir: &Path, args: &[&str]) -> String {
-        let output = Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(output.status.success(), "git {args:?} failed in {dir:?}");
-        String::from_utf8_lossy(&output.stdout).trim().to_string()
-    }
-
-    fn init_repo() -> TempDir {
-        let dir = TempDir::new().expect("tempdir");
-        git(dir.path(), &["init", "-b", "main"]);
-        git(dir.path(), &["config", "user.email", "test@example.com"]);
-        git(dir.path(), &["config", "user.name", "Test User"]);
-        dir
-    }
+    use test_support::{git, git_output, seed_empty_repo};
 
     fn commit(dir: &Path, file: &str, contents: &str, message: &str) -> String {
         fs::write(dir.join(file), contents).expect("write file");
@@ -634,7 +601,7 @@ mod tests {
 
     #[test]
     fn commits_to_rebase_lists_commits_oldest_first_excluding_onto_itself() {
-        let repo = init_repo();
+        let repo = seed_empty_repo();
         let base = commit(repo.path(), "base.txt", "base", "base");
         let c1 = commit(repo.path(), "a.txt", "1", "commit 1");
         let c2 = commit(repo.path(), "b.txt", "2", "commit 2");
@@ -646,7 +613,7 @@ mod tests {
 
     #[test]
     fn commits_to_rebase_is_empty_when_onto_is_head_itself() {
-        let repo = init_repo();
+        let repo = seed_empty_repo();
         commit(repo.path(), "base.txt", "base", "base");
         let head = git_output(repo.path(), &["rev-parse", "HEAD"]);
 
@@ -658,7 +625,7 @@ mod tests {
 
     #[test]
     fn all_pick_plan_completes_cleanly_with_history_matching_the_plan() {
-        let repo = init_repo();
+        let repo = seed_empty_repo();
         let base = commit(repo.path(), "base.txt", "base", "base");
         let c1 = commit(repo.path(), "a.txt", "1", "commit 1");
         let c2 = commit(repo.path(), "b.txt", "2", "commit 2");
@@ -690,7 +657,7 @@ mod tests {
 
     #[test]
     fn drop_removes_the_commit_from_history() {
-        let repo = init_repo();
+        let repo = seed_empty_repo();
         let base = commit(repo.path(), "base.txt", "base", "base");
         let c1 = commit(repo.path(), "a.txt", "1", "commit 1");
         let c2 = commit(repo.path(), "b.txt", "2", "commit 2");
@@ -715,7 +682,7 @@ mod tests {
 
     #[test]
     fn squash_folds_into_the_previous_commit_keeping_both_original_messages() {
-        let repo = init_repo();
+        let repo = seed_empty_repo();
         let base = commit(repo.path(), "base.txt", "base", "base");
         let c1 = commit(repo.path(), "a.txt", "1", "commit 1");
         let c2 = commit(repo.path(), "b.txt", "2", "commit 2");
@@ -748,7 +715,7 @@ mod tests {
 
     #[test]
     fn fixup_folds_into_the_previous_commit_discarding_its_own_message() {
-        let repo = init_repo();
+        let repo = seed_empty_repo();
         let base = commit(repo.path(), "base.txt", "base", "base");
         let c1 = commit(repo.path(), "a.txt", "1", "commit 1");
         let c2 = commit(repo.path(), "b.txt", "2", "commit 2");
@@ -779,7 +746,7 @@ mod tests {
 
     #[test]
     fn reword_with_a_supplied_message_runs_straight_through_with_no_stop() {
-        let repo = init_repo();
+        let repo = seed_empty_repo();
         let base = commit(repo.path(), "base.txt", "base", "base");
         let c1 = commit(repo.path(), "a.txt", "1", "original message");
 
@@ -799,7 +766,7 @@ mod tests {
 
     #[test]
     fn amend_head_message_replaces_the_real_committed_message() {
-        let repo = init_repo();
+        let repo = seed_empty_repo();
         commit(repo.path(), "a.txt", "1", "original message");
         let head = git_output(repo.path(), &["rev-parse", "HEAD"]);
 
@@ -811,7 +778,7 @@ mod tests {
 
     #[test]
     fn amend_head_message_refuses_when_head_has_moved_since_expected() {
-        let repo = init_repo();
+        let repo = seed_empty_repo();
         commit(repo.path(), "a.txt", "1", "original message");
         let stale_expected = "0000000000000000000000000000000000000000".to_string();
 
@@ -828,7 +795,7 @@ mod tests {
 
     #[test]
     fn amend_head_message_refuses_when_the_real_index_has_staged_changes() {
-        let repo = init_repo();
+        let repo = seed_empty_repo();
         commit(repo.path(), "a.txt", "1", "original message");
         let head = git_output(repo.path(), &["rev-parse", "HEAD"]);
 
@@ -861,7 +828,7 @@ mod tests {
 
     #[test]
     fn reword_with_no_message_stops_and_reports_the_right_commit_and_reason() {
-        let repo = init_repo();
+        let repo = seed_empty_repo();
         let base = commit(repo.path(), "base.txt", "base", "base");
         let c1 = commit(repo.path(), "a.txt", "1", "commit 1");
 
@@ -889,7 +856,7 @@ mod tests {
 
     #[test]
     fn edit_always_stops_even_with_no_special_handling_and_continue_completes_it() {
-        let repo = init_repo();
+        let repo = seed_empty_repo();
         let base = commit(repo.path(), "base.txt", "base", "base");
         let c1 = commit(repo.path(), "a.txt", "1", "commit 1");
 
@@ -918,7 +885,7 @@ mod tests {
     /// Sets up a conflict: `base` sets `file.txt`, `v1` and `v2` change it differently, and the
     /// plan replays `v1` straight onto `base`.
     fn conflicting_repo() -> (TempDir, String, String, String) {
-        let repo = init_repo();
+        let repo = seed_empty_repo();
         let base = commit(repo.path(), "file.txt", "base", "base");
         commit(repo.path(), "file.txt", "v1", "commit v1");
         let v2 = commit(repo.path(), "file.txt", "v2", "commit v2");
@@ -1009,7 +976,7 @@ mod tests {
 
     #[test]
     fn a_plan_mixing_every_action_type_produces_the_exact_expected_history() {
-        let repo = init_repo();
+        let repo = seed_empty_repo();
         let base = commit(repo.path(), "base.txt", "base", "base");
         let c1 = commit(repo.path(), "f1.txt", "1", "commit 1");
         let c2 = commit(repo.path(), "f2.txt", "2", "commit 2");
@@ -1081,7 +1048,7 @@ mod tests {
 
     #[test]
     fn cascading_conflicts_before_a_reword_do_not_misalign_the_message_queue() {
-        let repo = init_repo();
+        let repo = seed_empty_repo();
         let base = commit(repo.path(), "file.txt", "base", "base");
         let c1 = commit(repo.path(), "file.txt", "v1", "commit v1");
         let c2 = commit(repo.path(), "file.txt", "v2", "commit v2");
@@ -1134,14 +1101,14 @@ mod tests {
 
     #[test]
     fn rebase_status_is_none_when_no_rebase_is_in_progress() {
-        let repo = init_repo();
+        let repo = seed_empty_repo();
         commit(repo.path(), "a.txt", "1", "commit 1");
         assert_eq!(rebase_status(repo.path()).expect("rebase_status"), None);
     }
 
     #[test]
     fn rebase_status_reports_real_state_when_stopped_mid_flight() {
-        let repo = init_repo();
+        let repo = seed_empty_repo();
         let base = commit(repo.path(), "base.txt", "base", "base");
         let c1 = commit(repo.path(), "a.txt", "1", "commit 1");
         let c2 = commit(repo.path(), "b.txt", "2", "commit 2");

--- a/crates/wt-core/src/remote.rs
+++ b/crates/wt-core/src/remote.rs
@@ -113,34 +113,8 @@ fn has_configured_upstream(worktree_path: &Path, branch: Option<&str>) -> Result
 mod tests {
     use super::*;
     use std::fs;
-    use std::process::Command;
     use tempfile::TempDir;
-
-    fn git(dir: &Path, args: &[&str]) {
-        let output = Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {:?} failed in {:?}:\nstdout: {}\nstderr: {}",
-            args,
-            dir,
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
-    fn git_output(dir: &Path, args: &[&str]) -> String {
-        let output = Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(output.status.success(), "git {args:?} failed in {dir:?}");
-        String::from_utf8_lossy(&output.stdout).trim().to_string()
-    }
+    use test_support::{git, git_output};
 
     fn init_bare_remote() -> TempDir {
         let dir = TempDir::new().expect("tempdir");

--- a/crates/wt-core/src/review.rs
+++ b/crates/wt-core/src/review.rs
@@ -319,32 +319,7 @@ mod tests {
     use super::*;
     use std::fs;
     use std::process::Command;
-    use tempfile::TempDir;
-
-    fn git(dir: &Path, args: &[&str]) {
-        let output = Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {:?} failed in {:?}:\nstdout: {}\nstderr: {}",
-            args,
-            dir,
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
-    fn git_stdout(dir: &Path, args: &[&str]) -> String {
-        let output = Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        String::from_utf8_lossy(&output.stdout).into_owned()
-    }
+    use test_support::{git, git_output, git_try, seed_repo};
 
     /// Snapshots, asserts untracked content was captured, and returns just the tree id.
     fn snapshot_tree(path: &Path) -> String {
@@ -358,20 +333,13 @@ mod tests {
         snapshot.tree_id
     }
 
-    fn init_repo() -> TempDir {
-        let dir = TempDir::new().expect("tempdir");
-        git(dir.path(), &["init", "-b", "main"]);
-        git(dir.path(), &["config", "user.email", "test@example.com"]);
-        git(dir.path(), &["config", "user.name", "Test User"]);
-        fs::write(dir.path().join("file.txt"), "hello\n").expect("write file");
-        git(dir.path(), &["add", "file.txt"]);
-        git(dir.path(), &["commit", "-m", "initial commit"]);
-        dir
-    }
-
+    /// The core promise of a baseline: nothing has changed since it was taken, so the review
+    /// diff against it is genuinely empty - even though this worktree has a real, non-empty
+    /// *git* diff (an uncommitted edit and an untracked file), which is exactly the distinction
+    /// GitHub issue #225 is about.
     #[test]
     fn a_fresh_snapshot_reports_no_review_changes_even_when_the_git_diff_is_not_empty() {
-        let repo = init_repo();
+        let repo = seed_repo();
         fs::write(repo.path().join("file.txt"), "hello\nedited\n").expect("write");
         fs::write(repo.path().join("untracked.txt"), "brand new\n").expect("write");
 
@@ -407,7 +375,7 @@ mod tests {
 
     #[test]
     fn changes_made_after_a_snapshot_show_up_in_the_review_diff_with_real_hunks() {
-        let repo = init_repo();
+        let repo = seed_repo();
         let tree = snapshot_tree(repo.path());
 
         fs::write(repo.path().join("file.txt"), "hello\nafter the snapshot\n").expect("write");
@@ -438,7 +406,7 @@ mod tests {
 
     #[test]
     fn an_untracked_file_created_after_a_snapshot_is_reported_as_an_addition() {
-        let repo = init_repo();
+        let repo = seed_repo();
         let tree = snapshot_tree(repo.path());
 
         fs::write(repo.path().join("brand_new.txt"), "written by an agent\n").expect("write");
@@ -457,7 +425,7 @@ mod tests {
 
     #[test]
     fn a_file_untracked_at_snapshot_time_is_captured_with_its_real_content() {
-        let repo = init_repo();
+        let repo = seed_repo();
         fs::write(repo.path().join("notes.txt"), "line one\n").expect("write");
 
         let tree = snapshot_tree(repo.path());
@@ -489,43 +457,48 @@ mod tests {
 
     #[test]
     fn snapshotting_a_worktree_leaves_real_git_status_byte_identical() {
-        let repo = init_repo();
+        let repo = seed_repo();
+        // A genuinely mixed state: one staged change, one unstaged change, one untracked file.
         fs::write(repo.path().join("staged.txt"), "staged content\n").expect("write");
         git(repo.path(), &["add", "staged.txt"]);
         fs::write(repo.path().join("file.txt"), "hello\nunstaged edit\n").expect("write");
         fs::write(repo.path().join("untracked.txt"), "untracked\n").expect("write");
 
-        let status_before = git_stdout(repo.path(), &["status", "--porcelain"]);
-        let head_before = git_stdout(repo.path(), &["rev-parse", "HEAD"]);
+        // Raw stdout, not `git_output`: this test's subject is byte-identity, so it must not
+        // compare through a helper that trims.
+        let status = |dir: &Path| git_try(dir, &["status", "--porcelain"]).stdout;
+        let status_before = status(repo.path());
+        let head_before = git_output(repo.path(), &["rev-parse", "HEAD"]);
         let index_before = fs::read(repo.path().join(".git").join("index")).expect("read index");
-        let stash_before = git_stdout(repo.path(), &["stash", "list"]);
+        let stash_before = git_output(repo.path(), &["stash", "list"]);
+        let rendered = String::from_utf8_lossy(&status_before).into_owned();
         assert!(
-            status_before.contains("A  staged.txt")
-                && status_before.contains(" M file.txt")
-                && status_before.contains("?? untracked.txt"),
+            rendered.contains("A  staged.txt")
+                && rendered.contains(" M file.txt")
+                && rendered.contains("?? untracked.txt"),
             "the test fixture must really have staged, unstaged and untracked entries - got:\n\
-             {status_before}"
+             {rendered}"
         );
 
         snapshot_worktree_tree(repo.path()).expect("snapshot");
 
         assert_eq!(
-            git_stdout(repo.path(), &["status", "--porcelain"]),
+            status(repo.path()),
             status_before,
             "snapshotting must not change one byte of what git reports about the worktree"
         );
-        assert_eq!(git_stdout(repo.path(), &["rev-parse", "HEAD"]), head_before);
+        assert_eq!(git_output(repo.path(), &["rev-parse", "HEAD"]), head_before);
         assert_eq!(
             fs::read(repo.path().join(".git").join("index")).expect("read index"),
             index_before,
             "the real index file must be untouched - every mutation goes to the shadow copy"
         );
-        assert_eq!(git_stdout(repo.path(), &["stash", "list"]), stash_before);
+        assert_eq!(git_output(repo.path(), &["stash", "list"]), stash_before);
     }
 
     #[test]
     fn a_snapshot_id_tracks_real_content_not_the_time_it_was_taken() {
-        let repo = init_repo();
+        let repo = seed_repo();
         let first = snapshot_tree(repo.path());
         let unchanged = snapshot_tree(repo.path());
         assert_eq!(
@@ -543,7 +516,7 @@ mod tests {
 
     #[test]
     fn changed_paths_agrees_with_the_full_review_diffs_file_list() {
-        let repo = init_repo();
+        let repo = seed_repo();
         let tree = snapshot_tree(repo.path());
 
         fs::write(repo.path().join("file.txt"), "hello\nedited\n").expect("write");
@@ -574,7 +547,7 @@ mod tests {
 
     #[test]
     fn changed_paths_is_empty_immediately_after_a_snapshot() {
-        let repo = init_repo();
+        let repo = seed_repo();
         fs::write(repo.path().join("file.txt"), "hello\nedited\n").expect("write");
         let tree = snapshot_tree(repo.path());
         assert!(
@@ -607,7 +580,9 @@ mod tests {
 
     #[test]
     fn an_oversized_untracked_set_is_never_hashed_into_the_object_database() {
-        let repo = init_repo();
+        let repo = seed_repo();
+        // Comfortably past the file cap, deliberately tiny so the test stays fast - the file cap
+        // exists precisely because many small files are as expensive as a few large ones.
         let junk = repo.path().join("build-output");
         std::fs::create_dir_all(&junk).expect("mkdir");
         for index in 0..(MAX_UNTRACKED_SNAPSHOT_FILES + 10) {
@@ -646,7 +621,7 @@ mod tests {
 
     #[test]
     fn an_ordinary_untracked_set_is_still_captured_in_full() {
-        let repo = init_repo();
+        let repo = seed_repo();
         fs::write(repo.path().join("scratch.txt"), "a normal untracked file\n").expect("write");
 
         let snapshot = snapshot_worktree_tree(repo.path()).expect("snapshot");
@@ -656,7 +631,7 @@ mod tests {
 
     #[test]
     fn gitignored_content_does_not_count_toward_the_untracked_cap() {
-        let repo = init_repo();
+        let repo = seed_repo();
         fs::write(repo.path().join(".gitignore"), "ignored/\n").expect("write");
         let ignored = repo.path().join("ignored");
         std::fs::create_dir_all(&ignored).expect("mkdir");
@@ -680,7 +655,7 @@ mod tests {
 
     #[test]
     fn an_anchored_baseline_survives_a_real_aggressive_gc() {
-        let repo = init_repo();
+        let repo = seed_repo();
         fs::write(repo.path().join("only_here.txt"), "unreferenced content\n").expect("write");
         let tree = snapshot_tree(repo.path());
 
@@ -690,16 +665,17 @@ mod tests {
         git(repo.path(), &["gc", "--prune=now", "--aggressive"]);
 
         assert_eq!(
-            git_stdout(repo.path(), &["rev-parse", &ref_name]).trim(),
+            git_output(repo.path(), &["rev-parse", &ref_name]),
             tree,
             "the anchored ref must still resolve to the same tree after a real gc"
         );
-        assert!(git_stdout(repo.path(), &["cat-file", "-p", &tree]).contains("only_here.txt"));
+        // And the tree's real content is still readable - not just the ref surviving.
+        assert!(git_output(repo.path(), &["cat-file", "-p", &tree]).contains("only_here.txt"));
     }
 
     #[test]
     fn anchoring_again_moves_an_existing_baseline_ref_rather_than_failing() {
-        let repo = init_repo();
+        let repo = seed_repo();
         let first = snapshot_tree(repo.path());
         let ref_name = baseline_ref_name("key");
         anchor_tree(repo.path(), &ref_name, &first).expect("anchor");
@@ -709,7 +685,7 @@ mod tests {
         anchor_tree(repo.path(), &ref_name, &second).expect("re-anchor");
 
         assert_eq!(
-            git_stdout(repo.path(), &["rev-parse", &ref_name]).trim(),
+            git_output(repo.path(), &["rev-parse", &ref_name]),
             second,
             "'Mark reviewed' advances the same ref onto the new snapshot"
         );
@@ -717,15 +693,15 @@ mod tests {
 
     #[test]
     fn deleting_a_baseline_ref_removes_it_and_is_idempotent() {
-        let repo = init_repo();
+        let repo = seed_repo();
         let tree = snapshot_tree(repo.path());
         let ref_name = baseline_ref_name("key");
         anchor_tree(repo.path(), &ref_name, &tree).expect("anchor");
 
         delete_ref(repo.path(), &ref_name).expect("delete");
         assert!(
-            git_stdout(repo.path(), &["rev-parse", "--verify", &ref_name])
-                .trim()
+            git_try(repo.path(), &["rev-parse", "--verify", &ref_name])
+                .stdout
                 .is_empty(),
             "the ref must really be gone"
         );
@@ -736,15 +712,15 @@ mod tests {
 
     #[test]
     fn a_ref_outside_the_review_namespace_is_refused_and_the_branch_survives() {
-        let repo = init_repo();
-        let head_before = git_stdout(repo.path(), &["rev-parse", "refs/heads/main"]);
+        let repo = seed_repo();
+        let head_before = git_output(repo.path(), &["rev-parse", "refs/heads/main"]);
 
         assert!(delete_ref(repo.path(), "refs/heads/main").is_err());
         assert!(anchor_tree(repo.path(), "refs/heads/main", &"0".repeat(40)).is_err());
         assert!(delete_ref(repo.path(), "refs/jerry/review/../../heads/main").is_err());
 
         assert_eq!(
-            git_stdout(repo.path(), &["rev-parse", "refs/heads/main"]),
+            git_output(repo.path(), &["rev-parse", "refs/heads/main"]),
             head_before,
             "the real branch must be completely untouched"
         );
@@ -769,7 +745,8 @@ mod tests {
 
     #[test]
     fn a_long_worktree_path_still_produces_a_usable_ref_name() {
-        let repo = init_repo();
+        let repo = seed_repo();
+        // A perfectly ordinary deep layout, well past the ~107-byte ceiling raw hex imposed.
         let long_key = format!(
             "/home/developer/Developer/some-organisation/{}/.worktrees/{}|Claude|1700000000",
             "a-reasonably-long-repository-name", "feature/a-descriptive-branch-name-here"
@@ -793,10 +770,7 @@ mod tests {
 
         let tree = snapshot_tree(repo.path());
         anchor_tree(repo.path(), &ref_name, &tree).expect("a long key must still anchor");
-        assert_eq!(
-            git_stdout(repo.path(), &["rev-parse", &ref_name]).trim(),
-            tree
-        );
+        assert_eq!(git_output(repo.path(), &["rev-parse", &ref_name]), tree);
         delete_ref(repo.path(), &ref_name).expect("and must still be deletable");
     }
 
@@ -810,7 +784,7 @@ mod tests {
 
     #[test]
     fn an_encoded_ref_name_is_accepted_by_real_git_check_ref_format() {
-        let repo = init_repo();
+        let repo = seed_repo();
         let nasty = "/home/u/my repo/../wt~1^2:3?4*5[6\\7.lock|Claude|1700000000";
         let ref_name = baseline_ref_name(nasty);
 
@@ -827,15 +801,12 @@ mod tests {
 
         let tree = snapshot_tree(repo.path());
         anchor_tree(repo.path(), &ref_name, &tree).expect("anchor");
-        assert_eq!(
-            git_stdout(repo.path(), &["rev-parse", &ref_name]).trim(),
-            tree
-        );
+        assert_eq!(git_output(repo.path(), &["rev-parse", &ref_name]), tree);
     }
 
     #[test]
     fn a_tree_id_that_is_not_a_hex_object_id_is_refused_before_git_ever_runs() {
-        let repo = init_repo();
+        let repo = seed_repo();
         assert!(diff_against_tree(
             repo.path(),
             "--upload-pack=evil",
@@ -855,7 +826,7 @@ mod tests {
 
     #[test]
     fn snapshots_are_scoped_to_the_worktree_they_were_taken_in() {
-        let repo = init_repo();
+        let repo = seed_repo();
         let other = repo.path().parent().expect("parent").join("linked-wt");
         git(
             repo.path(),

--- a/crates/wt-core/src/rewrite.rs
+++ b/crates/wt-core/src/rewrite.rs
@@ -36,41 +36,7 @@ mod tests {
     use super::*;
     use std::fs;
     use std::process::Command;
-    use tempfile::TempDir;
-
-    fn git(dir: &Path, args: &[&str]) {
-        let output = Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {:?} failed in {:?}:\nstdout: {}\nstderr: {}",
-            args,
-            dir,
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
-    fn git_output(dir: &Path, args: &[&str]) -> String {
-        let output = Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(output.status.success(), "git {args:?} failed in {dir:?}");
-        String::from_utf8_lossy(&output.stdout).trim().to_string()
-    }
-
-    fn init_repo() -> TempDir {
-        let dir = TempDir::new().expect("tempdir");
-        git(dir.path(), &["init", "-b", "main"]);
-        git(dir.path(), &["config", "user.email", "test@example.com"]);
-        git(dir.path(), &["config", "user.name", "Test User"]);
-        dir
-    }
+    use test_support::{git, git_output, seed_empty_repo};
 
     fn commit(dir: &Path, file: &str, contents: &str, message: &str) -> String {
         fs::write(dir.join(file), contents).expect("write file");
@@ -81,7 +47,7 @@ mod tests {
 
     #[test]
     fn cherry_pick_really_applies_the_commits_change_on_top_of_head() {
-        let repo = init_repo();
+        let repo = seed_empty_repo();
         commit(repo.path(), "a.txt", "base", "base");
         git(repo.path(), &["checkout", "-b", "feature"]);
         let feature_sha = commit(repo.path(), "b.txt", "feature content", "feature work");
@@ -100,7 +66,7 @@ mod tests {
 
     #[test]
     fn cherry_pick_a_real_conflict_surfaces_as_a_real_error_leaving_conflict_state_behind() {
-        let repo = init_repo();
+        let repo = seed_empty_repo();
         commit(repo.path(), "a.txt", "base", "base");
         git(repo.path(), &["checkout", "-b", "feature"]);
         let feature_sha = commit(repo.path(), "a.txt", "feature change", "feature work");
@@ -132,7 +98,7 @@ mod tests {
 
     #[test]
     fn revert_really_creates_a_new_commit_undoing_the_targets_change() {
-        let repo = init_repo();
+        let repo = seed_empty_repo();
         commit(repo.path(), "a.txt", "base", "base");
         let to_revert = commit(repo.path(), "a.txt", "changed", "the change to undo");
 
@@ -152,7 +118,7 @@ mod tests {
 
     #[test]
     fn revert_a_real_conflict_surfaces_as_a_real_error_leaving_conflict_state_behind() {
-        let repo = init_repo();
+        let repo = seed_empty_repo();
         commit(repo.path(), "a.txt", "base", "base");
         let to_revert = commit(repo.path(), "a.txt", "changed", "the change to undo");
         commit(
@@ -191,7 +157,7 @@ mod tests {
 
     #[test]
     fn rebase_onto_really_replays_the_current_branchs_commits_on_top_of_the_target() {
-        let repo = init_repo();
+        let repo = seed_empty_repo();
         commit(repo.path(), "a.txt", "base", "base");
         let base_sha = git_output(repo.path(), &["rev-parse", "HEAD"]);
 
@@ -218,7 +184,7 @@ mod tests {
 
     #[test]
     fn rebase_onto_a_real_conflict_surfaces_as_a_real_error_leaving_rebase_state_behind() {
-        let repo = init_repo();
+        let repo = seed_empty_repo();
         commit(repo.path(), "a.txt", "base", "base");
         let base_sha = git_output(repo.path(), &["rev-parse", "HEAD"]);
 

--- a/crates/wt-core/src/run_drift.rs
+++ b/crates/wt-core/src/run_drift.rs
@@ -85,37 +85,21 @@ fn parse_commit_dates(text: &str) -> Vec<i64> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::process::Command;
     use std::time::{SystemTime, UNIX_EPOCH};
+    use test_support::{git, git_with_env, seed_empty_repo};
 
-    fn git(dir: &Path, args: &[&str]) {
-        git_at(dir, args, None);
-    }
-
-    /// `at` pins both author and committer date, so commits land on a chosen side of a mark
-    /// deterministically rather than racing the wall clock.
-    fn git_at(dir: &Path, args: &[&str], at: Option<i64>) {
-        let mut command = Command::new("git");
-        command
-            .current_dir(dir)
-            .args(args)
-            .env("GIT_AUTHOR_NAME", "Test")
-            .env("GIT_AUTHOR_EMAIL", "test@example.com")
-            .env("GIT_COMMITTER_NAME", "Test")
-            .env("GIT_COMMITTER_EMAIL", "test@example.com");
-        if let Some(at) = at {
-            command
-                .env("GIT_AUTHOR_DATE", format!("@{at} +0000"))
-                .env("GIT_COMMITTER_DATE", format!("@{at} +0000"));
-        }
-        let status = command.status().expect("git must run");
-        assert!(status.success(), "git {args:?} must succeed");
-    }
-
+    /// `at` pins the commit's real author *and* committer date, so a test can place commits on
+    /// either side of a mark deterministically rather than racing the wall clock (the counting
+    /// this module does is by committer date - see [`commits_since`]'s own docs).
     fn commit_at(dir: &Path, name: &str, at: i64) {
         std::fs::write(dir.join(name), name).expect("write");
-        git_at(dir, &["add", "."], Some(at));
-        git_at(dir, &["commit", "-m", name], Some(at));
+        let date = format!("@{at} +0000");
+        let env = [
+            ("GIT_AUTHOR_DATE", date.as_str()),
+            ("GIT_COMMITTER_DATE", date.as_str()),
+        ];
+        git_with_env(dir, &["add", "."], &env);
+        git_with_env(dir, &["commit", "-m", name], &env);
     }
 
     fn commit(dir: &Path, name: &str) {
@@ -133,9 +117,8 @@ mod tests {
 
     #[test]
     fn a_real_repository_reports_the_real_number_of_commits_since_a_moment() {
-        let dir = tempfile::tempdir().expect("temp dir");
+        let dir = seed_empty_repo();
         let path = dir.path();
-        git(path, &["init", "-b", "main"]);
         commit_at(path, "before-a", 1_700_000_000);
         commit_at(path, "before-b", 1_700_000_100);
 
@@ -159,8 +142,7 @@ mod tests {
 
     #[test]
     fn an_unborn_head_has_no_answer_rather_than_a_fabricated_zero() {
-        let dir = tempfile::tempdir().expect("temp dir");
-        git(dir.path(), &["init", "-b", "main"]);
+        let dir = seed_empty_repo();
         assert_eq!(
             commits_since(dir.path(), now()).expect("must not error"),
             None,
@@ -170,8 +152,7 @@ mod tests {
 
     #[test]
     fn a_nonsense_timestamp_is_refused_rather_than_traversing_everything() {
-        let dir = tempfile::tempdir().expect("temp dir");
-        git(dir.path(), &["init", "-b", "main"]);
+        let dir = seed_empty_repo();
         commit(dir.path(), "one");
         assert_eq!(commits_since(dir.path(), 0).expect("must not error"), None);
         assert_eq!(commits_since(dir.path(), -5).expect("must not error"), None);
@@ -192,9 +173,8 @@ mod tests {
 
     #[test]
     fn every_run_in_one_checkout_is_answered_from_one_traversal() {
-        let dir = tempfile::tempdir().expect("temp dir");
+        let dir = seed_empty_repo();
         let path = dir.path();
-        git(path, &["init", "-b", "main"]);
         commit_at(path, "a", 1_700_000_000);
         commit_at(path, "b", 1_700_001_000);
         commit_at(path, "c", 1_700_002_000);
@@ -216,7 +196,7 @@ mod tests {
 
     #[test]
     fn asking_about_no_runs_at_all_spawns_nothing_and_answers_nothing() {
-        let dir = tempfile::tempdir().expect("temp dir");
+        let dir = seed_empty_repo();
         assert_eq!(
             commits_since_each(dir.path(), &[]).expect("must not error"),
             Some(Vec::new()),

--- a/crates/wt-core/src/stage.rs
+++ b/crates/wt-core/src/stage.rs
@@ -150,49 +150,12 @@ fn path_from_bytes(bytes: &[u8]) -> PathBuf {
 mod tests {
     use super::*;
     use std::fs;
-    use std::process::Command;
     use tempfile::TempDir;
-
-    fn git(dir: &Path, args: &[&str]) {
-        let output = Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {:?} failed in {:?}:\nstdout: {}\nstderr: {}",
-            args,
-            dir,
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
-    fn git_output(dir: &Path, args: &[&str]) -> String {
-        let output = Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(output.status.success(), "git {args:?} failed in {dir:?}");
-        String::from_utf8_lossy(&output.stdout).trim().to_string()
-    }
-
-    fn init_repo() -> TempDir {
-        let dir = TempDir::new().expect("tempdir");
-        git(dir.path(), &["init", "-b", "main"]);
-        git(dir.path(), &["config", "user.email", "test@example.com"]);
-        git(dir.path(), &["config", "user.name", "Test User"]);
-        fs::write(dir.path().join("file.txt"), "hello\n").expect("write file");
-        git(dir.path(), &["add", "file.txt"]);
-        git(dir.path(), &["commit", "-m", "initial commit"]);
-        dir
-    }
+    use test_support::{git, git_output, seed_repo};
 
     #[test]
     fn stage_path_really_adds_a_modified_file_to_the_real_index() {
-        let repo = init_repo();
+        let repo = seed_repo();
         fs::write(repo.path().join("file.txt"), "changed\n").expect("modify");
 
         stage_path(repo.path(), Path::new("file.txt")).expect("stage_path");
@@ -206,7 +169,7 @@ mod tests {
 
     #[test]
     fn stage_path_really_adds_a_new_untracked_file() {
-        let repo = init_repo();
+        let repo = seed_repo();
         fs::write(repo.path().join("new.txt"), "new\n").expect("write new file");
 
         stage_path(repo.path(), Path::new("new.txt")).expect("stage_path");
@@ -220,7 +183,7 @@ mod tests {
 
     #[test]
     fn unstage_path_really_removes_a_path_from_the_real_index_without_touching_the_working_tree() {
-        let repo = init_repo();
+        let repo = seed_repo();
         fs::write(repo.path().join("file.txt"), "changed\n").expect("modify");
         git(repo.path(), &["add", "file.txt"]);
         let staged_before = git_output(repo.path(), &["status", "--porcelain", "file.txt"]);
@@ -246,7 +209,7 @@ mod tests {
 
     #[test]
     fn unstage_path_is_a_harmless_no_op_when_already_unstaged() {
-        let repo = init_repo();
+        let repo = seed_repo();
         fs::write(repo.path().join("file.txt"), "changed\n").expect("modify");
 
         unstage_path(repo.path(), Path::new("file.txt")).expect("unstage_path on a clean index");
@@ -257,7 +220,7 @@ mod tests {
 
     #[test]
     fn staged_paths_reflects_the_real_git_index_including_files_staged_by_something_else() {
-        let repo = init_repo();
+        let repo = seed_repo();
         fs::write(repo.path().join("file.txt"), "changed\n").expect("modify");
         fs::write(repo.path().join("also.txt"), "also\n").expect("write");
         // Staged directly via a real `git add`, standing in for something other than
@@ -277,13 +240,13 @@ mod tests {
 
     #[test]
     fn staged_paths_is_empty_on_a_clean_index() {
-        let repo = init_repo();
+        let repo = seed_repo();
         assert!(staged_paths(repo.path()).expect("staged_paths").is_empty());
     }
 
     #[test]
     fn staged_paths_never_includes_an_unstaged_modification() {
-        let repo = init_repo();
+        let repo = seed_repo();
         fs::write(repo.path().join("file.txt"), "changed but not staged\n").expect("modify");
 
         let staged = staged_paths(repo.path()).expect("staged_paths");
@@ -298,7 +261,7 @@ mod tests {
     /// GitHub issue #220 is about. `committed.txt` is genuinely part of a commit and clean on
     /// disk; the caller then dirties whatever else it wants to contrast against it.
     fn repo_with_a_committed_clean_file() -> TempDir {
-        let dir = init_repo();
+        let dir = seed_repo();
         git(dir.path(), &["checkout", "-b", "feature"]);
         fs::write(dir.path().join("committed.txt"), "committed\n").expect("write");
         git(dir.path(), &["add", "committed.txt"]);
@@ -337,7 +300,7 @@ mod tests {
 
     #[test]
     fn dirty_paths_includes_a_staged_file() {
-        let repo = init_repo();
+        let repo = seed_repo();
         fs::write(repo.path().join("file.txt"), "changed\n").expect("modify");
         git(repo.path(), &["add", "file.txt"]);
 
@@ -352,7 +315,7 @@ mod tests {
 
     #[test]
     fn dirty_paths_includes_an_unstaged_file() {
-        let repo = init_repo();
+        let repo = seed_repo();
         fs::write(repo.path().join("file.txt"), "changed\n").expect("modify");
 
         assert!(
@@ -365,7 +328,7 @@ mod tests {
 
     #[test]
     fn dirty_paths_includes_an_untracked_file() {
-        let repo = init_repo();
+        let repo = seed_repo();
         fs::write(repo.path().join("brand-new.txt"), "new\n").expect("write");
 
         assert!(
@@ -379,7 +342,7 @@ mod tests {
 
     #[test]
     fn dirty_paths_includes_a_deleted_tracked_file() {
-        let repo = init_repo();
+        let repo = seed_repo();
         fs::remove_file(repo.path().join("file.txt")).expect("remove");
 
         assert!(
@@ -392,7 +355,7 @@ mod tests {
 
     #[test]
     fn dirty_paths_includes_both_halves_of_a_live_rename() {
-        let repo = init_repo();
+        let repo = seed_repo();
         git(repo.path(), &["mv", "file.txt", "renamed.txt"]);
 
         let dirty = dirty_paths(repo.path()).expect("dirty_paths");
@@ -413,7 +376,7 @@ mod tests {
 
     #[test]
     fn dirty_paths_reports_a_nested_path_relative_to_the_worktree_root() {
-        let repo = init_repo();
+        let repo = seed_repo();
         fs::create_dir_all(repo.path().join("src/db")).expect("mkdir");
         fs::write(repo.path().join("src/db/query.rs"), "fn q() {}\n").expect("write");
 
@@ -429,7 +392,7 @@ mod tests {
 
     #[test]
     fn dirty_paths_handles_a_path_with_a_space_without_quoting_it() {
-        let repo = init_repo();
+        let repo = seed_repo();
         fs::write(repo.path().join("my file.txt"), "spaces\n").expect("write");
 
         assert!(
@@ -466,7 +429,7 @@ mod tests {
 
     #[test]
     fn stage_then_unstage_round_trips_back_to_a_clean_staged_set() {
-        let repo = init_repo();
+        let repo = seed_repo();
         fs::write(repo.path().join("file.txt"), "changed\n").expect("modify");
 
         stage_path(repo.path(), Path::new("file.txt")).expect("stage_path");
@@ -481,7 +444,7 @@ mod tests {
 
     #[test]
     fn discard_path_really_restores_a_modified_file_from_head() {
-        let repo = init_repo();
+        let repo = seed_repo();
         fs::write(repo.path().join("file.txt"), "the agent wrote this\n").expect("modify");
 
         discard_path(repo.path(), Path::new("file.txt")).expect("discard_path");
@@ -500,7 +463,7 @@ mod tests {
 
     #[test]
     fn discard_path_also_drops_a_change_that_was_already_staged() {
-        let repo = init_repo();
+        let repo = seed_repo();
         fs::write(repo.path().join("file.txt"), "the agent wrote this\n").expect("modify");
         git(repo.path(), &["add", "file.txt"]);
         assert_eq!(
@@ -522,7 +485,7 @@ mod tests {
 
     #[test]
     fn discard_path_restores_a_file_the_agent_deleted() {
-        let repo = init_repo();
+        let repo = seed_repo();
         fs::remove_file(repo.path().join("file.txt")).expect("delete");
 
         discard_path(repo.path(), Path::new("file.txt")).expect("discard_path");
@@ -536,7 +499,7 @@ mod tests {
 
     #[test]
     fn discard_path_removes_an_untracked_file_outright() {
-        let repo = init_repo();
+        let repo = seed_repo();
         fs::write(repo.path().join("new.txt"), "brand new\n").expect("write");
 
         discard_path(repo.path(), Path::new("new.txt")).expect("discard_path");
@@ -550,7 +513,7 @@ mod tests {
 
     #[test]
     fn discard_path_removes_a_staged_addition_from_both_the_index_and_the_disk() {
-        let repo = init_repo();
+        let repo = seed_repo();
         fs::write(repo.path().join("new.txt"), "brand new\n").expect("write");
         git(repo.path(), &["add", "new.txt"]);
         assert_eq!(
@@ -569,7 +532,7 @@ mod tests {
 
     #[test]
     fn discarding_one_path_leaves_every_other_dirty_path_alone() {
-        let repo = init_repo();
+        let repo = seed_repo();
         fs::write(repo.path().join("file.txt"), "edited\n").expect("modify");
         fs::write(repo.path().join("other.txt"), "also new\n").expect("write");
 

--- a/crates/wt-core/src/undo.rs
+++ b/crates/wt-core/src/undo.rs
@@ -626,47 +626,7 @@ mod tests {
     use std::path::PathBuf;
     use std::process::Command;
     use tempfile::TempDir;
-
-    fn git(dir: &Path, args: &[&str]) {
-        let output = Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {:?} failed in {:?}:\nstdout: {}\nstderr: {}",
-            args,
-            dir,
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
-    fn git_output(dir: &Path, args: &[&str]) -> String {
-        let output = Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(output.status.success(), "git {args:?} failed in {dir:?}");
-        String::from_utf8_lossy(&output.stdout).trim().to_string()
-    }
-
-    fn init_repo_at(dir: &Path) {
-        git(dir, &["init", "-b", "main"]);
-        git(dir, &["config", "user.email", "test@example.com"]);
-        git(dir, &["config", "user.name", "Test User"]);
-        fs::write(dir.join("file.txt"), "hello\n").expect("write file");
-        git(dir, &["add", "file.txt"]);
-        git(dir, &["commit", "-m", "initial commit"]);
-    }
-
-    fn init_repo() -> TempDir {
-        let dir = TempDir::new().expect("tempdir");
-        init_repo_at(dir.path());
-        dir
-    }
+    use test_support::{git, git_output, seed_repo, seed_repo_at};
 
     /// A session worktree on branch `name`, checked out from `main`'s tip.
     fn add_session_worktree(repo: &Path, path: &Path, branch: &str) {
@@ -686,7 +646,7 @@ mod tests {
 
     #[test]
     fn commit_all_changes_stages_and_commits_modified_new_and_deleted_files() {
-        let repo = init_repo();
+        let repo = seed_repo();
         fs::write(repo.path().join("file.txt"), "changed\n").expect("modify");
         fs::write(repo.path().join("new.txt"), "new\n").expect("new file");
         fs::write(repo.path().join("to-delete.txt"), "bye\n").expect("write");
@@ -718,7 +678,7 @@ mod tests {
 
     #[test]
     fn commit_all_changes_refuses_on_a_clean_worktree() {
-        let repo = init_repo();
+        let repo = seed_repo();
         let err = commit_all_changes(repo.path(), "nothing to do").unwrap_err();
         assert!(matches!(err, Error::NothingToCommit { .. }));
     }
@@ -727,7 +687,7 @@ mod tests {
 
     #[test]
     fn commit_paths_commits_only_the_given_paths_leaving_other_changes_uncommitted() {
-        let repo = init_repo();
+        let repo = seed_repo();
         fs::write(repo.path().join("file.txt"), "changed\n").expect("modify");
         fs::write(repo.path().join("untouched.txt"), "not staged\n").expect("new file");
 
@@ -756,7 +716,7 @@ mod tests {
 
     #[test]
     fn commit_paths_never_commits_a_path_that_was_staged_by_something_else() {
-        let repo = init_repo();
+        let repo = seed_repo();
         fs::write(repo.path().join("file.txt"), "changed\n").expect("modify");
         fs::write(repo.path().join("also-staged.txt"), "staged elsewhere\n")
             .expect("write also-staged.txt");
@@ -787,7 +747,7 @@ mod tests {
 
     #[test]
     fn commit_paths_refuses_an_empty_path_list() {
-        let repo = init_repo();
+        let repo = seed_repo();
         fs::write(repo.path().join("file.txt"), "changed\n").expect("modify");
         let err = commit_paths(repo.path(), &[], "nothing selected").unwrap_err();
         assert!(matches!(err, Error::NothingToCommit { .. }));
@@ -799,7 +759,7 @@ mod tests {
 
     #[test]
     fn commit_paths_real_message_becomes_the_real_commit_message() {
-        let repo = init_repo();
+        let repo = seed_repo();
         fs::write(repo.path().join("file.txt"), "changed\n").expect("modify");
         commit_paths(
             repo.path(),
@@ -813,7 +773,7 @@ mod tests {
 
     #[test]
     fn undo_commit_all_changes_restores_the_exact_pre_commit_uncommitted_state() {
-        let repo = init_repo();
+        let repo = seed_repo();
         fs::write(repo.path().join("file.txt"), "changed\n").expect("modify");
         fs::write(repo.path().join("new.txt"), "new\n").expect("new file");
         let outcome =
@@ -841,7 +801,7 @@ mod tests {
 
     #[test]
     fn undo_commit_all_changes_refuses_when_head_moved_since() {
-        let repo = init_repo();
+        let repo = seed_repo();
         fs::write(repo.path().join("file.txt"), "changed\n").expect("modify");
         let outcome =
             commit_all_changes(repo.path(), "ade: keep all changes").expect("commit_all_changes");
@@ -860,7 +820,7 @@ mod tests {
 
     #[test]
     fn redo_commit_all_changes_moves_head_forward_again_to_the_exact_same_commit() {
-        let repo = init_repo();
+        let repo = seed_repo();
         fs::write(repo.path().join("file.txt"), "changed\n").expect("modify");
         let outcome =
             commit_all_changes(repo.path(), "ade: keep all changes").expect("commit_all_changes");
@@ -884,7 +844,7 @@ mod tests {
 
     #[test]
     fn redo_commit_all_changes_refuses_when_head_moved_since_the_undo() {
-        let repo = init_repo();
+        let repo = seed_repo();
         fs::write(repo.path().join("file.txt"), "changed\n").expect("modify");
         let outcome =
             commit_all_changes(repo.path(), "ade: keep all changes").expect("commit_all_changes");
@@ -908,9 +868,15 @@ mod tests {
         // `A <- B <- C`, `parent` records `A`, and the `HEAD == outcome.commit` guard cannot see
         // it - `HEAD` really is `C` - so the undo resets to `A` and discards `B`.
         //
-        // The race itself is not reproducible against a sequential blocking call, so this pins
-        // the invariant instead: an interleaved commit lands first, and `parent` must record it.
-        let repo = init_repo();
+        // This can't be reproduced by literally racing a second thread against
+        // `commit_all_changes` (it's a single, sequential blocking call), but the fix is
+        // structural: `parent` must always be derived from the real commit's own immutable
+        // parent (`<commit>^`), never from a pre-commit snapshot. This test proves that
+        // invariant directly: a real second commit interleaves *before* `commit_all_changes`
+        // ever runs (standing in for the vulnerable window an earlier implementation had), and
+        // `commit_all_changes`'s own recorded `parent` must be that real interleaved commit, not
+        // the one further back - and undoing must preserve it, never silently drop it.
+        let repo = seed_repo();
         let commit_a = git_output(repo.path(), &["rev-parse", "HEAD"]);
 
         fs::write(
@@ -985,7 +951,7 @@ mod tests {
 
     #[test]
     fn discard_worktree_snapshots_a_dirty_worktree_then_removes_it() {
-        let repo = init_repo();
+        let repo = seed_repo();
         let wt_path = repo.path().join("session-a");
         add_session_worktree(repo.path(), &wt_path, "session-a");
         fs::write(wt_path.join("scratch.txt"), "wip\n").expect("write untracked file");
@@ -1007,7 +973,7 @@ mod tests {
 
     #[test]
     fn discard_worktree_on_a_clean_worktree_records_no_stash() {
-        let repo = init_repo();
+        let repo = seed_repo();
         let wt_path = repo.path().join("session-clean");
         add_session_worktree(repo.path(), &wt_path, "session-clean");
 
@@ -1022,9 +988,11 @@ mod tests {
 
     #[test]
     fn a_stash_created_and_stored_from_a_worktree_survives_that_worktrees_own_removal() {
-        // `refs/stash` lives in the repository's shared refs, not the worktree's private files,
-        // so it survives - and stays appliable - after that worktree is gone.
-        let repo = init_repo();
+        // Direct, empirical verification of this module's own core claim (see its module docs):
+        // `refs/stash` (which `git stash push` moves) lives in the *repository's* shared refs,
+        // not inside the worktree's own private files, so it is genuinely still there - and
+        // still `git stash apply`-able - after the worktree that created it is gone.
+        let repo = seed_repo();
         let wt_path = repo.path().join("session-b");
         add_session_worktree(repo.path(), &wt_path, "session-b");
         fs::write(wt_path.join("scratch.txt"), "real content\n").expect("write");
@@ -1042,7 +1010,7 @@ mod tests {
 
     #[test]
     fn undo_discard_worktree_recreates_the_worktree_and_restores_the_real_stash_content() {
-        let repo = init_repo();
+        let repo = seed_repo();
         let wt_path = repo.path().join("session-c");
         add_session_worktree(repo.path(), &wt_path, "session-c");
         fs::write(wt_path.join("scratch.txt"), "wip content\n").expect("write");
@@ -1068,7 +1036,7 @@ mod tests {
 
     #[test]
     fn undo_discard_worktree_on_a_clean_snapshot_just_recreates_the_worktree() {
-        let repo = init_repo();
+        let repo = seed_repo();
         let wt_path = repo.path().join("session-clean2");
         add_session_worktree(repo.path(), &wt_path, "session-clean2");
         let snapshot = discard_worktree(repo.path(), &wt_path).expect("discard_worktree");
@@ -1086,7 +1054,7 @@ mod tests {
 
     #[test]
     fn undo_discard_worktree_refuses_when_the_path_was_reoccupied() {
-        let repo = init_repo();
+        let repo = seed_repo();
         let wt_path = repo.path().join("session-d");
         add_session_worktree(repo.path(), &wt_path, "session-d");
         let snapshot = discard_worktree(repo.path(), &wt_path).expect("discard_worktree");
@@ -1099,7 +1067,7 @@ mod tests {
 
     #[test]
     fn undo_discard_worktree_refuses_when_the_branch_moved_since() {
-        let repo = init_repo();
+        let repo = seed_repo();
         let wt_path = repo.path().join("session-e");
         add_session_worktree(repo.path(), &wt_path, "session-e");
         let snapshot = discard_worktree(repo.path(), &wt_path).expect("discard_worktree");
@@ -1128,7 +1096,7 @@ mod tests {
 
     #[test]
     fn undo_discard_worktree_refuses_when_the_branch_was_deleted() {
-        let repo = init_repo();
+        let repo = seed_repo();
         let wt_path = repo.path().join("session-f");
         add_session_worktree(repo.path(), &wt_path, "session-f");
         let snapshot = discard_worktree(repo.path(), &wt_path).expect("discard_worktree");
@@ -1141,7 +1109,7 @@ mod tests {
 
     #[test]
     fn undo_discard_worktree_refuses_when_the_branch_is_checked_out_elsewhere_already() {
-        let repo = init_repo();
+        let repo = seed_repo();
         let wt_path = repo.path().join("session-g");
         add_session_worktree(repo.path(), &wt_path, "session-g");
         let snapshot = discard_worktree(repo.path(), &wt_path).expect("discard_worktree");
@@ -1174,11 +1142,15 @@ mod tests {
         // The undo's identity guard makes a conflict essentially unreachable through the full
         // flow, but `apply_stash` must still handle one rather than assume its caller's guard.
         //
-        // An *uncommitted* conflicting edit is the wrong setup: `git stash apply` refuses
-        // outright ("local changes would be overwritten") without attempting a merge, which is a
-        // non-restore failure and belongs in `Err`. Producing real markers needs a clean working
-        // tree with `HEAD` moved - a committed change to the line the stash diverges from.
-        let repo = init_repo();
+        // An earlier version of this test used a real *uncommitted* conflicting edit to trigger
+        // this - live-reproduced as the wrong scenario during an audit: `git stash apply`
+        // refuses outright ("Your local changes ... would be overwritten by merge") rather than
+        // attempting a merge at all when the working tree already has uncommitted changes to the
+        // same file, which is a real *non-restore failure* (case for a genuine `Err`, not
+        // `RestoredWithConflicts` - nothing was restored), not a real conflict. A genuine
+        // conflict-with-markers instead needs the working tree *clean* but `HEAD` moved: a new,
+        // real *committed* change to the same line the stash's own base diverges from.
+        let repo = seed_repo();
         fs::write(repo.path().join("file.txt"), "stash content\n").expect("edit for stash");
         let stash = push_and_capture_stash(repo.path()).expect("push_and_capture_stash");
         assert_eq!(
@@ -1223,7 +1195,7 @@ mod tests {
         // working tree already has real uncommitted changes to the same file - this must
         // surface as a genuine `Err`, not `RestoredWithConflicts` (which would falsely claim
         // something was restored).
-        let repo = init_repo();
+        let repo = seed_repo();
         fs::write(repo.path().join("file.txt"), "stash content\n").expect("edit for stash");
         let stash = push_and_capture_stash(repo.path()).expect("push_and_capture_stash");
 
@@ -1244,7 +1216,7 @@ mod tests {
 
     #[test]
     fn apply_stash_reports_a_real_error_for_a_stash_id_that_no_longer_exists() {
-        let repo = init_repo();
+        let repo = seed_repo();
         let fake_stash = "0000000000000000000000000000000000000000";
         let err = apply_stash(repo.path(), fake_stash).unwrap_err();
         assert!(matches!(err, Error::GitCommand { .. }));
@@ -1254,7 +1226,7 @@ mod tests {
 
     #[test]
     fn discard_worktree_refuses_the_main_worktree_and_touches_nothing() {
-        let repo = init_repo();
+        let repo = seed_repo();
         fs::write(repo.path().join("wip.txt"), "real uncommitted work\n").expect("write");
 
         let err = discard_worktree(repo.path(), repo.path()).unwrap_err();
@@ -1274,7 +1246,7 @@ mod tests {
 
     #[test]
     fn discard_worktree_reports_ignored_content_honestly() {
-        let repo = init_repo();
+        let repo = seed_repo();
         let wt_path = repo.path().join("session-h");
         add_session_worktree(repo.path(), &wt_path, "session-h");
         fs::write(wt_path.join(".gitignore"), "ignored.txt\n").expect("write");
@@ -1297,7 +1269,7 @@ mod tests {
 
     #[test]
     fn discard_worktree_reports_no_ignored_content_when_there_is_none() {
-        let repo = init_repo();
+        let repo = seed_repo();
         let wt_path = repo.path().join("session-i");
         add_session_worktree(repo.path(), &wt_path, "session-i");
         fs::write(wt_path.join("scratch.txt"), "wip\n").expect("write");
@@ -1319,10 +1291,10 @@ mod tests {
         // sha back as if it were this worktree's own snapshot, then proceed to force-remove the
         // real worktree believing its content was captured. This must instead refuse outright,
         // before anything real is destroyed.
-        let repo = init_repo();
+        let repo = seed_repo();
 
         let sub_dir = TempDir::new().expect("tempdir for submodule");
-        init_repo_at(sub_dir.path());
+        seed_repo_at(sub_dir.path());
         let sub_url = format!("file://{}", sub_dir.path().display());
         git(
             repo.path(),
@@ -1420,7 +1392,7 @@ mod tests {
         // directory itself.
         use std::os::unix::fs::PermissionsExt;
 
-        let repo = init_repo();
+        let repo = seed_repo();
         let container = TempDir::new().expect("tempdir");
         let wt_path = container.path().join("session-j");
         git(
@@ -1464,7 +1436,7 @@ mod tests {
     /// A branch whose tip commit is amendable, with a second path staged alongside - the exact
     /// interleaving `amend_head_with_paths`' `--only` exists to keep out of the amend.
     fn repo_with_an_amendable_tip() -> TempDir {
-        let repo = init_repo();
+        let repo = seed_repo();
         git(repo.path(), &["checkout", "-b", "feature"]);
         fs::write(repo.path().join("a.txt"), "a1\n").expect("write a");
         fs::write(repo.path().join("b.txt"), "b1\n").expect("write b");

--- a/crates/wt-core/src/worktree_files.rs
+++ b/crates/wt-core/src/worktree_files.rs
@@ -61,28 +61,11 @@ pub fn list_worktree_files(worktree_path: &Path) -> Result<WorktreeFileList, Err
 mod tests {
     use super::*;
     use std::fs;
-    use std::process::Command;
-
-    fn git(dir: &Path, args: &[&str]) {
-        let status = Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .status()
-            .expect("git runs");
-        assert!(status.success(), "git {args:?} failed");
-    }
-
-    fn init_repo() -> tempfile::TempDir {
-        let dir = tempfile::tempdir().expect("tempdir");
-        git(dir.path(), &["init", "-q"]);
-        git(dir.path(), &["config", "user.email", "t@example.com"]);
-        git(dir.path(), &["config", "user.name", "Test"]);
-        dir
-    }
+    use test_support::{git, seed_empty_repo};
 
     #[test]
     fn lists_tracked_and_untracked_but_never_a_gitignored_build_directory() {
-        let dir = init_repo();
+        let dir = seed_empty_repo();
         let root = dir.path();
         fs::write(root.join(".gitignore"), "target/\n").expect("write");
         fs::create_dir_all(root.join("src")).expect("mkdir");
@@ -121,7 +104,7 @@ mod tests {
 
     #[test]
     fn an_explicitly_tracked_file_stays_listed_even_under_a_later_ignore_rule() {
-        let dir = init_repo();
+        let dir = seed_empty_repo();
         let root = dir.path();
         fs::create_dir_all(root.join("generated")).expect("mkdir");
         fs::write(root.join("generated/schema.rs"), "// generated\n").expect("write");

--- a/docs/architecture/decisions.md
+++ b/docs/architecture/decisions.md
@@ -254,3 +254,28 @@ and a ConPTY master is a named pipe, so the reader blocks until `master` itself 
 the child is reaped. Callers must therefore poll `try_wait` rather than wait for the output channel
 to disconnect. These paths are `#[cfg(windows)]`, never `#[cfg(not(unix))]`, so an unsupported
 non-unix target fails to compile instead of silently inheriting Windows semantics.
+
+## 9. `crates/test-support` is a real crate, not a feature-gated one
+
+**Status:** Accepted.
+
+**Context:** Test setup had no shared home, so it was copy-pasted instead: `fn git(dir, args)`
+appeared ~30 times across `wt-core` and `app`, alongside 1,223 separate tempdir setups and 303
+wall-clock waits. The obvious single crate to fix that has a trap in it — `crates/app`'s fixtures
+need `gpui` (a test window, `VisualTestContext`), and `wt-core`/`pty-core`/`lsp-core` must be able
+to dev-depend on the same crate without acquiring `gpui` (§1).
+
+A Cargo feature (`test-support = { features = ["gpui"] }` for `app` only) looks like it solves
+this and does not: features unify across a workspace build, so one crate enabling `gpui` enables it
+for every other crate resolving the same dependency. The core crates' dev graph would silently
+regain `gpui` — exactly the outcome §1 exists to prevent, and one no `Cargo.toml` review would
+catch.
+
+**Decision:** Two homes, split by dependency rather than by feature. `crates/test-support` is
+`gpui`-free and depends only on `tempfile`; anything needing `gpui` lives in
+`crates/app/src/test_support.rs`, inside the one crate already allowed to have it.
+
+**Consequences:** `cargo tree -e normal,dev,build -i gpui` reaching only `crates/app` is a
+checkable invariant, not a convention. A helper that "just needs a `TestAppContext`" is not added
+to `crates/test-support` under any flag — it goes in `crates/app` or it is restructured to take
+plain data. The policy those fixtures serve is [`docs/testing.md`](../testing.md).

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -48,10 +48,10 @@ process that applies them.
    against `design_handoff_jerry_ade/revision/` or the issue's acceptance criteria. The only way
    UI-visible work gets checked against something real instead of "looks right."
 
-7. **Finish — `ship`.** Runs `/check` (the gate: conventions, fmt, clippy — not tests right now,
-   see [issue #348](https://github.com/ColinEspinas/jerry/issues/348)), commits, pushes, and
-   opens the PR from `.github/pull_request_template.md` with a real summary — not a generic one.
-   Works standalone for anything that didn't start from a scoped issue, too.
+7. **Finish — `ship`.** Runs `/check` (the gate: conventions, fmt, clippy, and the `unit`/`ui`
+   test tiers), commits, pushes, and opens the PR from `.github/pull_request_template.md` with a
+   real summary — not a generic one. Works standalone for anything that didn't start from a scoped
+   issue, too.
 
 8. **Get reviewed — `review`.** Checks a diff or PR against `CLAUDE.md`'s standards and posts real
    findings with `gh pr review`, not a line-by-line narration.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,181 @@
+# Testing policy
+
+What deserves a test in Jerry, what it may cost, and what gets deleted. `CLAUDE.md`'s "Testing"
+section states the rule in two sentences and points here for the detail.
+
+This exists because the suite grew to 3,564 tests and 109,987 lines inside `#[cfg(test)]` blocks —
+**45.3% of the workspace's 242,846 lines** — with `fn git(dir, args)` copy-pasted ~30 times and
+1,223 separate tempdir setups. Nothing in the repo said what a test was *for*, so nothing said when
+not to write one.
+
+## The three tiers
+
+Every test belongs to exactly one tier, and the tier decides what it may do and what it may cost.
+
+| Tier | Marker | May do | Must not | Budget |
+|---|---|---|---|---|
+| `unit` | plain `#[test]` | pure logic, tempdir filesystem | spawn a process, open a gpui window, sleep, assert on wall-clock | < 10 ms |
+| `ui` | `#[gpui::test]` + `TestAppContext` / `VisualTestContext` | real git fixtures, real key/action dispatch | external language servers, real agent processes, sleep | < 2 s |
+| `external` | `#[ignore = "external: <binary>; see docs/testing.md"]` | real `rust-analyzer` / `typescript-language-server` / `pyright` / `gopls`, real OS process-tree semantics | — | dedicated CI job only |
+
+Tiers 1 and 2 are the PR gate. Tier 3 never is.
+
+Today that is 2,186 plain `#[test]` and 1,006 `#[gpui::test]` in `crates/app` alone — the split
+already roughly exists, it has just never been named or enforced.
+
+A `unit` test that shells out to `git` against a tempdir repository is still a `unit` test: the
+budget is what separates the tiers in practice, and a seeded fixture repo costs a few hundred
+milliseconds of `git` at most. What pushes a test into `ui` is needing a window; what pushes it
+into `external` is needing a binary the repo does not vendor or a real agent process.
+
+## What deserves a test
+
+- One test per behaviour a **user** could notice — not one per branch of the implementation.
+- One regression test per fixed bug, named after the symptom.
+- Pure derivations (colours, geometry, formatting) get **one table-driven invariant test**, not one
+  test per input.
+- Explicitly not worth a test: a constant equalling its own literal; a field round-tripping through
+  its own getter; "a render function returned some element"; exhaustively enumerating a sweep the
+  code itself already iterates over.
+
+## Deletion criteria
+
+The five reasons a test gets removed. A removal cites exactly one of them, by number, in the PR
+body:
+
+1. **Sweep redundancy** — N tests differing only by an input value. Collapse to one table-driven test.
+2. **Implementation mirroring** — the assertion recomputes what the code under test does.
+3. **Vacuous** — would still pass with the feature removed, or only asserts on test-local data.
+4. **Pixel over-specification** — asserts an exact `Pixels` literal with no invariant behind it.
+   Keep `all_three_elbow_pieces_paint_their_horizontal_stroke_on_the_very_same_pixel_row`;
+   drop the "...equals 12.5px" siblings.
+5. **Duplicate coverage across layers** — the same behaviour asserted in both a `unit` and a `ui`
+   test. Keep the cheaper one, unless the wiring itself is what is at risk.
+
+## Hard rules
+
+- **No `thread::sleep` in test code.** Use `cx.run_until_parked()` or
+  `test_support::wait_until(deadline, cond)`. There are **303** existing wall-clock waits, including
+  ten `from_millis(500)`; they are the purge issue's problem, but the rule starts here. The
+  `from_secs(9)` this list used to name is gone: `hooks::server`'s
+  `many_slow_clients_at_once_cannot_starve_a_real_hook` now waits on the drip-feeders' own
+  cut-off signal instead of guessing a duration.
+- Any test that spawns a process owns its teardown, via an RAII guard from `test-support`.
+- Any test that opens a file watcher shuts it down. A leaked watcher thread fails the tier's budget.
+- Every `#[ignore]` carries a reason string naming exactly what is missing.
+- Existing conventions that stay, unchanged: fixtures live under a sibling `testdata/` directory,
+  never inlined as string literals; test modules are named by concern
+  (`mod change_row_selection_tests`, not `mod tests`).
+
+## `crates/test-support`
+
+The shared fixtures, dev-dependency only. It is **`gpui`-free** so `wt-core`, `pty-core` and
+`lsp-core` can dev-depend on it without violating
+[`decisions.md` §1](architecture/decisions.md) — including behind a Cargo feature, which would not
+help: workspace feature unification would pull `gpui` into their dev graph anyway. GPUI-flavoured
+helpers live in `crates/app/src/test_support.rs` instead.
+
+Add it with `test-support = { path = "../test-support" }` under `[dev-dependencies]`, then
+`use test_support::{git, seed_repo};`.
+
+### Running git
+
+| Helper | Does |
+|---|---|
+| `git(dir, &["commit", "-m", "x"])` | runs git, panics with both streams on failure |
+| `git_output(dir, args) -> String` | trimmed stdout of a successful invocation |
+| `git_try(dir, args) -> Output` | runs git without asserting — for tests whose subject *is* a failure |
+| `git_with_env(dir, args, &[("GIT_AUTHOR_DATE", …)])` | as `git`, with extra environment variables |
+| `write_file(dir, "src/a.rs", "…")` | writes a `dir`-relative file, creating parent directories |
+| `commit(dir, "a.txt", "1\n", "message")` | write + `add` + `commit` |
+| `commit_at(dir, "a.txt", "1\n", "message", 1_700_000_000)` | as `commit`, with an explicit author/committer timestamp |
+
+Argv, never an interpolated shell string — the same rule production code follows (`CLAUDE.md`).
+
+### Seeding repositories
+
+| Helper | Yields |
+|---|---|
+| `seed_repo() -> TempDir` | branch `main`, one commit (`file.txt`), clean tree |
+| `seed_repo_at(dir)` | the same, into an existing directory |
+| `seed_empty_repo() -> TempDir` / `seed_empty_repo_at(dir)` | branch `main`, identity configured, **no** commits |
+| `seed_three_commits(dir)` | `first`/`second`/`third`, each rewriting `a.txt`, clean tree |
+| `seed_commits(dir, count)` | `count` commits, cheap (`--allow-empty` after the first) |
+| `seed_bare_remote() -> TempDir` | a bare repo on `main`, as a push/fetch target |
+| `add_worktree(repo, "feature", &path)` | a real second working copy on a new branch |
+
+Every seeded repo configures `user.email`, `user.name`, `commit.gpgsign=false` and
+`core.autocrlf=false`, so a fixture behaves the same on a machine with commit signing configured
+globally, and on Windows — where git otherwise ships `core.autocrlf=true` and would put `\r` into
+every content, diff and blame assertion.
+
+### Waiting and teardown
+
+| Helper | Does |
+|---|---|
+| `wait_until(deadline: Duration, cond) -> bool` | polls until `cond` holds or the deadline passes; the caller writes the assertion message |
+| `wait_until_every(interval, deadline, cond) -> bool` | as `wait_until`, with an explicit poll interval — for a check that perturbs what it measures |
+| `stays_false(window: Duration, cond) -> bool` | the inverse — proves something stays quiet for a bounded window |
+| `ChildGuard` | kill-on-drop wrapper for a spawned `Child`; derefs to `Child`, plus `spawn`, `is_running`, `kill_and_wait`, `into_inner` |
+
+`wait_until` is the *only* sanctioned wall-clock wait in the workspace. Anything a GPUI executor
+drives waits with `cx.run_until_parked()` instead.
+
+Reach for `wait_until_every` only when the check itself is not free — a probe that takes a
+connection slot in the server it is asking about, a check that contends for the lock the subject
+needs. At `wait_until`'s 10 ms such a check measures its own polling rate. Prefer, where it exists,
+a signal the subject already emits: perturbing nothing beats polling coarsely.
+
+### GPUI fixtures (`crates/app/src/test_support.rs`)
+
+- `open_test_app(cx, repo_path) -> (Entity<AdeApp>, &mut VisualTestContext)` — a real test window
+  with in-memory settings, so a test never reads or writes the developer's `settings.toml`.
+- `open_test_app_with_settings(cx, repo_path, settings, settings_path)` — for tests that assert on
+  what gets persisted.
+
+`crate::root::focus::palette_focus_tests::open_test_app` is a re-export of the first, kept so the
+~500 call sites that still name it keep resolving while they are migrated (GitHub issue #425).
+
+## Running tests
+
+`cargo nextest run --workspace` is part of the pre-commit gate (`CLAUDE.md`, `/check`) and runs on
+every PR in CI, on Linux and macOS. It covers the `unit` and `ui` tiers: the `external` tier is
+`#[ignore]`d, and nextest skips ignored tests unless asked for them.
+
+**Windows is not a test platform yet.** Its CI job builds the workspace and runs only
+`status_bar::process_stats`, the FFI backend that exists nowhere else. The full suite does not pass
+there — a single trial run scored 134 failures and 26 timeouts, mostly paths formatted into strings
+and forward slashes baked into expected values — and GitHub issue #440 tracks fixing it. Until then
+nothing asks a contributor to run the suite on Windows, and a Windows result is not a gate.
+
+While iterating, scope it to what you touched:
+
+```sh
+cargo nextest run -p wt-core
+cargo nextest run -p test-support
+cargo nextest run -p app --lib -E 'test(/my_concern_tests/)'
+```
+
+### The `external` tier
+
+Never on a PR. It runs in `ci.yml`'s `External (real language servers)` job, on a nightly schedule
+and on `workflow_dispatch`. To run it locally you need the servers on `PATH` and a live npm
+registry (one fixture does its own `npm install typescript@5`):
+
+```sh
+rustup component add rust-analyzer
+npm install -g "@vue/language-server@3.3.8" typescript-language-server pyright
+cargo nextest run --workspace --profile external --run-ignored all
+```
+
+`--profile external` inherits the `ci` profile and raises `slow-timeout` to 120s — a real
+handshake plus a first index pass legitimately takes seconds, which the default 30s/2min budget
+cannot tell apart from a hang.
+
+Only `@vue/language-server` is pinned, to the version `crate::language`'s own module docs were
+written against. `typescript-language-server` and `pyright` are knowingly unpinned: no commit
+message or comment in this repo records the version their tests were written against, and the only
+established fact is negative — `typescript-language-server@5.3.0` fails them. The nightly job
+prints `npm ls -g --depth=0` so a pin can eventually be derived from a run that actually passes,
+rather than guessed. `gopls` is not installed: `crate::language` gives Go `lsp: None`, so nothing
+in this workspace ever spawns it.


### PR DESCRIPTION
Closes #427. Closes #425. Closes #426.

## What

`cargo nextest run --workspace` passes, and it is now part of both CI and the pre-commit gate.
Before this, the suite was deliberately outside the gate (#348): a real run left most of the
GPUI-window-touching tests failing or hanging, so a clean `/check` said nothing about whether the
tests worked.

What changed, from a reviewer's point of view:

- **The gate has a fourth step.** `CLAUDE.md`, `/check` and `.claude/hooks/pre-commit-check.sh` all
  run `cargo nextest run --workspace` now. A broken test blocks a commit again.
- **The runner is `cargo-nextest`, not `cargo test`.** `.config/nextest.toml` gives each test its
  own process, a 30s slow warning and a 2-minute kill, and `retries = 0`. A hung test now fails
  that test instead of sitting on the whole run forever — the failure mode that made the suite
  unrunnable in the first place.
- **Every test belongs to a written tier.** `docs/testing.md` defines `unit` (plain `#[test]`, pure
  logic or a tempdir, < 10 ms), `ui` (`#[gpui::test]` against a real window) and `external` (real
  language-server processes, `#[ignore]`d, nightly job only, `--profile external`).
- **The suite is smaller.** `crates/app` goes from 3204 to 2827 tests: duplicates, tests asserting
  the framework rather than our code, and tests whose subject no longer exists were purged against
  the criteria in `docs/testing.md`, not by feel.
- **Fixtures are shared instead of copy-pasted.** `fn git(dir, args)` appeared ~30 times across the
  workspace; it now lives once in the new `crates/test-support`, alongside repo seeding and
  wall-clock-free waiting. The `gpui`-dependent half lives in `crates/app/src/test_support.rs` so
  the core crates can dev-depend on the shared one without acquiring `gpui`.
- **One real production bug fell out of it.** `child_pids_of` read Linux's `/proc` on every unix,
  so on macOS the descendant walk always returned nothing and the tree kill silently degraded to
  `killpg` on the direct child's group — closing a terminal pane leaked the shell's background
  jobs. macOS now walks the tree with `libproc`'s `proc_listchildpids`, and `pid_exists` moved to
  the portable POSIX `kill(pid, 0)` probe (`pty-core` and `lsp-core` both).
- **CI runs the same thing you run.** Linux and macOS run the full suite per PR; Windows builds,
  clippies and runs only its platform-specific sampling tests, because the rest does not pass there
  yet (#440, deferred out of #427 deliberately). A nightly job runs the `external` tier with real
  servers installed.
- **Both convention ratchets got tighter** on the way through: glob imports 304 → 300, render
  adapter calls 222 → 170.

This is the squash of the twelve reviewed sub-PRs that landed on `chore/test-suite-health`
(#429, #430, #432, #434, #435, #436, #438, #439, #441, #444, #445, #446); the commit body lists
them. It was squashed rather than rebased commit-by-commit because master's own comment sweep
touches the same regions as most of them, which would have meant conflict-resolving twelve
intermediate states that are not independently verifiable. The per-PR history stays on GitHub.

## Testing

- [x] `/check` (conventions + fmt + clippy `-D warnings` + `cargo nextest run --workspace`) passes
      locally — **3156 passed, 34 skipped, 0 failed** in 148s on macOS; conventions ratchet at
      300/300 globs and 170/170 adapter calls
- [ ] `verify` capture attached below, if this touches `render.rs`/`theme.rs`/layout — **not
      applicable**: every `render.rs`/`theme.rs` change here is inside a `#[cfg(test)]` module
      (imports, fixtures, test renames). No production render path changed, so there is nothing to
      capture
- [x] New/changed behavior has a real test, in the right tier (docs/testing.md) — the macOS
      process-tree fix is covered by `drop_terminates_entire_process_tree_including_escaped_grandchild`
      and `pid_exists_separates_a_live_process_from_a_reaped_one` in both crates
- [ ] If this touches the `external` tier, it was run with the servers installed — **not run**:
      needs real `rust-analyzer`/`typescript-language-server`/`vue-language-server`/`pyright`
      installed locally. That tier is `#[ignore]`d and is what the new nightly CI job exists to run

The 34 skipped are the `external` tier plus the platform-gated tests that do not apply on macOS.

## Architecture notes

- New crate: `crates/test-support` — `gpui`-free, depends only on `tempfile`, so `wt-core`,
  `pty-core` and `lsp-core` can dev-depend on it without pulling `gpui` into their dev graph.
  Anything needing `gpui` lives in `crates/app/src/test_support.rs` instead. The reasoning, and why
  a Cargo feature flag would have silently broken §1, is written up as a new
  `docs/architecture/decisions.md` §9.
- `cargo tree -e normal,dev,build -i gpui` reaching only `crates/app` is now a checkable invariant
  rather than a convention.
