### PR TITLE
fix(app): refresh the Changes pane and its counter without visiting the tab

### DIFF
--- a/crates/app/src/code_surface/tabs.rs
+++ b/crates/app/src/code_surface/tabs.rs
@@ -41,6 +41,18 @@ impl AdeApp {
         self._load_diff_task = Some(self.spawn_diff_reload(root, cx));
     }
 
+    /// Re-runs the same reload [`Self::refresh_diff`] does, but only when no reload is already in
+    /// flight - GitHub issue #415. The watcher/poll loop driving this fires far faster than the
+    /// five git queries take on a large worktree, so an ungated call would cancel its own
+    /// still-running predecessor on every tick (assigning [`Self::_load_diff_task`] drops the
+    /// previous task) and the pane could starve indefinitely while an agent keeps writing.
+    pub(crate) fn refresh_diff_if_idle(&mut self, cx: &mut Context<Self>) {
+        if self.diff_reload_in_flight {
+            return;
+        }
+        self.refresh_diff(cx);
+    }
+
     /// The real background git reload both [`Self::load_diff`] and [`Self::refresh_diff`] run -
     /// the five real `wt_core` queries (`diff_against_base`, `staged_paths`, `dirty_paths`,
     /// `diff_against_head`, `commits_since_base`), off the foreground thread, folded into exactly
