### PR TITLE
chore: release prep for v0.1.2 — version bump and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## v0.1.2 — Real app bundles, and a terminal that hears the mouse
+
+### New features
+
+- **Real, launchable app bundles on all three platforms** — Jerry now ships as a real `Jerry.app` and DMG on macOS, a `.desktop` launcher entry with a full icon set on Linux, and a Windows executable carrying its own icon and version resource. Finder no longer has to host the binary in Terminal to launch it, Windows no longer opens a console window alongside it, and the macOS menu bar says "Jerry" instead of "app".
+- **The mouse works in the terminal** — clicks, hovers and drags now reach the program running in an agent shell (xterm mouse reporting). An interactive TUI like Claude Code responds to the mouse instead of ignoring it; when a program asks for no reporting, text selection behaves exactly as before.
+
+### Improvements
+
+- A GUI-launched Jerry resolves your real login-shell `PATH`, so agent detection, language-server detection and the sidebar's availability checks find the same binaries they would from a terminal — Homebrew, `~/.cargo/bin`, nvm and the rest.
+- The Changes pane and its counter refresh from an agent's own writes, instead of only when you switch to that tab. The list no longer sits frozen at whatever the worktree looked like the last time you opened it, which read as "some files are missing" rather than as staleness.
+- The test suite is green and back in both the pre-commit gate and CI, running under `cargo nextest` so a hung test fails on its own instead of stalling the whole run.
+- The README is a real product page, with images and badges.
+
+**Full Changelog**: https://github.com/ColinEspinas/jerry/compare/v0.1.1...v0.1.2
+
+## v0.1.1 — Settings that persist on Windows
+
+### Improvements
+
+- Settings load and save on Windows. The settings path resolved `$HOME` only, which Windows does not set, so saving silently did nothing and every launch fell back to an in-memory default — edits appeared to apply but were never written. It now resolves `%USERPROFILE%` there. Runs launched from Git Bash or WSL2 were unaffected, which is why this went unnoticed.
+
+**Full Changelog**: https://github.com/ColinEspinas/jerry/compare/v0.1.0...v0.1.1
+
 ## v0.1.0 — Search, review, and a real history view
 
 ### New features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,7 +288,7 @@ checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "app"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "alacritty_terminal",
  "anyhow",
@@ -4776,7 +4776,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lsp-core"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "dunce",
  "libc",
@@ -6149,7 +6149,7 @@ dependencies = [
 
 [[package]]
 name = "pty-core"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "filedescriptor",
@@ -7937,7 +7937,7 @@ dependencies = [
 
 [[package]]
 name = "test-support"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "tempfile",
 ]
@@ -9908,7 +9908,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wt-core"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "gix",
  "sha2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 [workspace.package]
 # Single source of truth for the release version - crates inherit via `version = { workspace =
 # true }` rather than pinning their own.
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 publish = false
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## What

Release prep for **v0.1.2**, in the order `.github/workflows/release.yml` requires: the workspace
version has to match the tag before `v0.1.2` is pushed, since the workflow's first job fails fast
otherwise (issue #317's guard, `.claude/hooks/check-release-version.sh`).

- `chore: bump version to 0.1.2` — `[workspace.package] version`, plus the five workspace crates
  that inherit it in `Cargo.lock`. No crate manifest pins its own version.
- `docs: add the v0.1.1 and v0.1.2 changelog entries` — v0.1.2, and **v0.1.1, which was tagged and
  released on GitHub but never landed in `CHANGELOG.md`**. This catches that up rather than leaving
  a hole between v0.1.0 and v0.1.2.

The v0.1.2 entry covers the two features since v0.1.1 (real app bundles on all three platforms,
xterm mouse reporting in the terminal), the login-shell `PATH` resolution that makes agent
detection work in a GUI-launched build, the Changes pane refreshing from an agent's own writes,
and the test suite returning to the gate.

## Testing

- [x] `/check` (conventions + fmt + clippy `-D warnings` + `cargo nextest run --workspace`) passes
      locally — run by the pre-commit hook on both commits
- [ ] `verify` capture — not applicable, no UI surface is touched
- [x] New/changed behavior has a real test, in the right tier — not applicable beyond the existing
      guard: `check-release-version.sh v0.1.2` passes ("workspace version 0.1.2 matches tag
      v0.1.2"), which is the same check the release workflow runs against the pushed tag

Worth flagging separately: the first gate run failed on
`status_bar::process_stats::tests::sample_processes_reports_real_nonzero_cpu_for_a_real_busy_child`
— it expects a core-pinned child to report close to 100% of one core and measured 19.9% on a
loaded machine. It passes in isolation and passed on the re-run, so nothing here is a regression
(a version-string bump cannot affect CPU sampling), but that test is hostage to machine load in
exactly the way `docs/testing.md` now warns against. No open issue tracks it.
