### PR TITLE
fix(app): scroll the command palette to follow the keyboard selection (#413)

### DIFF
--- a/crates/app/src/palette/render.rs
+++ b/crates/app/src/palette/render.rs
@@ -376,6 +376,12 @@ impl AdeApp {
         }
         let next = (self.palette_selected as i32 + delta).clamp(0, total as i32 - 1);
         self.palette_selected = next as usize;
+        // Moving the highlight has to move the viewport with it, or the selection walks off the
+        // bottom and `⏎` runs a row the user cannot see (GitHub issue #413). Resolved on the next
+        // prepaint against real child bounds, and a no-op when the row is already fully visible.
+        if let Some(child) = palette::row_child_index(&groups, self.palette_selected) {
+            self.palette_results_scroll_handle.scroll_to_item(child);
+        }
         cx.notify();
     }
 
@@ -839,6 +845,9 @@ impl AdeApp {
 
         let mut container = div()
             .id("palette-groups")
+            // Test-only, as above: the results viewport's own painted box, so a test can assert a
+            // row is inside it rather than re-deriving the viewport from theme constants.
+            .debug_selector(|| "palette-results".to_string())
             .flex_1()
             .min_h_0()
             .overflow_y_scroll()
@@ -847,9 +856,18 @@ impl AdeApp {
             .flex_col()
             .py(px(4.0));
 
+        // Headers and rows are children of the scroller itself rather than of a per-group wrapper,
+        // so `palette_results_scroll_handle`'s child bounds line up with
+        // `palette::row_child_index` and a row can actually be scrolled to. The old wrapper was a
+        // bare `flex_col` with no styling of its own, so this lays out identically.
         let mut flat_index = 0usize;
         for group in groups {
-            container = container.child(self.render_palette_group(group, &mut flat_index, cx));
+            container = container.child(self.render_palette_group_header(group));
+            for entry in &group.entries {
+                let index = flat_index;
+                flat_index += 1;
+                container = container.child(self.render_palette_row(entry, index, cx));
+            }
         }
 
         // See `crate::sidebar::render::AdeApp::render_file_tree`'s own docs on why the scrollbar
@@ -871,47 +889,35 @@ impl AdeApp {
             .into_any_element()
     }
 
-    pub(in crate::palette) fn render_palette_group(
+    /// One group's header band - its label and how many rows it contributes. The rows themselves
+    /// are siblings of this, not children; see [`Self::render_palette_groups`].
+    pub(in crate::palette) fn render_palette_group_header(
         &self,
         group: &palette::PaletteGroup,
-        flat_index: &mut usize,
-        cx: &mut Context<Self>,
     ) -> impl IntoElement {
-        let mut el = div()
+        div()
             .id(format!("palette-group-{}", group.label))
             .flex()
-            .flex_col()
+            .items_center()
+            .gap(px(7.0))
+            .px(px(12.0))
+            .pt(px(7.0))
+            .pb(px(4.0))
             .child(
                 div()
-                    .flex()
-                    .items_center()
-                    .gap(px(7.0))
-                    .px(px(12.0))
-                    .pt(px(7.0))
-                    .pb(px(4.0))
-                    .child(
-                        div()
-                            .font(font(theme::font::SANS))
-                            .font_weight(gpui::FontWeight::SEMIBOLD)
-                            .text_size(self.ui_text_size(9.5))
-                            .text_color(theme::palette::GROUP_HEADER)
-                            .child(group.label.to_uppercase()),
-                    )
-                    .child(
-                        div()
-                            .font(font(theme::font::MONO))
-                            .text_size(self.ui_text_size(9.5))
-                            .text_color(theme::text::GHOSTER)
-                            .child(group.entries.len().to_string()),
-                    ),
-            );
-
-        for entry in &group.entries {
-            let index = *flat_index;
-            *flat_index += 1;
-            el = el.child(self.render_palette_row(entry, index, cx));
-        }
-        el
+                    .font(font(theme::font::SANS))
+                    .font_weight(gpui::FontWeight::SEMIBOLD)
+                    .text_size(self.ui_text_size(9.5))
+                    .text_color(theme::palette::GROUP_HEADER)
+                    .child(group.label.to_uppercase()),
+            )
+            .child(
+                div()
+                    .font(font(theme::font::MONO))
+                    .text_size(self.ui_text_size(9.5))
+                    .text_color(theme::text::GHOSTER)
+                    .child(group.entries.len().to_string()),
+            )
     }
 
     /// One result row: a kind chip (command/agent-badge/language, per [`palette::EntryTarget`]),
@@ -958,6 +964,11 @@ impl AdeApp {
 
         let mut row = div()
             .id(("palette-row", index as u64))
+            // Test-only (a no-op outside test builds, like every other `debug_selector` in this
+            // codebase) - lets a real render test read a row's own painted bounds back with
+            // `VisualTestContext::debug_bounds` and prove the selected row really sits inside the
+            // results viewport, rather than trusting that scrolling "probably" happened.
+            .debug_selector(move || format!("palette-row-{index}"))
             .cursor_pointer()
             .flex()
             .items_center()
@@ -1565,5 +1576,220 @@ mod palette_language_server_step_tests {
                  when there are none - it would open an empty step and do nothing"
             );
         });
+    }
+}
+
+/// The results list is a real scrolling viewport, so moving the highlight with `↑`/`↓` has to
+/// bring the highlighted row with it (GitHub issue #413). Asserted against the row's and the
+/// viewport's genuinely painted boxes, since an index that moves while the viewport stays put is
+/// exactly the bug and reads as correct from the render code alone.
+#[cfg(test)]
+mod palette_scroll_tests {
+    use crate::palette::state as palette;
+    use crate::root::focus::palette_focus_tests;
+    use crate::root::scrollbar::ScrollableHandle;
+    use crate::root::{AdeApp, TogglePalette};
+    use gpui::{Bounds, Entity, Pixels, TestAppContext, VisualTestContext};
+
+    /// `VisualTestContext::debug_bounds` takes a `&'static str`, so a row's selector cannot be
+    /// interpolated from its index and has to be looked up here instead. Long enough to cover
+    /// every row the fixture below produces, which [`row_selector`] asserts rather than assumes.
+    const ROW_SELECTORS: [&str; 24] = [
+        "palette-row-0",
+        "palette-row-1",
+        "palette-row-2",
+        "palette-row-3",
+        "palette-row-4",
+        "palette-row-5",
+        "palette-row-6",
+        "palette-row-7",
+        "palette-row-8",
+        "palette-row-9",
+        "palette-row-10",
+        "palette-row-11",
+        "palette-row-12",
+        "palette-row-13",
+        "palette-row-14",
+        "palette-row-15",
+        "palette-row-16",
+        "palette-row-17",
+        "palette-row-18",
+        "palette-row-19",
+        "palette-row-20",
+        "palette-row-21",
+        "palette-row-22",
+        "palette-row-23",
+    ];
+
+    fn row_selector(index: usize) -> &'static str {
+        ROW_SELECTORS
+            .get(index)
+            .copied()
+            .expect("ROW_SELECTORS must cover every row this fixture builds")
+    }
+
+    /// An open palette whose results genuinely overflow, which is the only state issue #413 is
+    /// about: the commands the palette always offers fill ten rows, which fit, so a real "Recent
+    /// Files" group is added on top - `changed` is what puts a file in that group with an empty
+    /// query, the same way a repository with uncommitted additions does.
+    fn open_overflowing_palette<'a>(
+        cx: &'a mut TestAppContext,
+        root: &std::path::Path,
+    ) -> (Entity<AdeApp>, &'a mut VisualTestContext) {
+        let (app, cx) = palette_focus_tests::open_test_app(cx, root.to_path_buf());
+        cx.run_until_parked();
+
+        app.update(cx, |app, _| {
+            app.palette_file_candidates = (0..8)
+                .map(|i| palette::FileCandidate {
+                    path: root.join(format!("src/fixture{i}.rs")),
+                    name: format!("fixture{i}.rs"),
+                    dir: "src".to_string(),
+                    add: 1,
+                    del: 0,
+                    changed: Some(palette::FileChangeKind::Added),
+                })
+                .collect();
+        });
+
+        cx.dispatch_action(TogglePalette);
+        cx.run_until_parked();
+        assert!(
+            app.read_with(cx, |app, _| app.palette_open),
+            "sanity check: the palette should actually be open"
+        );
+        assert!(
+            max_scroll_offset(&app, cx) > gpui::px(0.0),
+            "premise: the seeded results must genuinely overflow the viewport - a zero \
+             `max_offset` would mean everything fits and there is nothing to scroll"
+        );
+        (app, cx)
+    }
+
+    fn row_count(app: &Entity<AdeApp>, cx: &mut VisualTestContext) -> usize {
+        app.read_with(cx, |app, cx| {
+            palette::flatten(&app.build_palette_groups(cx)).len()
+        })
+    }
+
+    fn selected(app: &Entity<AdeApp>, cx: &mut VisualTestContext) -> usize {
+        app.read_with(cx, |app, _| app.palette_selected)
+    }
+
+    fn scroll_offset(app: &Entity<AdeApp>, cx: &mut VisualTestContext) -> Pixels {
+        app.read_with(cx, |app, _| {
+            app.palette_results_scroll_handle.scroll_offset().y
+        })
+    }
+
+    fn max_scroll_offset(app: &Entity<AdeApp>, cx: &mut VisualTestContext) -> Pixels {
+        app.read_with(cx, |app, _| {
+            app.palette_results_scroll_handle.max_scroll_offset().y
+        })
+    }
+
+    /// Whether a row's real painted box sits entirely inside the results viewport's real painted
+    /// box - "visible to the user", not "exists in the element tree".
+    fn fully_inside(row: Bounds<Pixels>, viewport: Bounds<Pixels>) -> bool {
+        row.top() >= viewport.top() && row.bottom() <= viewport.bottom()
+    }
+
+    /// Asserts the invariant issue #413 is about, against the real painted frame: whichever row is
+    /// highlighted right now is entirely visible.
+    fn assert_selection_visible(app: &Entity<AdeApp>, cx: &mut VisualTestContext, step: &str) {
+        let index = selected(app, cx);
+        let viewport = cx
+            .debug_bounds("palette-results")
+            .expect("the results viewport should have really painted");
+        let row = cx
+            .debug_bounds(row_selector(index))
+            .unwrap_or_else(|| panic!("row {index} should have really painted after {step}"));
+        assert!(
+            fully_inside(row, viewport),
+            "after {step} the highlighted row {index} must sit entirely inside the results \
+             viewport - got row {row:?} against viewport {viewport:?}"
+        );
+    }
+
+    #[gpui::test]
+    fn arrowing_down_keeps_the_highlighted_row_inside_the_viewport(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let (app, cx) = open_overflowing_palette(cx, repo.path());
+
+        let total = row_count(&app, cx);
+        assert_eq!(
+            scroll_offset(&app, cx),
+            gpui::px(0.0),
+            "a freshly opened palette must start at the top"
+        );
+
+        // The premise the whole issue rests on: the bottom of the list really is out of sight
+        // before any key is pressed, so walking down to it has to move the viewport.
+        let viewport = cx
+            .debug_bounds("palette-results")
+            .expect("the results viewport should have really painted");
+        let last = cx
+            .debug_bounds(row_selector(total - 1))
+            .expect("the last row should have really painted - the list is not virtualized");
+        assert!(
+            !fully_inside(last, viewport),
+            "premise: the last of {total} rows must start out past the viewport's bottom edge, \
+             otherwise arrowing to it would never need to scroll - got row {last:?} inside \
+             viewport {viewport:?}"
+        );
+
+        for step in 1..total {
+            cx.simulate_keystrokes("down");
+            cx.run_until_parked();
+            assert_eq!(
+                selected(&app, cx),
+                step,
+                "sanity check: {step} presses of `down` must land on row {step}"
+            );
+            assert_selection_visible(&app, cx, "pressing `down`");
+        }
+
+        assert!(
+            scroll_offset(&app, cx) < gpui::px(0.0),
+            "walking to the last row must have really scrolled the viewport (GPUI's own scroll \
+             offset goes negative as you scroll down), not merely moved an index - this is \
+             GitHub issue #413"
+        );
+    }
+
+    #[gpui::test]
+    fn arrowing_back_up_brings_the_viewport_back_with_it(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let (app, cx) = open_overflowing_palette(cx, repo.path());
+
+        let total = row_count(&app, cx);
+        for _ in 1..total {
+            cx.simulate_keystrokes("down");
+        }
+        cx.run_until_parked();
+
+        let scrolled_down = scroll_offset(&app, cx);
+        assert!(
+            scrolled_down < gpui::px(0.0),
+            "premise: the list must really be scrolled down before `up` can be shown to undo it"
+        );
+
+        for step in (0..total - 1).rev() {
+            cx.simulate_keystrokes("up");
+            cx.run_until_parked();
+            assert_eq!(
+                selected(&app, cx),
+                step,
+                "sanity check: walking back up must pass through row {step}"
+            );
+            assert_selection_visible(&app, cx, "pressing `up`");
+        }
+
+        assert!(
+            scroll_offset(&app, cx) > scrolled_down,
+            "walking back up to the first row must have really scrolled the viewport back toward \
+             the top (the offset rises toward zero), not left the highlight stranded above the \
+             fold - still at {scrolled_down:?}"
+        );
     }
 }