@@ -48,6 +60,10 @@ impl AdeApp {
     /// they do *before* this runs (see [`Self::refresh_diff`]'s own docs), never in what happens
     /// once the real answer comes back.
     fn spawn_diff_reload(&mut self, root: PathBuf, cx: &mut Context<Self>) -> gpui::Task<()> {
+        // Set here rather than in the two callers so every spawn is covered by construction,
+        // including the one that cancels a still-running predecessor: the replacement task owns
+        // the flag from this point, and its own completion below is what clears it.
+        self.diff_reload_in_flight = true;
         cx.spawn(async move |this, cx| {
             let (diff_result, staged_result, dirty_result, uncommitted_result, commits_result) = cx
                 .background_executor()
@@ -85,6 +101,7 @@ impl AdeApp {
                 })
                 .await;
             let _ = this.update(cx, |this, cx| {
+                this.diff_reload_in_flight = false;
                 match diff_result {
                     Ok((base, totals)) => {
                         this.diff_state = DiffLoadState::Loaded(base);
@@ -2165,5 +2182,221 @@ mod terminal_link_click_tests {
                 "a link to a nonexistent path must not add a real tab either"
             );
         });
+    }
+}
+
+#[cfg(test)]
+mod diff_self_refresh_tests {
+    use crate::root::focus::palette_focus_tests;
+    use crate::root::{AdeApp, FILE_TREE_WATCH_SETTLE, FILE_TREE_WATCH_TICK};
+    use crate::settings::store as settings_store;
+    use gpui::{Entity, TestAppContext, VisualTestContext};
+    use std::path::PathBuf;
+    use std::time::{Duration, Instant};
+
+    fn git_repo(dir: &std::path::Path, args: &[&str]) {
+        let output = std::process::Command::new("git")
+            .current_dir(dir)
+            .args(args)
+            .output()
+            .expect("failed to spawn git");
+        assert!(
+            output.status.success(),
+            "git {:?} failed in {:?}:\nstderr: {}",
+            args,
+            dir,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    /// A repo on a feature branch with one committed file, so `diff_against_head` has a real base
+    /// to answer against.
+    fn repo_on_a_feature_branch() -> tempfile::TempDir {
+        let repo = tempfile::tempdir().expect("tempdir");
+        git_repo(repo.path(), &["init", "-b", "main"]);
+        git_repo(repo.path(), &["config", "user.email", "test@example.com"]);
+        git_repo(repo.path(), &["config", "user.name", "Test User"]);
+        std::fs::write(repo.path().join("a.txt"), "1\n").expect("write a.txt");
+        git_repo(repo.path(), &["add", "."]);
+        git_repo(repo.path(), &["commit", "-m", "initial"]);
+        git_repo(repo.path(), &["checkout", "-b", "feature"]);
+        repo
+    }
+
+    /// Unlike `palette_focus_tests::open_test_app`, this passes a real settings path: without one
+    /// `AdeApp::start_file_tree_watch` returns before arming anything, so the watch loop these
+    /// tests exercise would never run at all.
+    fn open_watched_app(
+        cx: &mut TestAppContext,
+        repo_path: PathBuf,
+        settings_path: PathBuf,
+    ) -> (Entity<AdeApp>, &mut VisualTestContext) {
+        cx.add_window_view(|window, cx| {
+            AdeApp::new_with_settings(
+                Some(repo_path),
+                true,
+                settings_store::Settings::default(),
+                Some(settings_path),
+                window,
+                cx,
+            )
+        })
+    }
+
+    fn uncommitted_paths(app: &AdeApp) -> Vec<PathBuf> {
+        app.uncommitted_diff
+            .loaded()
+            .map(|diff| diff.files.iter().map(|file| file.path.clone()).collect())
+            .unwrap_or_default()
+    }
+
+    /// The watcher's callback is delivered by the OS on its own thread, so this cannot be a purely
+    /// simulated clock - the same real-time bounded wait `crate::sidebar::file_tree_watch`'s own
+    /// tests use, with the executor's timers advanced on each pass so the loop's tick/settle
+    /// waits actually elapse.
+    fn wait_until(
+        app: &Entity<AdeApp>,
+        cx: &mut VisualTestContext,
+        mut done: impl FnMut(&AdeApp) -> bool,
+    ) -> bool {
+        let deadline = Instant::now() + Duration::from_secs(15);
+        while Instant::now() < deadline {
+            cx.executor()
+                .advance_clock(FILE_TREE_WATCH_TICK + FILE_TREE_WATCH_SETTLE);
+            cx.run_until_parked();
+            if app.read_with(cx, |app, _| done(app)) {
+                return true;
+            }
+            std::thread::sleep(Duration::from_millis(25));
+        }
+        false
+    }
+
+    /// GitHub issue #415's headline symptom: an agent writes a file and the Changes pane never
+    /// hears about it, because the only steady-state reload was the user navigating *to* the
+    /// Changes tab. Nothing here touches `set_right_sidebar_view`.
+    #[gpui::test]
+    fn a_write_after_load_reaches_the_changes_pane_without_visiting_the_tab(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = repo_on_a_feature_branch();
+        let settings = tempfile::tempdir().expect("settings tempdir");
+        let (app, cx) = open_watched_app(
+            cx,
+            repo.path().to_path_buf(),
+            settings.path().join("settings.toml"),
+        );
+        cx.run_until_parked();
+
+        assert!(
+            app.read_with(cx, |app, _| uncommitted_paths(app))
+                .is_empty(),
+            "sanity: a freshly opened clean worktree has no uncommitted files"
+        );
+
+        // What an agent does: write a file nothing in the app initiated.
+        std::fs::write(repo.path().join("agent-wrote-this.txt"), "hello\n").expect("write");
+
+        let target = PathBuf::from("agent-wrote-this.txt");
+        assert!(
+            wait_until(&app, cx, |app| uncommitted_paths(app).contains(&target)),
+            "a file written behind the app's back must appear in the Changes pane on its own, \
+             without the user switching to the Changes tab first"
+        );
+    }
+
+    /// The other half of #415: the `+n`/`-n` totals live in the sidebar header band, which is
+    /// rendered above all three views, so they have to self-update wherever the user is standing.
+    #[gpui::test]
+    fn the_header_totals_self_update_after_a_write(cx: &mut TestAppContext) {
+        let repo = repo_on_a_feature_branch();
+        let settings = tempfile::tempdir().expect("settings tempdir");
+        let (app, cx) = open_watched_app(
+            cx,
+            repo.path().to_path_buf(),
+            settings.path().join("settings.toml"),
+        );
+        cx.run_until_parked();
+
+        std::fs::write(repo.path().join("a.txt"), "1\n2\n3\n").expect("rewrite a.txt");
+
+        assert!(
+            wait_until(&app, cx, |app| app
+                .diff_totals
+                .is_some_and(|(add, _)| add >= 2)),
+            "the header's +n/-n totals must reflect a write the app did not initiate"
+        );
+    }
+
+    /// The in-flight guard: the watch loop ticks far faster than five git queries take on a real
+    /// worktree, and assigning `_load_diff_task` drops whatever was still running - so an ungated
+    /// refresh would cancel its own predecessor every tick and could never finish.
+    #[gpui::test]
+    fn a_refresh_is_skipped_while_a_reload_is_still_in_flight(cx: &mut TestAppContext) {
+        let repo = repo_on_a_feature_branch();
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+
+        assert!(
+            !app.read_with(cx, |app, _| app.diff_reload_in_flight),
+            "a settled app has no reload running"
+        );
+
+        std::fs::write(repo.path().join("b.txt"), "b\n").expect("write b.txt");
+
+        // Stand in for a reload that has been spawned but has not landed yet, then ask for the
+        // refresh the watch loop would ask for on its next tick.
+        app.update(cx, |app, cx| {
+            app.diff_reload_in_flight = true;
+            app.refresh_diff_if_idle(cx);
+        });
+        cx.run_until_parked();
+
+        let target = PathBuf::from("b.txt");
+        assert!(
+            !app.read_with(cx, |app, _| uncommitted_paths(app))
+                .contains(&target),
+            "the guard must have skipped the refresh, so the new file is not picked up yet"
+        );
+
+        // Once the in-flight reload lands, the very next tick does the work.
+        app.update(cx, |app, cx| {
+            app.diff_reload_in_flight = false;
+            app.refresh_diff_if_idle(cx);
+        });
+        cx.run_until_parked();
+
+        assert!(
+            app.read_with(cx, |app, _| uncommitted_paths(app))
+                .contains(&target),
+            "with no reload in flight the same call must genuinely refresh"
+        );
+    }
+
+    /// `spawn_diff_reload` owns the flag for every spawn, including the manual button's, so a
+    /// cancelled-and-replaced reload can never strand it `true` and wedge the watcher refresh off
+    /// for the rest of the session.
+    #[gpui::test]
+    fn a_replaced_reload_still_clears_the_in_flight_flag(cx: &mut TestAppContext) {
+        let repo = repo_on_a_feature_branch();
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+
+        // Two reloads back to back: the second drops the first's still-running task.
+        app.update(cx, |app, cx| {
+            app.refresh_diff(cx);
+            app.refresh_diff(cx);
+        });
+        assert!(
+            app.read_with(cx, |app, _| app.diff_reload_in_flight),
+            "a spawned reload must mark itself in flight"
+        );
+        cx.run_until_parked();
+
+        assert!(
+            !app.read_with(cx, |app, _| app.diff_reload_in_flight),
+            "the surviving reload's completion must clear the flag, or every later watcher-driven \
+             refresh is silently skipped forever"
+        );
     }
 }

--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -459,6 +459,10 @@ pub struct AdeApp {
     /// [`Self::current_diff`]'s docs for exactly which [`DiffLoadState`]/[`DiffBase`]
     /// combinations count).
     pub(crate) diff_totals: Option<(u32, u32)>,
+    /// Whether a `Self::spawn_diff_reload` task is running right now, so the watcher-driven
+    /// refresh behind GitHub issue #415 can skip a tick instead of cancelling a reload that is
+    /// still working - see [`Self::refresh_diff_if_idle`].
+    pub(crate) diff_reload_in_flight: bool,
     /// Every open agent's own **review** state (GitHub issue #225) - its captured baseline, the
     /// diff loaded against that baseline, and which file it has open. Keyed by
     /// [`crate::work_surface::agents::AgentId`].

--- a/crates/app/src/root/state.rs
+++ b/crates/app/src/root/state.rs
@@ -342,6 +342,7 @@ impl AdeApp {
             find_bar_focus_handle: cx.focus_handle(),
             diff_state: DiffLoadState::Loading,
             diff_totals: None,
+            diff_reload_in_flight: false,
             agent_reviews: HashMap::new(),
             review_baseline_state,
             review_baseline_path,
@@ -1455,6 +1456,15 @@ impl AdeApp {
                         return false;
                     }
                     this.load_file_tree(root.clone(), cx);
+                    // GitHub issue #415: the Changes pane and the sidebar's `+n`/`-n` totals used
+                    // to have no time- or watcher-driven trigger at all - the only steady-state
+                    // reload was the user navigating *to* the Changes tab, so an agent's writes
+                    // stayed invisible until then. Riding this loop rather than adding a second
+                    // watcher covers both halves: the watcher arm catches working-tree writes
+                    // within one tick, and the poll arm catches the `.git/`-only changes
+                    // (`git add`, `git commit`) that `spawn_file_tree_watcher` deliberately
+                    // filters out and would otherwise never report.
+                    this.refresh_diff_if_idle(cx);
                     true
                 });
                 match updated {

--- a/crates/app/src/sidebar/render.rs
+++ b/crates/app/src/sidebar/render.rs
@@ -1733,6 +1733,36 @@ impl AdeApp {
                                     },
                                 )),
                         )
+                    })
+                    // GitHub issue #415's explicit ask ("even better have a refresh button or
+                    // something on the changes pane"). The watcher now keeps the pane current on
+                    // its own, so this is the escape hatch for the cases a filesystem watcher
+                    // structurally cannot cover - a dropped OS event, or a `notify` backend that
+                    // silently stopped delivering - rather than the primary refresh path.
+                    // Deliberately `refresh_diff`, not `load_diff`: the pane keeps showing its
+                    // last real answer for the duration instead of blanking to "Loading".
+                    .when(self.right_sidebar_view == RightSidebarView::Changes, |el| {
+                        el.child(
+                            div()
+                                .id("changes-refresh")
+                                .debug_selector(|| "changes-refresh".to_string())
+                                .flex_none()
+                                .cursor_pointer()
+                                .px(px(5.0))
+                                .rounded(theme::radius::CHIP)
+                                .font(font(theme::font::MONO))
+                                .text_size(self.ui_text_size(12.0))
+                                .text_color(theme::text::GHOST)
+                                .hover(|el| {
+                                    el.bg(theme::surface::ROW_HOVER_ALT)
+                                        .text_color(theme::text::PRIMARY)
+                                })
+                                .tooltip(text_tooltip("Refresh the changes list"))
+                                .child("\u{21bb}")
+                                .on_click(cx.listener(|this, _event: &ClickEvent, _window, cx| {
+                                    this.refresh_diff(cx);
+                                })),
+                        )
                     }),
             )
     }


### PR DESCRIPTION
Closes #415

## What

The Changes pane was **pull-only**. `spawn_diff_reload` (`code_surface/tabs.rs:50`) is the sole writer of every field the pane renders, and its only steady-state trigger was `set_right_sidebar_view` switching *to* the Changes tab — every other caller is a mutation Jerry itself performed (worktree switch, own-editor save, commit, discard). An agent's writes reached nothing.

That one mechanism produces both halves of the report:

- **"Some files are there but not everything"** is the time-sliced form. The files present at your last visit are all correct, so it reads as incompleteness rather than staleness.
- **The stale counter** is the same freeze on `diff_totals`. Its header band is rendered above *all three* views (`sidebar/render.rs:1758`, before the `match`), so it was visibly wrong wherever the user was standing — while the left rail's equivalent, riding the 3s status poll, kept updating beside it.

The fix gives the reload a real trigger by riding the existing file-tree watch loop rather than adding a second OS watcher on the same tree: the watcher arm catches working-tree writes within one tick, and the 5s poll arm catches the `.git/`-only changes (`git add`, `git commit`) that `spawn_file_tree_watcher` deliberately filters out and would otherwise never report.

`refresh_diff_if_idle` gates on a new `diff_reload_in_flight` flag. The loop ticks far faster than five git queries take on a large worktree, and assigning `_load_diff_task` drops whatever it replaces — ungated, it would cancel its own still-running predecessor every tick and could starve while an agent keeps writing. The flag is set inside `spawn_diff_reload` so every spawn is covered by construction, including one replacing a live reload; otherwise a cancelled task's missing completion would strand it `true` and wedge the refresh off for the rest of the session.