--- a/crates/app/src/palette/render.rs
+++ b/crates/app/src/palette/render.rs
@@ -858,8 +858,10 @@ impl AdeApp {
 
         // Headers and rows are children of the scroller itself rather than of a per-group wrapper,
         // so `palette_results_scroll_handle`'s child bounds line up with
-        // `palette::row_child_index` and a row can actually be scrolled to. The old wrapper was a
-        // bare `flex_col` with no styling of its own, so this lays out identically.
+        // `palette::row_child_index` and a row can actually be scrolled to. Both carry `flex_none`
+        // for that to be safe: as direct children of a column flex container they would otherwise
+        // shrink below their themed heights the moment the list overflows, compacting the list
+        // rather than scrolling it (the per-group wrapper used to absorb that shrink).
         let mut flat_index = 0usize;
         for group in groups {
             container = container.child(self.render_palette_group_header(group));
@@ -897,6 +899,9 @@ impl AdeApp {
     ) -> impl IntoElement {
         div()
             .id(format!("palette-group-{}", group.label))
+            // Same reason as [`Self::render_palette_row`]'s own: a direct child of the scrolling
+            // column must not shrink when the list overflows.
+            .flex_none()
             .flex()
             .items_center()
             .gap(px(7.0))
@@ -970,6 +975,9 @@ impl AdeApp {
             // results viewport, rather than trusting that scrolling "probably" happened.
             .debug_selector(move || format!("palette-row-{index}"))
             .cursor_pointer()
+            // A row is a direct child of the scrolling column, so it has to opt out of flex
+            // shrinking or an overflowing list compacts its rows instead of scrolling them.
+            .flex_none()
             .flex()
             .items_center()
             .gap(px(9.0))
@@ -1709,6 +1717,30 @@ mod palette_scroll_tests {
             "after {step} the highlighted row {index} must sit entirely inside the results \
              viewport - got row {row:?} against viewport {viewport:?}"
         );
+    }
+
+    /// A scrolling list must scroll, not squash. Rows and headers are flex children of a column
+    /// container, so without `flex_none` they shrink below their themed height as soon as the
+    /// content overflows - the list quietly compacts instead of overflowing, which is both wrong
+    /// on its own and hides the very overflow the scrolling exists to handle.
+    #[gpui::test]
+    fn an_overflowing_list_keeps_every_row_at_its_full_themed_height(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let (app, cx) = open_overflowing_palette(cx, repo.path());
+
+        let total = row_count(&app, cx);
+        for index in 0..total {
+            let row = cx
+                .debug_bounds(row_selector(index))
+                .unwrap_or_else(|| panic!("row {index} should have really painted"));
+            assert_eq!(
+                row.size.height,
+                crate::theme::band::PALETTE_ROW,
+                "row {index} of {total} must paint at its full themed height even though the list \
+                 overflows - a shorter row means flex shrank it, compacting the list instead of \
+                 scrolling it"
+            );
+        }
     }
 
     #[gpui::test]

--- a/crates/app/src/palette/state.rs
+++ b/crates/app/src/palette/state.rs
@@ -391,6 +391,25 @@ pub fn flatten(groups: &[PaletteGroup]) -> Vec<&PaletteEntry> {
         .collect()
 }
 
+/// Maps a [`flatten`] row index onto that row's position among the *children* of the scrolling
+/// results list, which `crate::palette::render::AdeApp::render_palette_groups` lays out flat as
+/// `[header, rows.., header, rows..]`. `gpui::ScrollHandle::scroll_to_item` addresses those
+/// children, so every group header above a row shifts it down by one. `None` for a row index past
+/// the end.
+pub fn row_child_index(groups: &[PaletteGroup], row: usize) -> Option<usize> {
+    let mut child = 0usize;
+    let mut rows_before = 0usize;
+    for group in groups {
+        child += 1; // the group's own header
+        if row < rows_before + group.entries.len() {
+            return Some(child + (row - rows_before));
+        }
+        child += group.entries.len();
+        rows_before += group.entries.len();
+    }
+    None
+}
+
 /// A position-preserving ASCII-fold of `text` (only ASCII letters are case-folded; every other
 /// `char` passes through unchanged), so a matched span's `(char_index, char_len)` always indexes
 /// back correctly into the *original* string. A full Unicode fold (`str::to_lowercase`) can
@@ -1112,6 +1131,75 @@ mod tests {
         assert_eq!(
             flat[1].target,
             EntryTarget::Command(PaletteCommand::NewShell)
+        );
+    }
+
+    /// `n` groups of `size` rows each, which is all [`row_child_index`] looks at.
+    fn sized_groups(sizes: &[usize]) -> Vec<PaletteGroup> {
+        sizes
+            .iter()
+            .map(|size| PaletteGroup {
+                label: "Commands",
+                entries: (0..*size)
+                    .map(|_| PaletteEntry {
+                        label: MatchedText::plain("row"),
+                        secondary: String::new(),
+                        shortcut: None,
+                        status: None,
+                        file_change: None,
+                        process_kind: None,
+                        target: EntryTarget::Command(PaletteCommand::NewShell),
+                    })
+                    .collect(),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn row_child_index_skips_one_child_per_group_header() {
+        let groups = sized_groups(&[2, 3]);
+
+        // Children lay out as: header, r0, r1, header, r2, r3, r4.
+        assert_eq!(row_child_index(&groups, 0), Some(1));
+        assert_eq!(row_child_index(&groups, 1), Some(2));
+        assert_eq!(
+            row_child_index(&groups, 2),
+            Some(4),
+            "the first row of the second group sits after that group's own header, so it skips \
+             two children rather than one"
+        );
+        assert_eq!(row_child_index(&groups, 3), Some(5));
+        assert_eq!(row_child_index(&groups, 4), Some(6));
+    }
+
+    #[test]
+    fn row_child_index_agrees_with_flatten_on_every_row() {
+        let groups = sized_groups(&[1, 4, 2]);
+        let total = flatten(&groups).len();
+
+        let mapped: Vec<usize> = (0..total)
+            .map(|row| row_child_index(&groups, row).expect("every flattened row must map"))
+            .collect();
+        assert!(
+            mapped.windows(2).all(|pair| pair[1] > pair[0]),
+            "the mapping must be strictly increasing - two rows sharing a child index would \
+             scroll to the wrong one, got {mapped:?}"
+        );
+        assert_eq!(
+            mapped.last().copied(),
+            Some(total + groups.len() - 1),
+            "the last row's child index must account for every header above it"
+        );
+    }
+
+    #[test]
+    fn row_child_index_is_none_past_the_last_row() {
+        let groups = sized_groups(&[2, 1]);
+        assert_eq!(row_child_index(&groups, 3), None);
+        assert_eq!(
+            row_child_index(&[], 0),
+            None,
+            "an empty palette has no row to scroll to"
         );
     }
 

--- a/crates/app/src/palette/state.rs
+++ b/crates/app/src/palette/state.rs
@@ -410,32 +410,57 @@ pub fn row_child_index(groups: &[PaletteGroup], row: usize) -> Option<usize> {
     None
 }
 
-/// A position-preserving ASCII-fold of `text` (only ASCII letters are case-folded; every other
-/// `char` passes through unchanged), so a matched span's `(char_index, char_len)` always indexes
-/// back correctly into the *original* string. A full Unicode fold (`str::to_lowercase`) can
-/// change a string's char count (e.g. `'İ'` folds to two chars), which would misalign that
-/// mapping - not worth guarding against for this app's content, so the simpler, alignment-safe
-/// ASCII fold is used instead.
-fn ascii_fold(text: &str) -> Vec<char> {
-    text.chars().map(|c| c.to_ascii_lowercase()).collect()
-}
-
 /// Leftmost case-insensitive substring search (see the module docs for why this is plain
 /// substring matching, not fuzzy/skip-char). Returns `(start_char_index, len_in_chars)`, or
 /// `None` if `needle` is empty or doesn't occur in `haystack`.
+///
+/// Case folding is ASCII-only and applied per `char` as the comparison walks, so it is
+/// position-preserving: a returned span always indexes back correctly into the *original*
+/// `haystack`. A full Unicode fold (`str::to_lowercase`) can change a string's char count (e.g.
+/// `'İ'` folds to two chars), which would misalign that mapping - not worth guarding against for
+/// this app's content, so the simpler, alignment-safe ASCII fold is used instead.
+///
+/// Allocation-free by construction: this runs once per candidate per *aux field* on every
+/// keystroke and every frame while the palette is open (see
+/// `crate::root::AdeApp::build_palette_groups`), so the two folded `Vec<char>` buffers it used to
+/// build per call dominated the cost of filtering a large repository.
 pub fn substring_match(haystack: &str, needle: &str) -> Option<(usize, usize)> {
     if needle.is_empty() {
         return None;
     }
-    let haystack_lower = ascii_fold(haystack);
-    let needle_lower = ascii_fold(needle);
-    if needle_lower.len() > haystack_lower.len() {
+
+    // Fast path for the overwhelmingly common case - file names, command labels, branch names.
+    // With both sides pure ASCII a byte index *is* a char index and a byte length *is* a char
+    // length, so the search runs straight over the bytes with no decoding at all.
+    if haystack.is_ascii() && needle.is_ascii() {
+        let haystack = haystack.as_bytes();
+        let needle = needle.as_bytes();
+        if needle.len() > haystack.len() {
+            return None;
+        }
+        return (0..=haystack.len() - needle.len())
+            .find(|&start| haystack[start..start + needle.len()].eq_ignore_ascii_case(needle))
+            .map(|start| (start, needle.len()));
+    }
+
+    let needle_len = needle.chars().count();
+    let haystack_len = haystack.chars().count();
+    if needle_len > haystack_len {
         return None;
     }
-    let last_start = haystack_lower.len() - needle_lower.len();
-    for start in 0..=last_start {
-        if haystack_lower[start..start + needle_lower.len()] == needle_lower[..] {
-            return Some((start, needle_lower.len()));
+
+    for (start, (byte_offset, _)) in haystack.char_indices().enumerate() {
+        // Past this point the remaining tail is shorter than `needle`, and `zip` below would
+        // silently stop early and report a false match.
+        if start + needle_len > haystack_len {
+            break;
+        }
+        let matches = needle
+            .chars()
+            .zip(haystack[byte_offset..].chars())
+            .all(|(want, got)| want.eq_ignore_ascii_case(&got));
+        if matches {
+            return Some((start, needle_len));
         }
     }
     None
@@ -467,10 +492,20 @@ fn match_against(
     None
 }
 
-fn finish_group(mut scored: Vec<(usize, PaletteEntry)>) -> Vec<PaletteEntry> {
+/// Ranks the matches, caps the group, and only *then* turns the survivors into rows.
+///
+/// Selecting before building is what keeps a large repository cheap: a broad query qualifies every
+/// file in the tree, and a [`PaletteEntry`] is not free (a cloned path, a formatted secondary
+/// line, a label split into three owned strings). Building one per match and discarding all but
+/// [`MAX_ENTRIES_PER_GROUP`] of them dominated the cost of a keystroke, which runs this on every
+/// key *and* every frame. `sort_by_key` is stable, so equal ranks keep candidate order.
+fn finish_group<T>(
+    mut scored: Vec<(usize, T)>,
+    build: impl Fn(T) -> PaletteEntry,
+) -> Vec<PaletteEntry> {
     scored.sort_by_key(|(rank, _)| *rank);
     scored.truncate(MAX_ENTRIES_PER_GROUP);
-    scored.into_iter().map(|(_, entry)| entry).collect()
+    scored.into_iter().map(|(_, item)| build(item)).collect()
 }
 
 fn filter_agents(agents: &[AgentCandidate], query: &str) -> Vec<PaletteEntry> {
@@ -481,23 +516,20 @@ fn filter_agents(agents: &[AgentCandidate], query: &str) -> Vec<PaletteEntry> {
         let Some((span, rank)) = match_against(&candidate.title, &aux, query) else {
             continue;
         };
-        scored.push((
-            rank,
-            PaletteEntry {
-                label: MatchedText::from_match(&candidate.title, span),
-                secondary: candidate
-                    .branch
-                    .clone()
-                    .unwrap_or_else(|| "(detached)".to_string()),
-                shortcut: None,
-                status: Some(candidate.status),
-                file_change: None,
-                process_kind: Some(candidate.kind),
-                target: EntryTarget::Agent(candidate.id),
-            },
-        ));
+        scored.push((rank, (candidate, span)));
     }
-    finish_group(scored)
+    finish_group(scored, |(candidate, span)| PaletteEntry {
+        label: MatchedText::from_match(&candidate.title, span),
+        secondary: candidate
+            .branch
+            .clone()
+            .unwrap_or_else(|| "(detached)".to_string()),
+        shortcut: None,
+        status: Some(candidate.status),
+        file_change: None,
+        process_kind: Some(candidate.kind),
+        target: EntryTarget::Agent(candidate.id),
+    })
 }
 
 fn filter_commands(commands: &[CommandCandidate], query: &str) -> Vec<PaletteEntry> {
@@ -508,20 +540,17 @@ fn filter_commands(commands: &[CommandCandidate], query: &str) -> Vec<PaletteEnt
         let Some((span, rank)) = match_against(label, &aux, query) else {
             continue;
         };
-        scored.push((
-            rank,
-            PaletteEntry {
-                label: MatchedText::from_match(label, span),
-                secondary: candidate.secondary.clone(),
-                shortcut: candidate.command.shortcut(),
-                status: None,
-                file_change: None,
-                process_kind: None,
-                target: EntryTarget::Command(candidate.command),
-            },
-        ));
+        scored.push((rank, (candidate, span)));
     }
-    finish_group(scored)
+    finish_group(scored, |(candidate, span)| PaletteEntry {
+        label: MatchedText::from_match(candidate.command.label(), span),
+        secondary: candidate.secondary.clone(),
+        shortcut: candidate.command.shortcut(),
+        status: None,
+        file_change: None,
+        process_kind: None,
+        target: EntryTarget::Command(candidate.command),
+    })
 }
 
 fn file_secondary(candidate: &FileCandidate) -> String {
@@ -549,20 +578,17 @@ fn filter_files(files: &[FileCandidate], query: &str) -> Vec<PaletteEntry> {
         let Some((span, rank)) = match_against(&candidate.name, &aux, query) else {
             continue;
         };
-        scored.push((
-            rank,
-            PaletteEntry {
-                label: MatchedText::from_match(&candidate.name, span),
-                secondary: file_secondary(candidate),
-                shortcut: None,
-                status: None,
-                file_change: candidate.changed,
-                process_kind: None,
-                target: EntryTarget::File(candidate.path.clone()),
-            },
-        ));
+        scored.push((rank, (candidate, span)));
     }
-    finish_group(scored)
+    finish_group(scored, |(candidate, span)| PaletteEntry {
+        label: MatchedText::from_match(&candidate.name, span),
+        secondary: file_secondary(candidate),
+        shortcut: None,
+        status: None,
+        file_change: candidate.changed,
+        process_kind: None,
+        target: EntryTarget::File(candidate.path.clone()),
+    })
 }
 
 /// Builds the [`PaletteStep::PickLanguageServer`] step's single group - the same
@@ -579,20 +605,17 @@ pub fn build_language_server_groups(
         let Some((span, rank)) = match_against(candidate.client_key, &aux, query) else {
             continue;
         };
-        scored.push((
-            rank,
-            PaletteEntry {
-                label: MatchedText::from_match(candidate.client_key, span),
-                secondary: candidate.secondary.clone(),
-                shortcut: None,
-                status: Some(candidate.status),
-                file_change: None,
-                process_kind: None,
-                target: EntryTarget::LanguageServer(candidate.client_key),
-            },
-        ));
+        scored.push((rank, (candidate, span)));
     }
-    let entries = finish_group(scored);
+    let entries = finish_group(scored, |(candidate, span)| PaletteEntry {
+        label: MatchedText::from_match(candidate.client_key, span),
+        secondary: candidate.secondary.clone(),
+        shortcut: None,
+        status: Some(candidate.status),
+        file_change: None,
+        process_kind: None,
+        target: EntryTarget::LanguageServer(candidate.client_key),
+    });
     if entries.is_empty() {
         return Vec::new();
     }
@@ -718,6 +741,107 @@ mod tests {
         assert_eq!(substring_match("anything", ""), None);
         assert_eq!(substring_match("short", "much too long"), None);
         assert_eq!(substring_match("query.rs", "zzz"), None);
+    }
+
+    #[test]
+    fn finish_group_only_builds_the_rows_it_actually_keeps() {
+        // The guard on the optimisation, not a timing assertion: a broad query qualifies every
+        // file in the repository, and building a row per match before capping is what made a
+        // keystroke cost milliseconds. Counting real `build` calls catches a regression here that
+        // no assertion on the returned rows could.
+        let built = std::cell::Cell::new(0usize);
+        let scored: Vec<(usize, usize)> = (0..1_000).map(|i| (i, i)).collect();
+
+        let entries = finish_group(scored, |i| {
+            built.set(built.get() + 1);
+            PaletteEntry {
+                label: MatchedText::plain(&format!("row{i}")),
+                secondary: String::new(),
+                shortcut: None,
+                status: None,
+                file_change: None,
+                process_kind: None,
+                target: EntryTarget::Command(PaletteCommand::NewShell),
+            }
+        });
+
+        assert_eq!(entries.len(), MAX_ENTRIES_PER_GROUP);
+        assert_eq!(
+            built.get(),
+            MAX_ENTRIES_PER_GROUP,
+            "1000 matches must build only the {MAX_ENTRIES_PER_GROUP} rows that survive the cap"
+        );
+        assert_eq!(
+            entries[0].label.pre, "row0",
+            "and the survivors must still be the best-ranked ones, in rank order"
+        );
+    }
+
+    #[test]
+    fn finish_group_keeps_candidate_order_within_an_equal_rank() {
+        let scored: Vec<(usize, usize)> = vec![(5, 10), (0, 20), (5, 11), (0, 21)];
+        let entries = finish_group(scored, |i| PaletteEntry {
+            label: MatchedText::plain(&format!("row{i}")),
+            secondary: String::new(),
+            shortcut: None,
+            status: None,
+            file_change: None,
+            process_kind: None,
+            target: EntryTarget::Command(PaletteCommand::NewShell),
+        });
+
+        let labels: Vec<&str> = entries.iter().map(|e| e.label.pre.as_str()).collect();
+        assert_eq!(
+            labels,
+            vec!["row20", "row21", "row10", "row11"],
+            "ties must keep the order the candidates were scored in - the sort has to stay stable"
+        );
+    }
+
+    #[test]
+    fn substring_match_does_not_run_off_the_end_of_the_haystack() {
+        // A needle that starts matching but outruns the tail. Worth its own test: a comparison
+        // that walks the two strings in step will happily report a match here the moment it stops
+        // at whichever ran out first.
+        assert_eq!(substring_match("abc", "bcd"), None);
+        assert_eq!(substring_match("query.rs", "rs.more"), None);
+        assert_eq!(
+            substring_match("query.rs", ".rs"),
+            Some((5, 3)),
+            "a needle that ends exactly at the haystack's end still matches"
+        );
+    }
+
+    #[test]
+    fn substring_match_spans_are_char_indices_not_byte_indices() {
+        // `é` is two bytes, so a byte-indexed search reports 6 here and `MatchedText::from_match`
+        // (which slices by `char`) would then highlight the wrong span.
+        assert_eq!(
+            substring_match("café_query.rs", "query"),
+            Some((5, 5)),
+            "the span must be measured in chars, not bytes"
+        );
+        let matched =
+            MatchedText::from_match("café_query.rs", substring_match("café_query.rs", "query"));
+        assert_eq!(matched.pre, "café_");
+        assert_eq!(matched.mid, "query");
+        assert_eq!(matched.post, ".rs");
+    }
+
+    #[test]
+    fn substring_match_handles_a_non_ascii_needle_and_folds_only_ascii() {
+        assert_eq!(substring_match("Straße.rs", "STRA"), Some((0, 4)));
+        assert_eq!(
+            substring_match("Straße.rs", "ße"),
+            Some((4, 2)),
+            "a multi-byte needle matches at its real char offset"
+        );
+        assert_eq!(
+            substring_match("İstanbul.rs", "i"),
+            None,
+            "folding is ASCII-only on purpose - a Unicode fold would change the char count and \
+             misalign every span this returns"
+        );
     }
 
     #[test]

--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -1220,7 +1220,10 @@ pub struct AdeApp {
     pub(crate) palette_open: bool,
     /// The palette's own real overlay scrollbar handle (GitHub issue #30) - a plain
     /// `gpui::ScrollHandle`: `crate::palette::render::AdeApp::render_palette_groups` renders
-    /// every result row eagerly, not through a `uniform_list`.
+    /// every result row eagerly, not through a `uniform_list`. It also carries the keyboard
+    /// selection (GitHub issue #413), which is why that function lays headers and rows out as one
+    /// flat run of children: `ScrollHandle::scroll_to_item` addresses direct children, and
+    /// `crate::palette::state::row_child_index` is the mapping from a row index to one.
     pub(crate) palette_results_scroll_handle: gpui::ScrollHandle,
     /// The palette's active scope (`All`/`Commands`/`Files`).
     pub(crate) palette_scope: palette::PaletteScope,


### PR DESCRIPTION
Closes #413

## What

Three things, in the order they were found.

**1. The palette didn't scroll to its keyboard selection.** Arrow keys moved the highlight without
moving the results viewport, so once the list overflowed the selection walked off the bottom edge
and `⏎` ran a row the user could not see. `move_palette_selection` now reveals the selected row
through the palette's existing `ScrollHandle`, using GPUI's minimum-movement strategy — a no-op when
the row is already visible, so it never fights the mouse wheel.

Making the row addressable is the substantive part. `ScrollHandle::scroll_to_item` indexes the
scroller's *direct* children, and `render_palette_groups` nested each group's rows inside a
per-group wrapper — so the handle only ever saw groups. Headers and rows are now one flat run of
children, and the new pure `palette::row_child_index` maps a flattened row index onto its child
position by skipping one child per header above it.

**2. That flattening compacted the list** (caught in review). As direct children of a column flex
container, headers and rows shrink by default, so an overflowing list squashed its rows to 19.5px
instead of `theme::band::PALETTE_ROW`'s 30px — the per-group wrapper had been absorbing that shrink.
Both now carry `flex_none`, matching `completion_popup`'s rows.

**3. Palette input lag and a key-repeat stall** (also from review: holding `↑`/`↓` froze the
highlight, which then jumped on release). `build_palette_groups` runs from both
`move_palette_selection` and `render_palette`, so anything O(files) there is paid twice per
keystroke; on a large repo that exceeded the frame budget and key-repeat events queued faster than
frames could be produced. Two costs, both in the GPUI-free half:

- `substring_match` allocated two folded `Vec<char>` per call, once per candidate *per aux field*.
  It now compares in place, with a byte-wise fast path for pure-ASCII input (file names, command
  labels, branches) — for ASCII a byte index is a char index, so the returned span is unchanged.
- `finish_group` built a `PaletteEntry` (cloned path, formatted secondary, label split into three
  owned strings) for every match, then discarded all but `MAX_ENTRIES_PER_GROUP`. It now ranks and
  caps first, and builds only the survivors.

Measured on `build_groups`, **`--release`**, 20k files:

| query | before | after | |
|---|---|---|---|
| broad (`"file"`) | 8.13ms | 0.60ms | **13.6×** |
| narrow (`"file123"`) | 1.02ms | 0.71ms | 1.4× |
| no match (`"zzz"`) | 1.10ms | 0.91ms | 1.2× |
| empty | 17.0µs | 17.5µs | — |

Worst case is now ~0.9ms per build, ~1.8ms per keystroke, inside a 16ms frame. Note these are
release figures on purpose — debug-build numbers pointed at the wrong bottleneck entirely, exactly
as `CLAUDE.md` warns.

Worth recording: this is **not** a missing virtualized list. Each group is capped at
`MAX_ENTRIES_PER_GROUP` (8), so at most ~40 rows ever render regardless of repo size — row count was
never the cost.

## Testing

- [x] `/check` — `cargo fmt --all -- --check` and `cargo clippy --workspace --all-targets -- -D
      warnings` clean. The conventions script itself skipped (`jq` not installed on this machine),
      so both counts were run by hand: `glob_imports_app_src` 300 and `render_adapter_calls` 170,
      exactly at baseline.
- [ ] `verify` capture — **not run**, by agreement: a release build plus a live window was not worth
      it here, and this machine's GPUI/PTY tests are unreliable (see below).
- [x] New/changed behavior has a real test, in the right tier:
      - `ui` — `arrowing_down_keeps_the_highlighted_row_inside_the_viewport` and
        `arrowing_back_up_brings_the_viewport_back_with_it` walk the whole list with real keystrokes
        and assert after *every* step that the highlighted row's painted box sits entirely inside
        the results viewport's. Both confirmed to fail without the scroll call.
      - `ui` — `an_overflowing_list_keeps_every_row_at_its_full_themed_height` asserts every row's
        painted height against the theme constant; fails at 19.5px without `flex_none`.
      - `unit` — `row_child_index` (header offset, strictly increasing against `flatten`,
        past-the-end/empty).
      - `unit` — for the perf change, behaviour is guarded rather than assumed: the
        char-index-vs-byte-index contract the folded buffers used to provide (**nothing covered this
        before — every existing case was ASCII**), the tail-overrun case an in-place comparison can
        get wrong, that a capped group builds only the rows it keeps, and that equal ranks keep
        candidate order. No timing assertions — those would be flaky.
- [ ] `external` tier — not touched.

`cargo nextest run --workspace` on this machine reports pre-existing, environmental failures
unrelated to this branch, concentrated in `pty-core` (real PTY spawning), `lsp-core` (path
canonicalization) and agent/session-restore tests — including crates this diff does not touch at
all. The four `tabless_window_keybinding_tests` timeouts were confirmed to reproduce identically on
a clean, stashed tree. No palette test fails.

## Architecture notes

`row_child_index` and both perf changes live in `crates/app/src/palette/state.rs`, the palette's
GPUI-free half, so the layout contract and the matching pipeline stay unit-testable without a live
window. No crate boundary or Command/Query shape changes.

## Still open

`build_palette_groups` is still called twice per keystroke. Removing the second call means caching,
and its docs make "built fresh every call so what's drawn and what `⏎`/`↑`/`↓` act on can never
disagree" a deliberate correctness choice — not worth trading for ~0.9ms now that a build is cheap.

The lag and key-repeat symptoms were diagnosed and fixed by measurement, but **not confirmed
resolved in the running app** — that needs a real session on a large repo, which pairs naturally
with the skipped `verify` pass.