Refreshing uses `refresh_diff`, not `load_diff`, so the pane keeps showing its last real answer instead of blanking to `Loading` on every agent keystroke.

Also adds the refresh button the issue asks for ("even better have a refresh button or something on the changes pane"), in the header's existing action cluster beside the totals it refreshes. With the watcher in place it's the escape hatch for what a filesystem watcher structurally cannot cover — a dropped OS event, or a backend that silently stopped delivering — not the primary path.

### One thing this deliberately does not change

Committed files still leave the per-file list. The Uncommitted section (`diff_against_head`) is the only source of per-file rows; Against-main renders none, on an explicit product decision recorded at `sidebar/render.rs:2027-2032` — *"commited files should not appear on the changes tab under against master."* If an agent commits as it goes, files will still disappear from the list, and that may account for part of what the issue describes. Worth deciding separately rather than folding into this fix.

## Why

Investigated before writing anything, and two plausible-sounding causes were checked and **ruled out** rather than fixed:

- `wt_core::diff`'s 300-file / 2 MiB caps are real but feed the Against-main section, which emits zero per-file rows — and they raise a loud truncation row when hit. Not this bug.
- The Windows CRLF theory dies on inspection: `parse_status_porcelain_z` uses `git status -z` (NUL-separated), and `parse_git_diff` uses `str::lines()`, which strips a trailing `\r` anyway.

## Testing

- [x] `/check` (conventions + fmt + clippy `-D warnings`) passes locally
- [ ] `verify` capture attached below, if this touches `render.rs`/`theme.rs`/layout — **not run: no display in this environment** (see Screenshot)
- [x] New/changed behavior has a real test, run manually and confirmed passing

Four new tests in `code_surface::tabs::diff_self_refresh_tests`. **Two of them fail with the wiring disabled and pass with it** — confirmed by temporarily reverting the one-line call, not assumed:

- `a_write_after_load_reaches_the_changes_pane_without_visiting_the_tab` — the headline regression; touches nothing on `set_right_sidebar_view`.
- `the_header_totals_self_update_after_a_write` — the counter half.
- `a_refresh_is_skipped_while_a_reload_is_still_in_flight` — the guard.
- `a_replaced_reload_still_clears_the_in_flight_flag` — the guard can't wedge itself off.

The two loop-driven tests need a real settings path (`start_file_tree_watch` returns early without one, so `palette_focus_tests::open_test_app` never arms the watcher) and a real-time bounded wait for the OS to deliver the watcher callback — matching what `sidebar::file_tree_watch`'s own tests already do for the same reason.

Also run green: `cargo test -p app --lib` for `code_surface::tabs::` (26), `sidebar::` (273), `root::` (141).

## Screenshot

**No capture — this branch was built in a headless container with no display, so `/verify` could not be run.** Flagging rather than leaving the box quietly unchecked.

The button reuses the exact idiom of the two Files-only buttons beside it in the same cluster (identical sizing, padding, chip radius, hover treatment, monospace glyph, tooltip shape), and is gated to the Changes view the same way those are gated to Files. But nobody has looked at it, and it touches `render.rs` — worth a real capture before merge.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E2VFTy4hJKfSnQGoXNzUqf

---
_Generated by [Claude Code](https://claude.ai/code/session_01E2VFTy4hJKfSnQGoXNzUqf)_