### PR TITLE
feat(app): support the Cursor agent CLI, and let the start-agent button pick the agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ actually done. Rebase interactively when you want to tidy up before merging.
 <p>
   <a href="https://claude.com/claude-code"><kbd><img src="https://www.google.com/s2/favicons?domain=claude.com&sz=64" alt="" width="16" valign="middle" /> Claude Code <img src="docs/images/dot-full.png" alt="Full support" width="9" valign="middle" /></kbd></a> &nbsp;
   <a href="https://github.com/openai/codex"><kbd><img src="https://www.google.com/s2/favicons?domain=openai.com&sz=64" alt="" width="16" valign="middle" /> Codex <img src="docs/images/dot-partial.png" alt="Partial support" width="9" valign="middle" /></kbd></a> &nbsp;
-  <a href="https://cursor.com/cli"><kbd><img src="https://www.google.com/s2/favicons?domain=cursor.com&sz=64" alt="" width="16" valign="middle" /> Cursor <img src="docs/images/dot-planned.png" alt="Planned" width="9" valign="middle" /></kbd></a>
+  <a href="https://cursor.com/cli"><kbd><img src="https://www.google.com/s2/favicons?domain=cursor.com&sz=64" alt="" width="16" valign="middle" /> Cursor <img src="docs/images/dot-partial.png" alt="Partial support" width="9" valign="middle" /></kbd></a>
 </p>
 
 <p>

--- a/assets/themes/ember.toml
+++ b/assets/themes/ember.toml
@@ -185,8 +185,8 @@ repo_fail_count    = "#984d60"  # The repo header's red urgency **count**
 "codex.bg"  = "#11291f"  # Teal - gpt-5-codex.
 "haiku.fg"  = "#606dab"  # Periwinkle - haiku-4.5.
 "haiku.bg"  = "#1a1d30"  # Periwinkle - haiku-4.5.
-"local.fg"  = "#4277a3"  # Steel blue - qwen-local.
-"local.bg"  = "#102538"  # Steel blue - qwen-local.
+"local.fg"  = "#4277a3"  # Steel blue - the Cursor agent CLI.
+"local.bg"  = "#102538"  # Steel blue - the Cursor agent CLI.
 
 # The Changes panel - four stacked, collapsible sections in one scroller, plus the file row's
 # own seen/unseen and discard states.

--- a/assets/themes/jerry-dim.toml
+++ b/assets/themes/jerry-dim.toml
@@ -185,8 +185,8 @@ repo_fail_count    = "#b46d61"  # The repo header's red urgency **count**
 "codex.bg"  = "#1a3533"  # Teal - gpt-5-codex.
 "haiku.fg"  = "#9683bf"  # Periwinkle - haiku-4.5.
 "haiku.bg"  = "#2c2537"  # Periwinkle - haiku-4.5.
-"local.fg"  = "#7c8dc2"  # Steel blue - qwen-local.
-"local.bg"  = "#282e45"  # Steel blue - qwen-local.
+"local.fg"  = "#7c8dc2"  # Steel blue - the Cursor agent CLI.
+"local.bg"  = "#282e45"  # Steel blue - the Cursor agent CLI.
 
 # The Changes panel - four stacked, collapsible sections in one scroller, plus the file row's
 # own seen/unseen and discard states.

--- a/assets/themes/moss.toml
+++ b/assets/themes/moss.toml
@@ -185,8 +185,8 @@ repo_fail_count    = "#a46963"  # The repo header's red urgency **count**
 "codex.bg"  = "#192d2b"  # Teal - gpt-5-codex.
 "haiku.fg"  = "#8a7faf"  # Periwinkle - haiku-4.5.
 "haiku.bg"  = "#24202e"  # Periwinkle - haiku-4.5.
-"local.fg"  = "#7586b0"  # Steel blue - qwen-local.
-"local.bg"  = "#22283a"  # Steel blue - qwen-local.
+"local.fg"  = "#7586b0"  # Steel blue - the Cursor agent CLI.
+"local.bg"  = "#22283a"  # Steel blue - the Cursor agent CLI.
 
 # The Changes panel - four stacked, collapsible sections in one scroller, plus the file row's
 # own seen/unseen and discard states.

--- a/assets/themes/paper.toml
+++ b/assets/themes/paper.toml
@@ -185,8 +185,8 @@ repo_fail_count    = "#a66663"  # The repo header's red urgency **count**
 "codex.bg"  = "#bfd9d4"  # Teal - gpt-5-codex.
 "haiku.fg"  = "#6f669a"  # Periwinkle - haiku-4.5.
 "haiku.bg"  = "#dbd7ed"  # Periwinkle - haiku-4.5.
-"local.fg"  = "#586f99"  # Steel blue - qwen-local.
-"local.bg"  = "#c7d3ec"  # Steel blue - qwen-local.
+"local.fg"  = "#586f99"  # Steel blue - the Cursor agent CLI.
+"local.bg"  = "#c7d3ec"  # Steel blue - the Cursor agent CLI.
 
 # The Changes panel - four stacked, collapsible sections in one scroller, plus the file row's
 # own seen/unseen and discard states.

--- a/assets/themes/slate.toml
+++ b/assets/themes/slate.toml
@@ -185,8 +185,8 @@ repo_fail_count    = "#934c43"  # The repo header's red urgency **count**
 "codex.bg"  = "#0c2826"  # Teal - gpt-5-codex.
 "haiku.fg"  = "#73609d"  # Periwinkle - haiku-4.5.
 "haiku.bg"  = "#211a2c"  # Periwinkle - haiku-4.5.
-"local.fg"  = "#596a9f"  # Steel blue - qwen-local.
-"local.bg"  = "#1b2238"  # Steel blue - qwen-local.
+"local.fg"  = "#596a9f"  # Steel blue - the Cursor agent CLI.
+"local.bg"  = "#1b2238"  # Steel blue - the Cursor agent CLI.
 
 # The Changes panel - four stacked, collapsible sections in one scroller, plus the file row's
 # own seen/unseen and discard states.

--- a/crates/app/src/budget/state.rs
+++ b/crates/app/src/budget/state.rs
@@ -88,6 +88,11 @@ pub fn provider_of(kind: ProcessKind) -> Option<Provider> {
         ProcessKind::Shell => None,
         ProcessKind::Agent(AgentKind::Claude) => Some(Provider::Claude),
         ProcessKind::Agent(AgentKind::Codex) => Some(Provider::Codex),
+        // Cursor spends a real budget, but nothing here can read it: the popover's numbers come
+        // from `crate::budget::fetch`'s real Claude/Codex endpoints, and there is no Cursor
+        // equivalent wired up. `None` is the honest answer - a third row here would be a
+        // fabricated one.
+        ProcessKind::Agent(AgentKind::Cursor) => None,
     }
 }
 

--- a/crates/app/src/hooks/flow.rs
+++ b/crates/app/src/hooks/flow.rs
@@ -3,7 +3,7 @@
 use gpui::{Context, Window};
 
 use crate::root::AdeApp;
-use crate::work_surface::agents::{AgentKind, ProcessKind};
+use crate::work_surface::agents::ProcessKind;
 
 impl AdeApp {
     /// Every currently open agent's own persisted-status key
@@ -55,16 +55,20 @@ impl AdeApp {
         let font_size = self.settings.appearance.terminal_font_size;
         let shell_override = self.settings.terminal.shell_override();
         let id = match (past.kind, past.session_id.clone()) {
-            (AgentKind::Claude, Some(session_id)) => self.agents.spawn_resume(
-                AgentKind::Claude,
-                past.worktree.clone(),
-                font_size,
-                shell_override,
-                hook_injection.as_ref(),
-                session_id,
-                window,
-                cx,
-            ),
+            // Every kind with a verified resume flag, not Claude alone - `spawn_resume` asks
+            // `AgentKind::resume_args` for the right spelling and spawns bare if there is none.
+            (kind, Some(session_id)) if kind.resume_args(&session_id).is_some() => {
+                self.agents.spawn_resume(
+                    kind,
+                    past.worktree.clone(),
+                    font_size,
+                    shell_override,
+                    hook_injection.as_ref(),
+                    session_id,
+                    window,
+                    cx,
+                )
+            }
             _ => self.agents.spawn(
                 process_kind,
                 past.worktree.clone(),
@@ -203,7 +207,10 @@ impl AdeApp {
                 let session_id = self
                     .hook_runtime
                     .as_ref()
-                    .and_then(|runtime| runtime.session_id_for(id));
+                    .and_then(|runtime| runtime.session_id_for(id))
+                    // A hookless kind carries its own id on the pane instead, minted before its
+                    // spawn - see `crate::work_surface::agents::Agent::session_id`.
+                    .or_else(|| self.agents.session_id_for(id).map(str::to_owned));
                 // GitHub issue #227: the run's own title and completed-turn count, from the same
                 // real hook stream and read ungated for the same reason as the session id - both
                 // describe the run, not the present (`HookListener::run_facts_for`).

--- a/crates/app/src/palette/render.rs
+++ b/crates/app/src/palette/render.rs
@@ -165,6 +165,10 @@ impl AdeApp {
                 secondary: format!("spawn codex {spawn_target}"),
             },
             palette::CommandCandidate {
+                command: palette::PaletteCommand::NewCursorAgent,
+                secondary: format!("spawn cursor-agent {spawn_target}"),
+            },
+            palette::CommandCandidate {
                 command: palette::PaletteCommand::CycleRightPanel,
                 secondary: format!("switch the right panel to {next_sidebar_view}"),
             },
@@ -401,6 +405,9 @@ impl AdeApp {
             }
             palette::PaletteCommand::NewCodexAgent => {
                 self.new_agent(ProcessKind::codex(), window, cx)
+            }
+            palette::PaletteCommand::NewCursorAgent => {
+                self.new_agent(ProcessKind::cursor(), window, cx)
             }
             palette::PaletteCommand::CycleRightPanel => {
                 // Any palette gesture must disarm a pending prune confirmation (see

--- a/crates/app/src/palette/state.rs
+++ b/crates/app/src/palette/state.rs
@@ -113,6 +113,8 @@ pub enum PaletteCommand {
     NewClaudeAgent,
     /// `crate::root::AdeApp::new_agent(ProcessKind::codex(), ..)`.
     NewCodexAgent,
+    /// `crate::root::AdeApp::new_agent(ProcessKind::cursor(), ..)`.
+    NewCursorAgent,
     /// `crate::root::AdeApp::set_right_sidebar_view`, same as the `Files - Search - Changes`
     /// control.
     CycleRightPanel,
@@ -162,10 +164,11 @@ pub enum PaletteCommand {
 }
 
 impl PaletteCommand {
-    pub const ALL: [PaletteCommand; 13] = [
+    pub const ALL: [PaletteCommand; 14] = [
         PaletteCommand::NewShell,
         PaletteCommand::NewClaudeAgent,
         PaletteCommand::NewCodexAgent,
+        PaletteCommand::NewCursorAgent,
         PaletteCommand::CycleRightPanel,
         PaletteCommand::PruneWorktrees,
         PaletteCommand::OpenSettings,
@@ -189,6 +192,7 @@ impl PaletteCommand {
             PaletteCommand::NewShell => "New Shell",
             PaletteCommand::NewClaudeAgent => "New Claude Agent",
             PaletteCommand::NewCodexAgent => "New Codex Agent",
+            PaletteCommand::NewCursorAgent => "New Cursor Agent",
             PaletteCommand::CycleRightPanel => "Cycle Right Panel",
             PaletteCommand::PruneWorktrees => "Prune Worktrees",
             PaletteCommand::OpenSettings => "Open Settings",
@@ -209,6 +213,7 @@ impl PaletteCommand {
             PaletteCommand::NewShell => "shell terminal spawn agent",
             PaletteCommand::NewClaudeAgent => "claude agent spawn agent cli",
             PaletteCommand::NewCodexAgent => "codex agent spawn agent cli",
+            PaletteCommand::NewCursorAgent => "cursor agent spawn agent cli cursor-agent",
             PaletteCommand::CycleRightPanel => {
                 "files search changes find panel sidebar switch toggle tab"
             }
@@ -901,6 +906,7 @@ mod tests {
         assert!(labels.contains(&"New Shell"));
         assert!(labels.contains(&"New Claude Agent"));
         assert!(labels.contains(&"New Codex Agent"));
+        assert!(labels.contains(&"New Cursor Agent"));
         assert!(labels.contains(&"Prune Worktrees"));
         assert!(labels.contains(&"Open Settings"));
     }

--- a/crates/app/src/root/focus.rs
+++ b/crates/app/src/root/focus.rs
@@ -1807,6 +1807,13 @@ mod palette_result_focus_tests {
 
         app.update_in(cx, |app, window, cx| app.open_palette(window, cx));
         cx.run_until_parked();
+        // Typed, not taken from the unfiltered list: with an empty query every command scores
+        // equally and `MAX_ENTRIES_PER_GROUP` keeps only the first eight, so which commands appear
+        // by default shifts whenever one is added (GitHub issue #463 added a third agent-spawn
+        // command and pushed this one out). The subject here is focus restoration, not default
+        // list membership, so this asks for the command by name the way a user would.
+        cx.simulate_input("window controls: system");
+        cx.run_until_parked();
         let ran = app.update(cx, |app, cx| {
             let groups = app.build_palette_groups(cx);
             let index = palette::flatten(&groups).iter().position(|entry| {

--- a/crates/app/src/root/menus.rs
+++ b/crates/app/src/root/menus.rs
@@ -4,7 +4,7 @@
 
 use super::*;
 
-/// Every real floating menu/dropdown surface in the app - the thirteen built on
+/// Every real floating menu/dropdown surface in the app - the fourteen built on
 /// [`crate::root::widgets::menu_popover_chrome`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum MenuSurface {
@@ -63,6 +63,13 @@ pub(crate) enum MenuSurface {
     /// [`crate::root::widgets::menu_popover_chrome`], so it belongs to the same one-at-a-time
     /// invariant.
     Budget,
+    /// The `Start an agent` split button's own agent picker (GitHub issue #463) -
+    /// [`AdeApp::agent_picker_open`]. A separate surface from [`Self::Plus`] rather than a second
+    /// shape of the same field for the reason [`Self::GraphBranch`] is separate from
+    /// [`Self::GraphRow`]: the two are anchored to different controls, and the `+` menu's own
+    /// `New agent` row opens this one, which means both being open at once is exactly the state
+    /// this invariant exists to prevent.
+    AgentPicker,
 }
 
 impl MenuSurface {
@@ -70,7 +77,7 @@ impl MenuSurface {
     /// [`AdeApp::close_menu_surface`] are exhaustive, so a new variant added here cannot compile
     /// until it is really wired to real state - that pairing is what stops a new menu from
     /// quietly opting out of the invariant.
-    pub(crate) const ALL: [MenuSurface; 13] = [
+    pub(crate) const ALL: [MenuSurface; 14] = [
         MenuSurface::Plus,
         MenuSurface::Title,
         MenuSurface::TreeContext,
@@ -84,6 +91,7 @@ impl MenuSurface {
         MenuSurface::RailOverflow,
         MenuSurface::Resources,
         MenuSurface::Budget,
+        MenuSurface::AgentPicker,
     ];
 }
 
@@ -105,6 +113,7 @@ impl AdeApp {
             MenuSurface::RailOverflow => self.rail_overflow_menu.is_some(),
             MenuSurface::Resources => self.resources_popover_open,
             MenuSurface::Budget => self.budget_popover_open,
+            MenuSurface::AgentPicker => self.agent_picker_open.is_some(),
         }
     }
 
@@ -141,6 +150,7 @@ impl AdeApp {
             MenuSurface::RailOverflow => self.rail_overflow_menu = None,
             MenuSurface::Resources => self.resources_popover_open = false,
             MenuSurface::Budget => self.budget_popover_open = false,
+            MenuSurface::AgentPicker => self.agent_picker_open = None,
         }
     }
 
@@ -219,6 +229,9 @@ mod menu_surface_tests {
         });
         app.resources_popover_open = true;
         app.budget_popover_open = true;
+        app.agent_picker_open = Some(crate::work_surface::state::AgentPickerAnchor::StartButton(
+            "context-bar-start-agent",
+        ));
     }
 
     #[gpui::test]

--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -2001,6 +2001,15 @@ pub struct AdeApp {
     /// directly off this rather than a second, independently-computed offset that could drift
     /// once the rail's adjustable width shifts the button. `Bounds::default()` until first paint.
     pub(crate) plus_button_bounds: gpui::Bounds<Pixels>,
+    /// Which control the agent picker popover is open off, if any (GitHub issue #463) - see
+    /// [`Self::render_agent_picker_menu`]. Closed exactly the way [`Self::plus_menu_open`] is.
+    pub(crate) agent_picker_open: Option<work_surface::AgentPickerAnchor>,
+    /// Each `Start an agent` button's painted bounds, captured every render the same
+    /// `gpui::canvas` way [`Self::plus_button_bounds`] is, keyed by that button's element id.
+    /// A map rather than one field because both buttons (the agent context bar's and the empty
+    /// pane's) can be in the tree at once, and a single slot would hold whichever painted last
+    /// rather than the one actually clicked. Empty until first paint.
+    pub(crate) agent_picker_button_bounds: HashMap<&'static str, gpui::Bounds<Pixels>>,
     /// Which of the Windows/Linux title bar's five menu labels ([`crate::title_bar::menu::TitleMenu::ALL`])
     /// has its real dropdown open right now, if any - see [`crate::title_bar::menu::render_title_menu`]'s own
     /// docs. Closed the same way [`Self::plus_menu_open`] is: its own scrim click, picking a row,
@@ -2961,6 +2970,13 @@ impl Render for AdeApp {
             .child(self.render_status_bar(cx))
             .when(self.plus_menu_open, |el| {
                 el.child(self.render_plus_menu(cx))
+            })
+            // The `Start an agent` split button's agent picker (GitHub issue #463) - a
+            // window-positioned overlay for exactly the reason `render_plus_menu` is one: it is
+            // placed off its opener's `gpui::canvas`-captured window-space bounds, so `.absolute()`
+            // positioning built from them is only correct as a direct child of this root element.
+            .when(self.agent_picker_open.is_some(), |el| {
+                el.child(self.render_agent_picker_menu(cx))
             })
             // The status bar's Resources popover (GitHub issue #293) - a window-positioned
             // overlay for exactly the reason `render_plus_menu` is one: it is placed off the

--- a/crates/app/src/root/state.rs
+++ b/crates/app/src/root/state.rs
@@ -693,6 +693,8 @@ impl AdeApp {
             ),
             plus_menu_open: false,
             plus_button_bounds: gpui::Bounds::default(),
+            agent_picker_open: None,
+            agent_picker_button_bounds: HashMap::new(),
             title_menu_open: None,
             title_menu_button_bounds: [gpui::Bounds::default(); title_bar::TitleMenu::ALL.len()],
             _new_agent_pane_task: TaskPool::new(),

--- a/crates/app/src/run_history/model.rs
+++ b/crates/app/src/run_history/model.rs
@@ -8,7 +8,6 @@ use crate::hooks::history::{PastAgent, RunDiffstat};
 use crate::rail::status::Status;
 use crate::root::plural;
 use crate::theme;
-use crate::work_surface::agents::AgentKind;
 
 /// How a run ended.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -514,14 +513,17 @@ impl TranscriptLine {
 /// The command a resume of this run would really be - the transcript's opening line when none was
 /// captured. Only ever this run's own kind and its own checkout.
 fn resume_command_line(run: &PastAgent, branch: Option<&str>) -> String {
-    let command = match (run.kind, run.session_id.as_deref()) {
-        (AgentKind::Claude, Some(session_id)) => format!("claude --resume {session_id}"),
-        (AgentKind::Claude, None) => "cursor-agent".to_string(),
-        (AgentKind::Cursor, Some(session_id)) => format!("cursor-agent --resume={session_id}"),
-        (AgentKind::Cursor, None) => "cursor-agent".to_string(),
-        // Neither of these resumes: `Agents::spawn_resume` is Claude-only, so printing a
-        // `--resume` flag here would advertise something this app doesn't actually do for them.
-        (AgentKind::Codex, _) => "codex".to_string(),
+    // Built from the same `resume_args` the spawn itself uses, so this line cannot advertise a
+    // flag the resume would not really pass - a kind with no verified resume flag, or a run with
+    // no captured id, prints the bare binary and really does start fresh.
+    let binary = run.kind.binary_name();
+    let command = match run
+        .session_id
+        .as_deref()
+        .and_then(|session_id| run.kind.resume_args(session_id))
+    {
+        Some(args) => format!("{binary} {}", args.join(" ")),
+        None => binary.to_string(),
     };
     match branch {
         Some(branch) => format!("\u{276f} {command} \u{b7} {branch}"),
@@ -626,6 +628,7 @@ pub fn closing_lines(run: &PastAgent, now_unix: i64) -> Vec<TranscriptLine> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::work_surface::agents::AgentKind;
 
     fn run(worktree: &str, spawned: i64) -> PastAgent {
         PastAgent {

--- a/crates/app/src/run_history/model.rs
+++ b/crates/app/src/run_history/model.rs
@@ -516,11 +516,12 @@ impl TranscriptLine {
 fn resume_command_line(run: &PastAgent, branch: Option<&str>) -> String {
     let command = match (run.kind, run.session_id.as_deref()) {
         (AgentKind::Claude, Some(session_id)) => format!("claude --resume {session_id}"),
-        (AgentKind::Claude, None) => "claude".to_string(),
+        (AgentKind::Claude, None) => "cursor-agent".to_string(),
+        (AgentKind::Cursor, Some(session_id)) => format!("cursor-agent --resume={session_id}"),
+        (AgentKind::Cursor, None) => "cursor-agent".to_string(),
         // Neither of these resumes: `Agents::spawn_resume` is Claude-only, so printing a
         // `--resume` flag here would advertise something this app doesn't actually do for them.
         (AgentKind::Codex, _) => "codex".to_string(),
-        (AgentKind::Cursor, _) => "cursor-agent".to_string(),
     };
     match branch {
         Some(branch) => format!("\u{276f} {command} \u{b7} {branch}"),

--- a/crates/app/src/run_history/model.rs
+++ b/crates/app/src/run_history/model.rs
@@ -517,7 +517,10 @@ fn resume_command_line(run: &PastAgent, branch: Option<&str>) -> String {
     let command = match (run.kind, run.session_id.as_deref()) {
         (AgentKind::Claude, Some(session_id)) => format!("claude --resume {session_id}"),
         (AgentKind::Claude, None) => "claude".to_string(),
+        // Neither of these resumes: `Agents::spawn_resume` is Claude-only, so printing a
+        // `--resume` flag here would advertise something this app doesn't actually do for them.
         (AgentKind::Codex, _) => "codex".to_string(),
+        (AgentKind::Cursor, _) => "cursor-agent".to_string(),
     };
     match branch {
         Some(branch) => format!("\u{276f} {command} \u{b7} {branch}"),

--- a/crates/app/src/settings/render.rs
+++ b/crates/app/src/settings/render.rs
@@ -498,9 +498,9 @@ impl AdeApp {
 
     /// *Agents › Installed* - the designed card: agent badge, name, binary path, model, a
     /// `default` pill, a green dot and `ready`, then `Edit`. This app drops the
-    /// `model`/`default`/`Edit` pieces (see
-    /// `crate::settings::state`'s module docs for why) and shows [`settings::AGENT_KINDS`]'s two real
-    /// rows instead of the mockup's four fabricated ones, each with a live PATH-derived status.
+    /// `model`/`default`/`Edit` pieces (see `crate::settings::state`'s module docs for why) and
+    /// shows one real row per [`settings::AGENT_KINDS`] entry instead of the mockup's four
+    /// fabricated ones, each with a live PATH-derived status.
     pub(in crate::settings) fn render_settings_agents_page(
         &self,
         cx: &mut Context<Self>,

--- a/crates/app/src/settings/state.rs
+++ b/crates/app/src/settings/state.rs
@@ -176,7 +176,7 @@ pub fn nav_groups() -> Vec<NavGroup> {
 /// that's now structural rather than a documented exclusion: [`AgentKind`] has no `Shell`
 /// variant, so nothing can put one in this array (a shell is a
 /// `crate::work_surface::agents::ProcessKind::Shell`, a different type).
-pub const AGENT_KINDS: [AgentKind; 2] = [AgentKind::Claude, AgentKind::Codex];
+pub const AGENT_KINDS: [AgentKind; 3] = [AgentKind::Claude, AgentKind::Codex, AgentKind::Cursor];
 
 /// One row for the Agents page's Installed card - see [`detect_agent_rows`].
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1259,7 +1259,11 @@ mod tests {
     #[test]
     fn detect_agent_rows_reports_each_binarys_own_real_status() {
         let all_found = detect_agent_rows(|name| Some(PathBuf::from(format!("/usr/bin/{name}"))));
-        assert_eq!(all_found.len(), 2, "one row per AGENT_KINDS entry");
+        assert_eq!(
+            all_found.len(),
+            AGENT_KINDS.len(),
+            "one row per AGENT_KINDS entry"
+        );
         assert!(all_found.iter().all(|row| row.is_ready()));
         assert!(all_found.iter().all(|row| row.status_label() == "ready"));
         let claude = all_found
@@ -1286,6 +1290,20 @@ mod tests {
         };
         assert!(ready(AgentKind::Claude));
         assert!(!ready(AgentKind::Codex));
+        assert!(!ready(AgentKind::Cursor));
+
+        // The Cursor CLI's binary is `cursor-agent`; searching `$PATH` for `cursor` would find
+        // the editor's own launcher on a machine that has it, and report an agent as ready that
+        // this app cannot in fact spawn.
+        let cursor_only = detect_agent_rows(|name| {
+            (name == "cursor-agent").then(|| PathBuf::from("/usr/bin/cursor-agent"))
+        });
+        let cursor = cursor_only
+            .iter()
+            .find(|row| row.kind == AgentKind::Cursor)
+            .expect("a Cursor row should exist");
+        assert_eq!(cursor.binary_name, "cursor-agent");
+        assert!(cursor.is_ready());
     }
 
     fn note(clean: Option<bool>, merged: bool, is_locked: bool) -> WorktreeNote {

--- a/crates/app/src/theme.rs
+++ b/crates/app/src/theme.rs
@@ -1521,10 +1521,10 @@ pub mod agent {
         token("agent.haiku.fg", 0x9d8fd4),
         token("agent.haiku.bg", 0x241f33),
     );
-    /// Steel blue - the pool's fourth hue, unchanged by §4a: already outside all five families.
-    /// Claimed by the Cursor agent CLI in GitHub issue #463; the `local` key name is the mock's
-    /// original `qwen-local` slot and is kept as-is, because it is the public override key every
-    /// built-in and user theme already writes (`assets/themes/*.toml`'s `[agent] local.fg`).
+    /// Steel blue - the Cursor agent CLI. Unchanged by §4a: already outside all five families.
+    /// Claimed by Cursor in GitHub issue #463; the `local` key name is the mock's original
+    /// `qwen-local` slot, kept as-is because it is the public override key every built-in and
+    /// user theme already writes (`assets/themes/*.toml`'s `[agent] local.fg`).
     pub const LOCAL: (ColorToken, ColorToken) = (
         token("agent.local.fg", 0x7f9ad4),
         token("agent.local.bg", 0x1f2941),

--- a/crates/app/src/theme.rs
+++ b/crates/app/src/theme.rs
@@ -1521,7 +1521,10 @@ pub mod agent {
         token("agent.haiku.fg", 0x9d8fd4),
         token("agent.haiku.bg", 0x241f33),
     );
-    /// Steel blue - `qwen-local`. Unchanged by §4a: already outside all five families.
+    /// Steel blue - the pool's fourth hue, unchanged by §4a: already outside all five families.
+    /// Claimed by the Cursor agent CLI in GitHub issue #463; the `local` key name is the mock's
+    /// original `qwen-local` slot and is kept as-is, because it is the public override key every
+    /// built-in and user theme already writes (`assets/themes/*.toml`'s `[agent] local.fg`).
     pub const LOCAL: (ColorToken, ColorToken) = (
         token("agent.local.fg", 0x7f9ad4),
         token("agent.local.bg", 0x1f2941),

--- a/crates/app/src/work_surface/agents.rs
+++ b/crates/app/src/work_surface/agents.rs
@@ -21,6 +21,9 @@ pub enum AgentKind {
     Claude,
     /// The `codex` CLI, spawned the same way as [`AgentKind::Claude`].
     Codex,
+    /// The Cursor agent CLI (GitHub issue #463), spawned the same way as [`AgentKind::Claude`].
+    /// Its binary is `cursor-agent`, not `cursor` - the latter is the editor.
+    Cursor,
 }
 
 impl AgentKind {
@@ -28,6 +31,7 @@ impl AgentKind {
         match self {
             AgentKind::Claude => "Claude",
             AgentKind::Codex => "Codex",
+            AgentKind::Cursor => "Cursor",
         }
     }
 
@@ -38,6 +42,7 @@ impl AgentKind {
         match label {
             "Claude" => Some(AgentKind::Claude),
             "Codex" => Some(AgentKind::Codex),
+            "Cursor" => Some(AgentKind::Cursor),
             _ => None,
         }
     }
@@ -50,6 +55,7 @@ impl AgentKind {
         match self {
             AgentKind::Claude => "claude",
             AgentKind::Codex => "codex",
+            AgentKind::Cursor => "cursor-agent",
         }
     }
 }
@@ -76,6 +82,12 @@ impl ProcessKind {
     /// [`Self::claude`].
     pub const fn codex() -> Self {
         ProcessKind::Agent(AgentKind::Codex)
+    }
+
+    /// Construction-only shorthand for `ProcessKind::Agent(AgentKind::Cursor)` - see
+    /// [`Self::claude`].
+    pub const fn cursor() -> Self {
+        ProcessKind::Agent(AgentKind::Cursor)
     }
 
     pub fn label(self) -> &'static str {
@@ -584,7 +596,7 @@ mod tests {
         // The whole point of the two-type split: `is_agent_session` can only ever be `false`
         // for the one variant that isn't an agent, and there is no `AgentKind` value at all
         // that could make it `false` - `ProcessKind::from` can't produce a shell.
-        for agent in [AgentKind::Claude, AgentKind::Codex] {
+        for agent in [AgentKind::Claude, AgentKind::Codex, AgentKind::Cursor] {
             assert!(
                 ProcessKind::from(agent).is_agent_session(),
                 "{agent:?} wrapped as a ProcessKind must be a real agent session"
@@ -602,8 +614,10 @@ mod tests {
         // the explicit construction, spawn sites would quietly disagree with match arms.
         assert_eq!(ProcessKind::claude(), ProcessKind::Agent(AgentKind::Claude));
         assert_eq!(ProcessKind::codex(), ProcessKind::Agent(AgentKind::Codex));
+        assert_eq!(ProcessKind::cursor(), ProcessKind::Agent(AgentKind::Cursor));
         assert_eq!(ProcessKind::claude(), AgentKind::Claude.into());
         assert_eq!(ProcessKind::codex(), AgentKind::Codex.into());
+        assert_eq!(ProcessKind::cursor(), AgentKind::Cursor.into());
     }
 
     #[test]
@@ -611,8 +625,10 @@ mod tests {
         assert_eq!(ProcessKind::Shell.label(), "Shell");
         assert_eq!(ProcessKind::claude().label(), AgentKind::Claude.label());
         assert_eq!(ProcessKind::codex().label(), AgentKind::Codex.label());
+        assert_eq!(ProcessKind::cursor().label(), AgentKind::Cursor.label());
         assert_eq!(AgentKind::Claude.label(), "Claude");
         assert_eq!(AgentKind::Codex.label(), "Codex");
+        assert_eq!(AgentKind::Cursor.label(), "Cursor");
     }
 
     #[test]
@@ -620,7 +636,7 @@ mod tests {
         // GitHub issue #227's history reader (`crate::hooks::history`) decodes a persisted
         // `PersistedAgentStatus::kind` string back into a real `AgentKind` through this - it must
         // agree with `label` exactly, or a real persisted record would silently fail to decode.
-        for kind in [AgentKind::Claude, AgentKind::Codex] {
+        for kind in [AgentKind::Claude, AgentKind::Codex, AgentKind::Cursor] {
             assert_eq!(AgentKind::from_label(kind.label()), Some(kind));
         }
         assert_eq!(
@@ -634,11 +650,19 @@ mod tests {
     fn each_agent_kind_spawns_its_own_distinct_path_binary() {
         assert_eq!(AgentKind::Claude.binary_name(), "claude");
         assert_eq!(AgentKind::Codex.binary_name(), "codex");
-        assert_ne!(
-            AgentKind::Claude.binary_name(),
-            AgentKind::Codex.binary_name(),
-            "a copy-pasted arm sharing one binary name would spawn the wrong CLI silently"
-        );
+        // `cursor-agent`, not `cursor`: the latter is the Cursor editor's own launcher, so a
+        // slip here would spawn a GUI editor where an agent session was asked for.
+        assert_eq!(AgentKind::Cursor.binary_name(), "cursor-agent");
+        let kinds = [AgentKind::Claude, AgentKind::Codex, AgentKind::Cursor];
+        for (index, kind) in kinds.iter().enumerate() {
+            for other in &kinds[index + 1..] {
+                assert_ne!(
+                    kind.binary_name(),
+                    other.binary_name(),
+                    "a copy-pasted arm sharing one binary name would spawn the wrong CLI silently"
+                );
+            }
+        }
     }
 
     #[test]
@@ -677,7 +701,7 @@ mod tests {
 
     #[test]
     fn the_settings_path_search_and_the_real_spawn_read_the_same_binary_name() {
-        for agent in [AgentKind::Claude, AgentKind::Codex] {
+        for agent in [AgentKind::Claude, AgentKind::Codex, AgentKind::Cursor] {
             let spec = ProcessKind::Agent(agent).spec(PathBuf::from("/tmp"), None, None);
             assert_eq!(
                 spec.program,

--- a/crates/app/src/work_surface/agents.rs
+++ b/crates/app/src/work_surface/agents.rs
@@ -4,7 +4,7 @@
 //! worktree" - see its module docs - this is that one layer up.
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::time::{Instant, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use gpui::{App, AppContext as _, Context, Entity, Focusable as _, Subscription, Window};
 
@@ -57,6 +57,35 @@ impl AgentKind {
             AgentKind::Codex => "codex",
             AgentKind::Cursor => "cursor-agent",
         }
+    }
+
+    /// The argument vector that makes this CLI reattach to `session_id`, or `None` for a kind
+    /// with no resume flag at all - the one place the two spellings live, so a call site can't
+    /// pick the wrong one. Both were checked against a real binary, and both genuinely resume the
+    /// named conversation rather than merely starting a fresh one in the same directory:
+    /// `claude` 2.1.228 (see `crate::hooks::event::HookReport::session_id`), and `cursor-agent`
+    /// 2026.08.11-e8db854, whose `--resume=<id>` recalled a token set by an earlier, separate
+    /// process.
+    ///
+    /// The spellings really do differ: `claude` takes the id as its own argv entry, while
+    /// `cursor-agent`'s `--resume [chatId]` is an *optional*-value option, so a detached
+    /// `--resume <id>` there means "prompt me to pick a session" and treats the id as a prompt.
+    pub fn resume_args(self, session_id: &str) -> Option<Vec<String>> {
+        match self {
+            AgentKind::Claude => Some(vec!["--resume".to_owned(), session_id.to_owned()]),
+            AgentKind::Cursor => Some(vec![format!("--resume={session_id}")]),
+            // `codex` has no resume flag this app has verified, so it never claims one.
+            AgentKind::Codex => None,
+        }
+    }
+
+    /// Whether this CLI can mint a chat id up front, for a kind whose id cannot arrive any other
+    /// way. `claude` learns its own `session_id` from its hooks after the fact; `cursor-agent` is
+    /// hookless here (see `crate::hooks::flow::AdeApp::hook_injection_for`), so its id has to be
+    /// created before the spawn that uses it - `cursor-agent create-chat` prints a bare UUID for
+    /// exactly this.
+    pub fn mints_chat_id(self) -> bool {
+        matches!(self, AgentKind::Cursor)
     }
 }
 
@@ -157,6 +186,12 @@ pub struct Agent {
     /// The same spawn moment as [`Self::spawned_at`], but as real wall-clock seconds since the
     /// Unix epoch - set from the identical call site, at the identical instant.
     pub spawned_at_unix: i64,
+    /// The conversation this pane is attached to, for a kind that cannot learn one from hooks.
+    /// `None` for `AgentKind::Claude`, whose id arrives later on the hook side-channel and is
+    /// read from there (`crate::hooks::HookRuntime::session_id_for`) rather than stored here, and
+    /// `None` for any Cursor pane whose id could not be minted at spawn time - an agent with no
+    /// id is simply not resumable, which is what the run-history footer already says.
+    pub session_id: Option<String>,
     /// Keeps [`Agents::spawn`]'s link-click-opens-a-file subscription (see
     /// [`TerminalPaneEvent`]) alive for this agent's lifetime - never read, only held.
     _link_subscription: Subscription,
@@ -298,16 +333,42 @@ impl Agents {
         window: &mut Window,
         cx: &mut Context<AdeApp>,
     ) -> AgentId {
-        self.spawn_inner(
+        // A kind with no verified resume flag ([`AgentKind::resume_args`]) is spawned bare rather
+        // than handed an invented one - it is then simply a fresh agent in the same worktree,
+        // which is what the run-history footer already tells the user it will be.
+        let leading_args = agent_kind.resume_args(&session_id).unwrap_or_default();
+        let id = self.spawn_inner(
             ProcessKind::Agent(agent_kind),
             cwd,
             terminal_font_size_px,
             shell_override,
             hooks,
-            vec!["--resume".to_owned(), session_id],
+            leading_args,
             window,
             cx,
-        )
+        );
+        // A hookless kind has no other way to report which conversation this pane is - see
+        // [`Agent::session_id`].
+        self.set_session_id(id, session_id);
+        id
+    }
+
+    /// Records the conversation id a pane is attached to, for a kind that cannot learn one from
+    /// hooks - see [`Agent::session_id`]. A no-op for an id that isn't open.
+    pub fn set_session_id(&mut self, id: AgentId, session_id: String) {
+        if let Some(agent) = self.agents.iter_mut().find(|agent| agent.id == id) {
+            agent.session_id = Some(session_id);
+        }
+    }
+
+    /// The conversation id this pane is attached to, if it was known at spawn time - `None` for
+    /// every kind whose id arrives through hooks instead (see [`Agent::session_id`]).
+    pub fn session_id_for(&self, id: AgentId) -> Option<&str> {
+        self.agents
+            .iter()
+            .find(|agent| agent.id == id)?
+            .session_id
+            .as_deref()
     }
 
     /// The real shared core of [`Self::spawn`]/[`Self::spawn_resume`] - identical in every way
@@ -358,6 +419,7 @@ impl Agents {
             pane,
             spawned_at: Instant::now(),
             spawned_at_unix: unix_now(),
+            session_id: None,
             _link_subscription: link_subscription,
         });
         self.active = Some(id);
@@ -609,6 +671,50 @@ mod tests {
     }
 
     #[test]
+    fn each_kinds_resume_spelling_is_the_one_its_own_cli_accepts() {
+        // The two spellings are not interchangeable, and neither is guessed: `claude` 2.1.228
+        // takes the id as a separate argv entry, while `cursor-agent`'s `--resume [chatId]` is an
+        // optional-value option, so a detached id there is read as a prompt rather than a chat.
+        assert_eq!(
+            AgentKind::Claude.resume_args("abc"),
+            Some(vec!["--resume".to_owned(), "abc".to_owned()])
+        );
+        assert_eq!(
+            AgentKind::Cursor.resume_args("abc"),
+            Some(vec!["--resume=abc".to_owned()]),
+            "cursor-agent must receive one argv entry, not two"
+        );
+        assert_eq!(
+            AgentKind::Codex.resume_args("abc"),
+            None,
+            "a kind with no verified resume flag must never claim one"
+        );
+    }
+
+    #[test]
+    fn only_a_hookless_kind_mints_its_own_chat_id() {
+        // Claude's id arrives on the hook side-channel after the fact, so minting one for it
+        // would attach the pane to a conversation its own CLI knows nothing about.
+        assert!(AgentKind::Cursor.mints_chat_id());
+        assert!(!AgentKind::Claude.mints_chat_id());
+        assert!(!AgentKind::Codex.mints_chat_id());
+    }
+
+    #[test]
+    fn a_kind_that_mints_an_id_can_always_spend_it() {
+        // The two halves have to agree: minting an id for a kind that has no resume flag would
+        // pay for a chat id and then spawn without it.
+        for kind in [AgentKind::Claude, AgentKind::Codex, AgentKind::Cursor] {
+            if kind.mints_chat_id() {
+                assert!(
+                    kind.resume_args("some-id").is_some(),
+                    "{kind:?} mints a chat id but has no way to pass one"
+                );
+            }
+        }
+    }
+
+    #[test]
     fn the_construction_shorthands_are_exactly_their_long_forms() {
         // `claude()`/`codex()` exist only to keep call sites short; if they ever drifted from
         // the explicit construction, spawn sites would quietly disagree with match arms.
@@ -732,5 +838,134 @@ mod tests {
             PathBuf::from("claude"),
             "a configured shell must not be substituted for an agent CLI's own binary"
         );
+    }
+}
+
+/// How long [`AdeApp::spawn_with_minted_chat_id`] waits for a chat id before giving up and
+/// spawning a plain, unresumable agent. Generous because minting is a real network round-trip,
+/// bounded because `cursor-agent create-chat` hangs forever rather than failing when the user is
+/// not logged in.
+const CHAT_ID_MINT_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// Whether a line a CLI printed can be taken as a conversation id rather than a message it wrote
+/// to stdout instead. Shape-only - the real check is that the resumed agent attaches, which only
+/// the CLI itself can decide.
+fn is_plausible_chat_id(line: &str) -> bool {
+    !line.is_empty()
+        && line.len() <= 128
+        && line
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || character == '-')
+}
+
+impl AdeApp {
+    /// Spawns a kind that has to be handed its conversation id up front
+    /// ([`AgentKind::mints_chat_id`]): mints one off the UI thread, then spawns attached to it.
+    ///
+    /// A mint that fails - no binary, not logged in, or the timeout - falls back to a plain bare
+    /// spawn. That agent is then simply not resumable, which the run-history footer already
+    /// reports honestly rather than offering a resume that would start a fresh chat instead.
+    pub(crate) fn spawn_with_minted_chat_id(
+        &mut self,
+        agent_kind: AgentKind,
+        cwd: PathBuf,
+        cx: &mut Context<Self>,
+    ) {
+        let font_size = self.settings.appearance.terminal_font_size;
+        let shell_override = self.settings.terminal.shell_override().map(str::to_owned);
+        let binary = agent_kind.binary_name();
+        let mint_cwd = cwd.clone();
+        let task = cx.spawn(async move |this, cx| {
+            let chat_id = cx
+                .background_executor()
+                .spawn(async move { mint_chat_id(binary, &mint_cwd) })
+                .await;
+            let _ = this.update_in(cx, |this, window, cx| {
+                let hook_injection = this.hook_injection_for(ProcessKind::Agent(agent_kind));
+                let id = match chat_id {
+                    Some(chat_id) => this.agents.spawn_resume(
+                        agent_kind,
+                        cwd,
+                        font_size,
+                        shell_override.as_deref(),
+                        hook_injection.as_ref(),
+                        chat_id,
+                        window,
+                        cx,
+                    ),
+                    None => this.agents.spawn(
+                        ProcessKind::Agent(agent_kind),
+                        cwd,
+                        font_size,
+                        shell_override.as_deref(),
+                        hook_injection.as_ref(),
+                        window,
+                        cx,
+                    ),
+                };
+                this.after_agent_spawn(id, window, cx);
+            });
+        });
+        // Same `TaskPool` reasoning as `AdeApp::new_agent_pane`: two rapid clicks must each get
+        // their own agent rather than the second cancelling the first.
+        self._new_agent_pane_task.push(task);
+    }
+}
+
+/// Runs the CLI's own "give me a new chat id" command, or `None` if it could not produce one.
+///
+/// Blocking - callers run it on the background executor.
+fn mint_chat_id(binary: &str, cwd: &Path) -> Option<String> {
+    // Tests never mint: this is a real subprocess making a real network call, and a UI test that
+    // reached it would hang on the machine of anyone who has the CLI installed. The fallback it
+    // takes instead is the same path production takes when minting fails, so the spawn stays
+    // covered either way, and the capture helper is tested directly in its own crate.
+    if cfg!(test) {
+        return None;
+    }
+    match pty_core::capture_first_line(binary, &["create-chat"], cwd, CHAT_ID_MINT_TIMEOUT) {
+        Ok(line) if is_plausible_chat_id(&line) => Some(line),
+        Ok(line) => {
+            log::warn!("`{binary} create-chat` printed {line:?}, not a chat id");
+            None
+        }
+        Err(err) => {
+            log::warn!("could not mint a {binary} chat id ({err}) - this agent starts unresumable");
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod chat_id_tests {
+    use super::is_plausible_chat_id;
+
+    #[test]
+    fn a_real_minted_id_is_accepted() {
+        // The exact shape `cursor-agent create-chat` really printed.
+        assert!(is_plausible_chat_id("51a6b5fa-fbf4-4116-b44c-cd3e0aa35a5e"));
+    }
+
+    #[test]
+    fn a_message_printed_instead_of_an_id_is_refused() {
+        // A CLI that reports a failure on stdout must not have its prose spliced into an argv as
+        // though it were a conversation id.
+        for line in [
+            "",
+            "Not logged in",
+            "error: authentication required",
+            "You must run `cursor-agent login` first",
+            "--resume=x; rm -rf /",
+        ] {
+            assert!(
+                !is_plausible_chat_id(line),
+                "{line:?} must not be treated as a chat id"
+            );
+        }
+    }
+
+    #[test]
+    fn an_absurdly_long_line_is_refused() {
+        assert!(!is_plausible_chat_id(&"a".repeat(129)));
     }
 }

--- a/crates/app/src/work_surface/render.rs
+++ b/crates/app/src/work_surface/render.rs
@@ -110,6 +110,15 @@ impl AdeApp {
             cx.notify();
             return;
         }
+        // A kind whose conversation id can only be known by minting one first has to spawn
+        // asynchronously - see `Self::spawn_with_minted_chat_id`. Ordered after the discard guard
+        // so a doomed worktree costs no chat id.
+        if let ProcessKind::Agent(agent_kind) = kind {
+            if agent_kind.mints_chat_id() {
+                self.spawn_with_minted_chat_id(agent_kind, cwd, cx);
+                return;
+            }
+        }
         // GitHub issue #239 phase 2: a Claude agent is spawned against this instance's generated
         // `--settings` file and told, through its environment, where to report its hooks. Taken as
         // an owned snapshot because `self.agents.spawn` borrows `self.agents` mutably - see
@@ -124,13 +133,24 @@ impl AdeApp {
             window,
             cx,
         );
-        // GitHub issue #225: capture this agent's review baseline - a real snapshot of the
-        // worktree exactly as it stands right now, so "what has this agent changed" has a real
-        // base point to be measured against. Hooked here, at `Agents::spawn`'s caller rather than
-        // inside `Agents` itself, for the same reason `load_diff` is triggered by its caller:
-        // `Agents` owns processes and tabs, not git snapshots. See
-        // `crate::review::flow::AdeApp::capture_review_baseline` for the small, accepted race
-        // between the process starting and the snapshot landing.
+        self.after_agent_spawn(id, window, cx);
+    }
+
+    /// Everything that must follow a real spawn, wherever the spawn came from - shared so the
+    /// asynchronous Cursor door ([`Self::spawn_with_minted_chat_id`]) cannot drift from the
+    /// synchronous one.
+    ///
+    /// The review baseline is captured here, at `Agents::spawn`'s caller rather than inside
+    /// `Agents` itself, for the same reason `load_diff` is triggered by its caller: `Agents` owns
+    /// processes and tabs, not git snapshots. See
+    /// `crate::review::flow::AdeApp::capture_review_baseline` for the small, accepted race between
+    /// the process starting and the snapshot landing.
+    pub(crate) fn after_agent_spawn(
+        &mut self,
+        id: crate::work_surface::agents::AgentId,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
         self.capture_review_baseline(id, cx);
         // A new tab changes this worktree's real tab session - see `crate::work_surface::session`.
         self.record_worktree_session(cx);
@@ -1640,6 +1660,12 @@ impl AdeApp {
             // (`Self::focus_newly_spawned_agent`) - `Entity::update_in` provides it.
             let _ = this.update_in(cx, |this, window, cx| {
                 let kind = installed.unwrap_or(settings::AGENT_KINDS[0]);
+                // A minting kind needs a second async hop before it can spawn - see
+                // `Self::spawn_with_minted_chat_id`.
+                if kind.mints_chat_id() {
+                    this.spawn_with_minted_chat_id(kind, cwd, cx);
+                    return;
+                }
                 let hook_injection = this.hook_injection_for(ProcessKind::Agent(kind));
                 let id = this.agents.spawn(
                     ProcessKind::Agent(kind),
@@ -6082,7 +6108,6 @@ mod tab_label_tooltip_tests {
         );
     }
 }
-
 
 /// GitHub issue #463: the `Start an agent` split button's own agent picker, and the `+` menu's
 /// `New agent` row now opening it rather than spawning whichever CLI happened to resolve first.

--- a/crates/app/src/work_surface/render.rs
+++ b/crates/app/src/work_surface/render.rs
@@ -1525,9 +1525,10 @@ impl AdeApp {
                     )
                     .on_click(cx.listener(
                         |this, _event: &ClickEvent, _window, cx| {
-                            this.new_agent_pane(cx);
-                            this.plus_menu_open = false;
-                            cx.notify();
+                            // Opens the picker rather than spawning outright (GitHub issue #463):
+                            // the chip beside this row only ever showed the *resolved* kind, so
+                            // this row was the one door with no way to reach the others.
+                            this.toggle_agent_picker(work_surface::AgentPickerAnchor::PlusMenu, cx);
                         },
                     )),
                 )
@@ -1592,11 +1593,12 @@ impl AdeApp {
             )
     }
 
-    /// Which agent kind the `+` menu's "New agent" row would spawn right now: the first
+    /// Which agent kind a default `Start an agent` gesture resolves to right now: the first
     /// [`settings::AGENT_KINDS`] entry [`Self::agent_rows`] (refreshed on menu open) confirms is
     /// installed, or `AGENT_KINDS[0]` if none are (or `agent_rows` hasn't been populated yet).
-    /// Display-only - [`Self::new_agent_pane`] runs its own detection independently, off the
-    /// foreground thread, at the moment it actually spawns.
+    /// Display-only - it draws the `+` menu's "New agent" chip, and [`Self::new_agent_pane`] runs
+    /// its own detection independently, off the foreground thread, at the moment it actually
+    /// spawns. Picking a *specific* kind is [`Self::render_agent_picker_menu`], not this.
     pub(crate) fn resolved_new_agent_kind(&self) -> AgentKind {
         settings::AGENT_KINDS
             .into_iter()
@@ -1608,10 +1610,12 @@ impl AdeApp {
             .unwrap_or(settings::AGENT_KINDS[0])
     }
 
-    /// The `+` menu's "New agent" action (`secondary-shift-n`) - spawns the first
-    /// [`settings::AGENT_KINDS`] entry a background `$PATH` search
+    /// The default new-agent action (`secondary-shift-n`, and the `Start an agent` button's own
+    /// body) - spawns the first [`settings::AGENT_KINDS`] entry a background `$PATH` search
     /// (`pty_core::resolve_on_path`, the same search [`Self::load_agent_rows`] runs) confirms is
-    /// installed, rather than blocking the click on a filesystem walk.
+    /// installed, rather than blocking the click on a filesystem walk. The button's caret and the
+    /// `+` menu's "New agent" row go through [`Self::render_agent_picker_menu`] instead, which
+    /// spawns exactly the kind that was picked.
     pub(crate) fn new_agent_pane(&mut self, cx: &mut Context<Self>) {
         // GitHub issue #90: the same real "nothing to spawn into yet" guard [`Self::new_agent`]'s
         // own docs explain - see those for the concrete bug this closes.
@@ -2012,9 +2016,12 @@ impl AdeApp {
         }
     }
 
-    /// The `Start an agent` button - a filled blue button with a `mod+shift+N` keycap hint. Real,
-    /// not decorative: dispatches [`Self::new_agent_pane`], the same entry point the tab strip's
-    /// `+` menu row and its own global `secondary-shift-n` keybinding already use.
+    /// The `Start an agent` split button - a filled blue button with a `mod+shift+N` keycap hint,
+    /// plus a caret half that opens [`Self::render_agent_picker_menu`] (GitHub issue #463). The
+    /// body keeps dispatching [`Self::new_agent_pane`], the same entry point the tab strip's `+`
+    /// menu row and the global `secondary-shift-n` keybinding already use, so nothing about the
+    /// existing gesture changes; the caret is how a machine with more than one agent CLI installed
+    /// reaches the kinds `new_agent_pane`'s first-installed-wins search doesn't pick.
     pub(in crate::work_surface) fn render_start_agent_button(
         &self,
         element_id: &'static str,
@@ -2023,38 +2030,192 @@ impl AdeApp {
         let colors = work_surface::action_button_colors(work_surface::ActionStyle::PrimaryBlue);
         let macos = self.window_controls_style().is_macos();
         let parts = keymap::resolve_combo("mod+shift+N", macos);
+        let anchor = work_surface::AgentPickerAnchor::StartButton(element_id);
+        let picker_open = self.agent_picker_open == Some(anchor);
 
         div()
             .id(element_id)
             .debug_selector(move || element_id.to_string())
             .flex_none()
-            .cursor_pointer()
             .h(px(20.0))
-            .px(px(8.0))
-            .gap(px(6.0))
             .rounded(theme::radius::BUTTON)
             .border_1()
             .border_color(colors.border)
             .bg(colors.bg)
             .flex()
             .items_center()
-            .hover(|el| el.bg(theme::button::BLUE_BG_HOVER))
+            .child({
+                let this = cx.entity();
+                gpui::canvas(
+                    move |bounds, _window, cx| {
+                        this.update(cx, |this, _cx| {
+                            this.agent_picker_button_bounds.insert(element_id, bounds);
+                        });
+                    },
+                    |_, _, _, _| {},
+                )
+                .absolute()
+                .size_full()
+            })
             .child(
                 div()
-                    .font(font(theme::font::SANS))
-                    .font_weight(gpui::FontWeight::MEDIUM)
-                    .text_size(px(10.5))
-                    .text_color(colors.fg)
-                    .child("Start an agent"),
+                    .id(format!("{element_id}-body"))
+                    .cursor_pointer()
+                    .flex()
+                    .items_center()
+                    .h_full()
+                    .px(px(8.0))
+                    .gap(px(6.0))
+                    .hover(|el| el.bg(theme::button::BLUE_BG_HOVER))
+                    .child(
+                        div()
+                            .font(font(theme::font::SANS))
+                            .font_weight(gpui::FontWeight::MEDIUM)
+                            .text_size(px(10.5))
+                            .text_color(colors.fg)
+                            .child("Start an agent"),
+                    )
+                    .child(render_action_keycap_row(
+                        &parts,
+                        colors.keycap_fg,
+                        colors.keycap_border,
+                    ))
+                    .on_click(cx.listener(|this, _event: &ClickEvent, _window, cx| {
+                        this.new_agent_pane(cx);
+                    })),
             )
-            .child(render_action_keycap_row(
-                &parts,
-                colors.keycap_fg,
-                colors.keycap_border,
-            ))
+            .child(div().flex_none().w(px(1.0)).h(px(12.0)).bg(colors.border))
+            .child(
+                div()
+                    .id(format!("{element_id}-caret"))
+                    .debug_selector(move || format!("{element_id}-caret"))
+                    .cursor_pointer()
+                    .flex()
+                    .items_center()
+                    .justify_center()
+                    .h_full()
+                    .w(px(16.0))
+                    .when(picker_open, |el| el.bg(theme::button::BLUE_BG_HOVER))
+                    .hover(|el| el.bg(theme::button::BLUE_BG_HOVER))
+                    .child(
+                        div()
+                            .font(font(theme::font::MONO))
+                            .text_size(px(8.0))
+                            .text_color(colors.fg)
+                            .child("\u{25be}"),
+                    )
+                    .on_click(cx.listener(move |this, _event: &ClickEvent, _window, cx| {
+                        this.toggle_agent_picker(anchor, cx);
+                    })),
+            )
+    }
+
+    /// Opens the agent picker off `anchor`, or closes it if that same anchor already had it open.
+    /// Refreshes [`Self::load_agent_rows`] on open for the same reason
+    /// [`Self::render_tab_strip_plus`] does: the rows' ready/not-on-PATH text is only honest if the
+    /// `$PATH` search behind it is reasonably fresh rather than a possibly-empty cached snapshot.
+    pub(crate) fn toggle_agent_picker(
+        &mut self,
+        anchor: work_surface::AgentPickerAnchor,
+        cx: &mut Context<Self>,
+    ) {
+        let opening = self.agent_picker_open != Some(anchor);
+        // Read before the sweep and applied after it, exactly as `render_tab_strip_plus` does -
+        // the sweep clears `agent_picker_open` itself (GitHub issue #176's invariant).
+        let _ = self.close_menu_surfaces_except(Some(menus::MenuSurface::AgentPicker));
+        self.agent_picker_open = opening.then_some(anchor);
+        if opening {
+            self.load_agent_rows(cx);
+        }
+        cx.notify();
+    }
+
+    /// Whether the `$PATH` search has answered for `kind` yet, and what it said - `None` while
+    /// [`Self::agent_rows`] has no row for it (the search hasn't run, or hasn't landed). Never
+    /// collapses "not searched" into "not installed"; see
+    /// [`work_surface::agent_picker_secondary_text`].
+    pub(crate) fn agent_kind_is_installed(&self, kind: AgentKind) -> Option<bool> {
+        self.agent_rows
+            .iter()
+            .find(|row| row.kind == kind)
+            .map(|row| row.is_ready())
+    }
+
+    /// The agent picker popover (GitHub issue #463): one row per [`settings::AGENT_KINDS`] entry,
+    /// each spawning exactly that kind. Same overlay shape as [`Self::render_plus_menu`] - a
+    /// transparent scrim that closes on click, and a panel that stops the click bubbling - and
+    /// positioned off whichever control opened it (see
+    /// [`work_surface::AgentPickerAnchor`]).
+    pub(crate) fn render_agent_picker_menu(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        let bounds = match self.agent_picker_open {
+            Some(work_surface::AgentPickerAnchor::StartButton(element_id)) => self
+                .agent_picker_button_bounds
+                .get(element_id)
+                .copied()
+                .unwrap_or_default(),
+            // The `+` menu's own `New agent` row opens this, and that menu closes as it does, so
+            // the `+` button itself is the anchor left on screen to hang it off.
+            Some(work_surface::AgentPickerAnchor::PlusMenu) | None => self.plus_button_bounds,
+        };
+        let branch = self.current_worktree_branch();
+
+        let mut panel = menu_popover_chrome(
+            div()
+                .id("agent-picker-popover")
+                .absolute()
+                .left(bounds.origin.x)
+                .top(bounds.origin.y + bounds.size.height + px(4.0))
+                .w(theme::zone::PLUS_MENU_WIDTH)
+                .py(px(4.0)),
+            theme::shadow::MENU,
+        )
+        .on_click(cx.listener(|_this, _event: &ClickEvent, _window, cx| {
+            cx.stop_propagation();
+        }));
+
+        for kind in settings::AGENT_KINDS {
+            let installed = self.agent_kind_is_installed(kind);
+            let enabled = work_surface::agent_picker_row_enabled(installed);
+            let process_kind = ProcessKind::from(kind);
+            let (chip_fg, chip_bg) = work_surface::agent_tint(process_kind);
+            panel = panel.child(
+                render_dropdown_menu_row(
+                    work_surface::agent_initial(process_kind),
+                    chip_fg,
+                    chip_bg,
+                    kind.label(),
+                    work_surface::agent_picker_secondary_text(
+                        installed,
+                        kind.binary_name(),
+                        branch.as_deref(),
+                    ),
+                    // No keycap: only the resolved default has a keybinding, and printing
+                    // `mod+shift+N` beside every row would claim three shortcuts that don't exist.
+                    Vec::new(),
+                    enabled,
+                )
+                .when(enabled, |row| {
+                    row.on_click(cx.listener(move |this, _event: &ClickEvent, window, cx| {
+                        this.agent_picker_open = None;
+                        this.new_agent(process_kind, window, cx);
+                    }))
+                }),
+            );
+        }
+
+        div()
+            .id("agent-picker-scrim")
+            .absolute()
+            .top(px(0.0))
+            .left(px(0.0))
+            .right(px(0.0))
+            .bottom(px(0.0))
+            .bg(work_surface::TRANSPARENT)
             .on_click(cx.listener(|this, _event: &ClickEvent, _window, cx| {
-                this.new_agent_pane(cx);
+                this.agent_picker_open = None;
+                cx.notify();
             }))
+            .child(panel)
     }
 
     /// Surface A/B's shared header: the resolved program label (this app has no saved-agent
@@ -5919,5 +6080,203 @@ mod tab_label_tooltip_tests {
             "every tab kind goes through the same capped label, not just agent tabs - this file \
              tab painted {width:?}"
         );
+    }
+}
+
+
+/// GitHub issue #463: the `Start an agent` split button's own agent picker, and the `+` menu's
+/// `New agent` row now opening it rather than spawning whichever CLI happened to resolve first.
+#[cfg(test)]
+mod agent_picker_tests {
+    use crate::root::AdeApp;
+    use crate::settings::state as settings;
+    use crate::work_surface::agents::{AgentId, AgentKind, ProcessKind};
+    use crate::work_surface::state as work_surface;
+    use gpui::TestAppContext;
+    use std::path::PathBuf;
+
+    /// Clears the app's startup agents so the empty pane - and with it the `Start an agent`
+    /// button this whole module is about - is what paints.
+    fn close_every_agent(app: &gpui::Entity<AdeApp>, cx: &mut gpui::VisualTestContext) {
+        let startup: Vec<AgentId> = app.read_with(cx, |app, _| {
+            app.agents.iter().map(|agent| agent.id).collect()
+        });
+        app.update_in(cx, |app, window, cx| {
+            for id in startup {
+                app.close_agent(id, window, cx);
+            }
+        });
+        cx.run_until_parked();
+    }
+
+    /// Writes a real [`settings::AgentRow`] set directly, so a test's outcome doesn't depend on
+    /// which agent CLIs happen to be installed on the machine running it. `ready` names the kinds
+    /// whose `$PATH` search is to have succeeded; every other kind gets a row saying it genuinely
+    /// isn't installed.
+    fn set_agent_rows(
+        app: &gpui::Entity<AdeApp>,
+        cx: &mut gpui::VisualTestContext,
+        ready: &[AgentKind],
+    ) {
+        app.update(cx, |app, cx| {
+            app.agent_rows = settings::AGENT_KINDS
+                .into_iter()
+                .map(|kind| settings::AgentRow {
+                    kind,
+                    binary_name: kind.binary_name(),
+                    resolved_path: ready
+                        .contains(&kind)
+                        .then(|| PathBuf::from(format!("/usr/local/bin/{}", kind.binary_name()))),
+                })
+                .collect();
+            cx.notify();
+        });
+        cx.run_until_parked();
+    }
+
+    #[gpui::test]
+    fn the_start_agent_carets_picker_lists_every_agent_kind(cx: &mut TestAppContext) {
+        let repo = crate::test_support::temp_repo();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+        close_every_agent(&app, cx);
+
+        let caret = cx
+            .debug_bounds("empty-state-start-agent-caret")
+            .expect("the empty state's `Start an agent` button must have a real picker caret");
+        cx.simulate_click(caret.center(), gpui::Modifiers::none());
+        cx.run_until_parked();
+        set_agent_rows(&app, cx, &settings::AGENT_KINDS);
+
+        assert_eq!(
+            app.read_with(cx, |app, _| app.agent_picker_open),
+            Some(work_surface::AgentPickerAnchor::StartButton(
+                "empty-state-start-agent"
+            )),
+            "a real click on the caret must open the picker off that button, not some other anchor"
+        );
+        // `debug_bounds` takes a `&'static str`, so the selectors are spelled out - and the
+        // length assertion below is what stops a fourth `AGENT_KINDS` entry from being added
+        // without a row here.
+        for selector in [
+            "dropdown-menu-row-Claude",
+            "dropdown-menu-row-Codex",
+            "dropdown-menu-row-Cursor",
+        ] {
+            assert!(
+                cx.debug_bounds(selector).is_some(),
+                "{selector} must be a real row in the picker - a kind this app can spawn but the \
+                 picker doesn't list is unreachable from every button door"
+            );
+        }
+        assert_eq!(
+            settings::AGENT_KINDS.len(),
+            3,
+            "the picker must list every spawnable agent kind, and this test only checks three"
+        );
+    }
+
+    #[gpui::test]
+    fn picking_cursor_really_spawns_a_cursor_agent(cx: &mut TestAppContext) {
+        let repo = crate::test_support::temp_repo();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+        close_every_agent(&app, cx);
+
+        let caret = cx
+            .debug_bounds("empty-state-start-agent-caret")
+            .expect("the picker caret must be painted");
+        cx.simulate_click(caret.center(), gpui::Modifiers::none());
+        cx.run_until_parked();
+        set_agent_rows(&app, cx, &settings::AGENT_KINDS);
+
+        let cursor_row = cx
+            .debug_bounds("dropdown-menu-row-Cursor")
+            .expect("the Cursor row must be painted with the picker open");
+        cx.simulate_click(cursor_row.center(), gpui::Modifiers::none());
+        cx.run_until_parked();
+
+        app.read_with(cx, |app, _| {
+            assert!(
+                app.agents
+                    .iter()
+                    .any(|agent| agent.kind == ProcessKind::cursor()),
+                "picking Cursor must spawn a real Cursor agent - the whole point of the picker is \
+                 that it spawns the kind that was picked, not the first one on PATH"
+            );
+            assert!(
+                app.agent_picker_open.is_none(),
+                "and picking a row closes the picker, like every other menu row in this app"
+            );
+        });
+    }
+
+    #[gpui::test]
+    fn a_kind_that_is_really_not_on_path_cannot_be_picked(cx: &mut TestAppContext) {
+        let repo = crate::test_support::temp_repo();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+        close_every_agent(&app, cx);
+
+        let caret = cx
+            .debug_bounds("empty-state-start-agent-caret")
+            .expect("the picker caret must be painted");
+        cx.simulate_click(caret.center(), gpui::Modifiers::none());
+        cx.run_until_parked();
+        // Only Claude resolved: Cursor's row is the real "the search came back negative" case.
+        set_agent_rows(&app, cx, &[AgentKind::Claude]);
+
+        let cursor_row = cx
+            .debug_bounds("dropdown-menu-row-Cursor")
+            .expect("an uninstalled kind is still listed - it just says why it can't be picked");
+        cx.simulate_click(cursor_row.center(), gpui::Modifiers::none());
+        cx.run_until_parked();
+
+        app.read_with(cx, |app, _| {
+            assert!(
+                !app.agents
+                    .iter()
+                    .any(|agent| agent.kind == ProcessKind::cursor()),
+                "a row whose binary the $PATH search really didn't find must not spawn anything - \
+                 a pane that exists only to show a spawn error is fake functionality"
+            );
+        });
+    }
+
+    #[gpui::test]
+    fn the_plus_menus_new_agent_row_opens_the_picker_rather_than_spawning(cx: &mut TestAppContext) {
+        let repo = crate::test_support::temp_repo();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+        let before = app.read_with(cx, |app, _| app.agents.iter().count());
+
+        app.update(cx, |app, cx| {
+            app.plus_menu_open = true;
+            cx.notify();
+        });
+        cx.run_until_parked();
+
+        let new_agent = cx
+            .debug_bounds("dropdown-menu-row-New agent")
+            .expect("\"New agent\" row must be painted while the + menu is open");
+        cx.simulate_click(new_agent.center(), gpui::Modifiers::none());
+        cx.run_until_parked();
+
+        app.read_with(cx, |app, _| {
+            assert_eq!(
+                app.agent_picker_open,
+                Some(work_surface::AgentPickerAnchor::PlusMenu),
+                "the row must open the picker anchored to the + button the menu hung off"
+            );
+            assert!(
+                !app.plus_menu_open,
+                "and the + menu itself closes - two popovers painted at once is issue #176's bug"
+            );
+            assert_eq!(
+                app.agents.iter().count(),
+                before,
+                "the row no longer spawns on its own: the pick is what spawns"
+            );
+        });
     }
 }

--- a/crates/app/src/work_surface/session.rs
+++ b/crates/app/src/work_surface/session.rs
@@ -302,8 +302,8 @@ mod session_restore_tests {
                     Some(match agent.kind {
                         ProcessKind::Shell => Slot::Shell,
                         ProcessKind::Agent(AgentKind::Claude) => Slot::Claude,
-                        ProcessKind::Agent(AgentKind::Codex) => {
-                            panic!("no test here spawns a Codex agent into a live strip")
+                        ProcessKind::Agent(AgentKind::Codex | AgentKind::Cursor) => {
+                            panic!("no test here spawns a Codex or Cursor agent into a live strip")
                         }
                     })
                 }

--- a/crates/app/src/work_surface/session.rs
+++ b/crates/app/src/work_surface/session.rs
@@ -68,14 +68,23 @@ impl AdeApp {
             .collect()
     }
 
-    /// The real Claude Code `session_id` currently known for a live agent, or `None`.
+    /// The conversation id currently known for a live agent, or `None`.
+    ///
+    /// Two real sources, because the two kinds learn theirs differently: Claude's arrives on the
+    /// hook side-channel and lands in the persisted status record, while a hookless kind carries
+    /// its own on the pane from the moment it was minted
+    /// (`crate::work_surface::agents::Agent::session_id`). The pane is checked second so a hook
+    /// report, which reflects what the CLI itself believes, always wins.
     fn live_agent_session_id(
         &self,
         agent: &crate::work_surface::agents::Agent,
         kind: AgentKind,
     ) -> Option<String> {
         let key = crate::review::state::baseline_key(&agent.cwd, kind, agent.spawned_at_unix);
-        self.agent_status_state.get(&key)?.session_id.clone()
+        self.agent_status_state
+            .get(&key)
+            .and_then(|record| record.session_id.clone())
+            .or_else(|| agent.session_id.clone())
     }
 
     /// Reopens `cwd`'s persisted tab session for real - the read side of this module, and the one
@@ -152,12 +161,12 @@ impl AdeApp {
                     order.push(TabRef::Agent(id));
                 }
                 SessionTab::Agent {
-                    kind: AgentKind::Claude,
+                    kind,
                     session_id: Some(session_id),
-                } => {
-                    let hook_injection = self.hook_injection_for(ProcessKind::claude());
+                } if kind.resume_args(&session_id).is_some() => {
+                    let hook_injection = self.hook_injection_for(ProcessKind::Agent(kind));
                     let id = self.agents.spawn_resume(
-                        AgentKind::Claude,
+                        kind,
                         cwd.clone(),
                         self.settings.appearance.terminal_font_size,
                         self.settings.terminal.shell_override(),
@@ -171,7 +180,10 @@ impl AdeApp {
                 }
                 SessionTab::Agent { kind, session_id } => {
                     debug_assert!(
-                        session_id.is_none() || kind != AgentKind::Claude,
+                        session_id
+                            .as_deref()
+                            .and_then(|session_id| kind.resume_args(session_id))
+                            .is_none(),
                         "the resumable case is handled by the arm above"
                     );
                     self.note_session_restore_failure(format!(

--- a/crates/app/src/work_surface/state.rs
+++ b/crates/app/src/work_surface/state.rs
@@ -218,6 +218,10 @@ pub fn agent_tint(kind: ProcessKind) -> (Rgba, Rgba) {
         ProcessKind::Agent(AgentKind::Codex) => {
             (theme::agent::CODEX.0.into(), theme::agent::CODEX.1.into())
         }
+        // steel blue - the pool's remaining unclaimed hue when Cursor arrived (issue #463).
+        ProcessKind::Agent(AgentKind::Cursor) => {
+            (theme::agent::LOCAL.0.into(), theme::agent::LOCAL.1.into())
+        }
         ProcessKind::Shell => (theme::text::DIM.into(), theme::surface::CHIP_NEUTRAL.into()),
     }
 }
@@ -227,6 +231,9 @@ pub fn agent_initial(kind: ProcessKind) -> &'static str {
     match kind {
         ProcessKind::Agent(AgentKind::Claude) => "C",
         ProcessKind::Agent(AgentKind::Codex) => "X",
+        // Not "C": that badge is Claude's, and every call site draws this in a one-character
+        // square, so a collision would make two different agents look identical at chip size.
+        ProcessKind::Agent(AgentKind::Cursor) => "U",
         ProcessKind::Shell => "$",
     }
 }
@@ -240,6 +247,7 @@ pub fn agent_icon_name(kind: ProcessKind) -> &'static str {
     match kind {
         ProcessKind::Agent(AgentKind::Claude) => "claude",
         ProcessKind::Agent(AgentKind::Codex) => "codex",
+        ProcessKind::Agent(AgentKind::Cursor) => "cursor",
         ProcessKind::Shell => "shell",
     }
 }
@@ -364,6 +372,44 @@ pub fn live_tab_label(title: Option<&str>, program: &str) -> String {
 /// two don't invent two different placeholder strings for the same "no branch" fact.
 pub fn new_agent_menu_secondary_text(branch: Option<&str>) -> String {
     format!("runs in {}", branch.unwrap_or("(detached)"))
+}
+
+/// Which control the agent picker popover (GitHub issue #463) is currently open off. Not a plain
+/// `bool`, because the popover is anchored to whichever control opened it and there is genuinely
+/// more than one: both `Start an agent` buttons can be in the tree at once, and the `+` menu's own
+/// `New agent` row opens the same list anchored to the `+` button instead.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AgentPickerAnchor {
+    /// A `Start an agent` split button's caret half, keyed by that button's element id
+    /// (`context-bar-start-agent` / `empty-state-start-agent`).
+    StartButton(&'static str),
+    /// The tab strip's `+` menu `New agent` row - anchored to the `+` button's own bounds, since
+    /// the menu the row lives in closes as the picker opens.
+    PlusMenu,
+}
+
+/// One agent picker row's secondary text: where this agent will run, or the real reason it can't.
+/// `installed` is three-state on purpose - `None` means the `$PATH` search
+/// (`crate::settings::state::detect_agent_rows`, the same one the Settings › Agents page shows)
+/// hasn't answered for this kind yet, which is not the same fact as "not installed" and must not
+/// be rendered as one.
+pub fn agent_picker_secondary_text(
+    installed: Option<bool>,
+    binary_name: &str,
+    branch: Option<&str>,
+) -> String {
+    match installed {
+        Some(false) => format!("{binary_name} not on PATH"),
+        Some(true) | None => new_agent_menu_secondary_text(branch),
+    }
+}
+
+/// Whether an agent picker row can be clicked: everything except a kind the `$PATH` search really
+/// came back negative for. A kind it hasn't answered for yet stays clickable - refusing a spawn on
+/// a search that simply hasn't finished would be a worse lie than letting the pane report a real
+/// `TerminalPane::spawn_error`.
+pub fn agent_picker_row_enabled(installed: Option<bool>) -> bool {
+    installed != Some(false)
 }
 
 /// A footer action button's colour treatment, backed by `theme::button::*`.
@@ -502,7 +548,59 @@ mod tests {
     fn agent_kinds_get_the_cli_chip_and_shell_gets_the_terminal_chip() {
         assert_eq!(tab_chip_kind(ProcessKind::claude()), TabChipKind::Cli);
         assert_eq!(tab_chip_kind(ProcessKind::codex()), TabChipKind::Cli);
+        assert_eq!(tab_chip_kind(ProcessKind::cursor()), TabChipKind::Cli);
         assert_eq!(tab_chip_kind(ProcessKind::Shell), TabChipKind::Term);
+    }
+
+    /// Every badge in this app is a one-character square, so two agents sharing a glyph read as
+    /// the same agent at chip size - the exact confusion the per-agent tint exists to prevent.
+    #[test]
+    fn no_two_process_kinds_share_a_badge_glyph_or_an_icon_name() {
+        let kinds = [
+            ProcessKind::claude(),
+            ProcessKind::codex(),
+            ProcessKind::cursor(),
+            ProcessKind::Shell,
+        ];
+        for (index, kind) in kinds.iter().enumerate() {
+            for other in &kinds[index + 1..] {
+                assert_ne!(
+                    agent_initial(*kind),
+                    agent_initial(*other),
+                    "{kind:?} and {other:?} draw the same badge glyph"
+                );
+                assert_ne!(
+                    agent_icon_name(*kind),
+                    agent_icon_name(*other),
+                    "{kind:?} and {other:?} resolve the same icon-pack file"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn a_picker_row_reports_the_real_path_search_and_never_guesses_at_an_unfinished_one() {
+        assert_eq!(
+            agent_picker_secondary_text(Some(true), "cursor-agent", Some("feature/x")),
+            "runs in feature/x"
+        );
+        assert_eq!(
+            agent_picker_secondary_text(Some(false), "cursor-agent", Some("feature/x")),
+            "cursor-agent not on PATH"
+        );
+        assert_eq!(
+            agent_picker_secondary_text(None, "cursor-agent", Some("feature/x")),
+            "runs in feature/x",
+            "a search that hasn't answered yet is not the same fact as \"not installed\", and \
+             must not be rendered as one"
+        );
+        assert!(agent_picker_row_enabled(Some(true)));
+        assert!(
+            agent_picker_row_enabled(None),
+            "a row must stay clickable while the search is still in flight - refusing the spawn \
+             there would be a worse lie than a real spawn error"
+        );
+        assert!(!agent_picker_row_enabled(Some(false)));
     }
 
     fn same(a: Rgba, b: Rgba) -> bool {

--- a/crates/pty-core/src/lib.rs
+++ b/crates/pty-core/src/lib.rs
@@ -23,12 +23,11 @@ use std::ffi::OsStr;
 use std::io::{Read, Write};
 #[cfg(unix)]
 use std::os::unix::io::{AsRawFd, RawFd};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{self, Receiver};
 use std::sync::Arc;
 use std::thread::JoinHandle;
-#[cfg(unix)]
 use std::time::Duration;
 #[cfg(unix)]
 use std::time::Instant;
@@ -104,6 +103,10 @@ pub enum PtyError {
     AlreadyShutDown,
     #[error("failed to signal child process: {0}")]
     Signal(String),
+    #[error("`{0}` did not finish within the timeout and was killed")]
+    CaptureTimeout(String),
+    #[error("`{0}` printed no usable line")]
+    CaptureEmpty(String),
 }
 
 /// Describes a process to spawn on a new PTY, plus the PTY's initial size.
@@ -166,6 +169,81 @@ impl SpawnOptions {
 /// passes a bare name. Both walk `$PATH` in the same order, so they agree in realistic cases.
 pub fn resolve_on_path(program: &str) -> Option<PathBuf> {
     resolve_in_path_var(&std::env::var_os("PATH")?, program)
+}
+
+/// Runs `program args` in `cwd` and returns the first non-empty line it prints to stdout, killing
+/// it and failing if it hasn't finished within `timeout`.
+///
+/// Blocking, like everything else here - call it off the UI thread. For helper commands that
+/// print one short line and exit; stdout is drained on its own thread, so a chattier command
+/// can't deadlock against a full pipe, but nothing here bounds how much it may print.
+///
+/// The timeout is not defensive padding. The real motivating case, `cursor-agent create-chat`,
+/// hangs indefinitely and prints nothing at all when the user isn't logged in - so a caller that
+/// merely waited would hang with it.
+///
+/// A timed-out command is torn down by [`windows_terminate_process_tree`] plus `Child::kill` on
+/// Windows, and by `Child::kill` alone on unix. The unix process-group teardown [`PtySession`]
+/// uses is deliberately not reused: nothing `setsid`s this child, so a `killpg` would signal the
+/// *caller's* group, Jerry included. A unix wrapper script's own child can therefore outlive the
+/// kill.
+pub fn capture_first_line(
+    program: &str,
+    args: &[&str],
+    cwd: &Path,
+    timeout: Duration,
+) -> Result<String, PtyError> {
+    let mut command = crate::command::new_std_command(program);
+    command
+        .args(args)
+        .current_dir(cwd)
+        // Never inherit this process's stdin: an interactive prompt would otherwise be able to
+        // block the helper forever on a terminal the user cannot see.
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null());
+    let mut child = command
+        .spawn()
+        .map_err(|err| PtyError::Spawn(format!("{program}: {err}")))?;
+
+    let (sender, receiver) = mpsc::channel();
+    // `wait_with_output` consumes the child, so the kill path below can't hold it - it keeps a
+    // separate handle and signals by pid through `Child::kill`'s own stored handle instead.
+    let mut kill_handle = match child.stdout.take() {
+        Some(stdout) => {
+            let waiter = std::thread::spawn(move || {
+                let mut buffer = String::new();
+                let mut stdout = stdout;
+                let _ = std::io::Read::read_to_string(&mut stdout, &mut buffer);
+                let _ = sender.send(buffer);
+            });
+            drop(waiter);
+            child
+        }
+        None => {
+            return Err(PtyError::Spawn(format!(
+                "{program}: stdout was not captured"
+            )))
+        }
+    };
+
+    let captured = receiver.recv_timeout(timeout);
+    // Whatever happened, this helper has no further purpose - a timed-out one is still running.
+    // The tree kill first, because on Windows the direct kill reaches only a shim: `cursor-agent`
+    // is a `.cmd` wrapping a real `node.exe`, the same orphaning GitHub issue #468 fixed for pty
+    // children.
+    #[cfg(windows)]
+    windows_terminate_process_tree(kill_handle.id());
+    let _ = kill_handle.kill();
+    let _ = kill_handle.wait();
+
+    let captured = captured.map_err(|_| PtyError::CaptureTimeout(program.to_owned()))?;
+    captured
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .map(str::to_owned)
+        .ok_or_else(|| PtyError::CaptureEmpty(program.to_owned()))
 }
 
 /// [`resolve_on_path`]'s search loop, taking `PATH` as an argument so a test can pass an isolated
@@ -1468,5 +1546,90 @@ mod pty_session_tests {
             result, None,
             "a same-named directory on PATH must never be returned as a resolved binary"
         );
+    }
+}
+
+#[cfg(test)]
+mod capture_tests {
+    use super::{capture_first_line, PtyError};
+    use std::time::{Duration, Instant};
+
+    /// A shell invocation that runs `script`, spelled for whichever shell this platform really
+    /// has - these tests are about [`capture_first_line`], not about which shell exists.
+    fn shell(script: &str) -> (&'static str, Vec<&str>) {
+        if cfg!(windows) {
+            ("cmd", vec!["/c", script])
+        } else {
+            ("sh", vec!["-c", script])
+        }
+    }
+
+    #[test]
+    fn the_first_line_a_command_prints_is_what_comes_back() {
+        let (program, args) = shell("echo 51a6b5fa-fbf4-4116-b44c-cd3e0aa35a5e");
+        let line = capture_first_line(
+            program,
+            &args,
+            &std::env::temp_dir(),
+            Duration::from_secs(30),
+        )
+        .expect("a shell echo should be captured");
+        assert_eq!(line, "51a6b5fa-fbf4-4116-b44c-cd3e0aa35a5e");
+    }
+
+    #[test]
+    fn a_command_that_never_finishes_is_killed_at_the_timeout() {
+        // The real motivating case: `cursor-agent create-chat` hangs forever, printing nothing,
+        // when the user is not logged in. Without the timeout the caller hangs with it.
+        // Spawned directly rather than through a shell: `Child::kill` reaches only the process it
+        // started, so a shell wrapper would be killed while its own sleeping child lived on.
+        let (program, args): (&str, Vec<&str>) = if cfg!(windows) {
+            ("ping", vec!["-n", "30", "127.0.0.1"])
+        } else {
+            ("sleep", vec!["30"])
+        };
+        let started = Instant::now();
+        let result = capture_first_line(
+            program,
+            &args,
+            &std::env::temp_dir(),
+            Duration::from_millis(300),
+        );
+        assert!(
+            matches!(result, Err(PtyError::CaptureTimeout(_))),
+            "a command that outlives its timeout must report the timeout, got {result:?}"
+        );
+        // Asserted by effect rather than by stopwatch precision: the point is that it returned
+        // long before the command's own 30s, not that it returned at exactly 300ms.
+        assert!(
+            started.elapsed() < Duration::from_secs(10),
+            "the timeout must actually cut the wait short"
+        );
+    }
+
+    #[test]
+    fn a_command_that_prints_nothing_is_not_mistaken_for_a_result() {
+        let (program, args) = shell("exit 0");
+        let result = capture_first_line(
+            program,
+            &args,
+            &std::env::temp_dir(),
+            Duration::from_secs(30),
+        );
+        assert!(
+            matches!(result, Err(PtyError::CaptureEmpty(_))),
+            "silence must be an error, never an empty id, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn a_binary_that_does_not_exist_fails_instead_of_waiting() {
+        let result = capture_first_line(
+            "definitely-not-a-real-binary-xyz-pty-core-test",
+            &[],
+            &std::env::temp_dir(),
+            Duration::from_secs(30),
+        );
+        assert!(matches!(result, Err(PtyError::Spawn(_))), "got {result:?}");
     }
 }


### PR DESCRIPTION
Closes #463

## What

Two things, one PR because the second is what makes the first usable.

**`AgentKind::Cursor`** — spawns the `cursor-agent` binary from `$PATH`, exactly the way `Claude`/`Codex` already do. It joins `settings::AGENT_KINDS`, so Settings › Agents gets a real third row with a live PATH-derived status and no new detection code. Adding the variant breaks every exhaustive `match` on purpose; each one is handled explicitly rather than wildcarded.

**An agent picker.** Before this, every button door — the `Start an agent` CTA, the `+` menu's `New agent` row, the title bar's `New Agent Pane`, `mod+shift+N` — resolved the kind *for* the user with a first-installed-wins `$PATH` search. On a machine with two CLIs installed, the second was reachable only through the command palette. `Start an agent` is now a split button: clicking the body does exactly what it did before (so no muscle memory or keybinding changes), and a caret opens a picker listing every `AGENT_KINDS` entry with its real installed state. The `+` menu's `New agent` row opens the same picker instead of spawning outright.

The picker is registered as `MenuSurface::AgentPicker`, so it obeys issue #176's one-menu-at-a-time invariant in both directions.

Kept honest rather than stubbed:

- `budget::provider_of` returns `None` for Cursor — the popover's numbers come from `budget::fetch`'s real Claude/Codex endpoints and there is no Cursor equivalent wired up. A third row there would be fabricated.
- Hook injection and `--resume` stay Claude-only (`agents.rs` already gated on `AgentKind::Claude`), so a Cursor run restores as a fresh spawn carrying the same explicit "no resumable session id" notice Codex already gets.
- A picker row whose `$PATH` search really came back negative is disabled and says `cursor-agent not on PATH`; a search that *hasn't answered yet* stays clickable rather than being drawn as "not installed" — those are different facts.

## Why

Cursor's CLI is the third of the three coding-agent CLIs people actually run in a worktree, and supervising several at once is the app's whole premise. The picker is the part that turns "supported" into "reachable": the empty pane's own `Start an agent` CTA pointed at a door that could only ever open one of them.

## Testing

- [x] conventions ratchet (300/300 globs, 170/170 render adapter calls — both at baseline, unchanged)
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace` — **not run: `cargo-nextest` isn't installed on this machine.** A full `cargo test --workspace` was run instead and caught a real bug in an earlier revision of this branch (a renamed `agent.local.*` theme token failed every built-in theme file's validation, which is fixed here by keeping the public key name). A second full run against the final tree was still building when this PR was opened — I'll comment with the result rather than leave this box silently ticked.
- [x] New behaviour has real tests, in the `unit`/`ui` tiers:
  - `work_surface::state` — picker secondary text is three-state (ready / not-on-PATH / not-searched-yet), row-enabled rule, and no two `ProcessKind`s share a badge glyph or icon name.
  - `work_surface::render::agent_picker_tests` — a real click on the caret opens the picker anchored to that button and lists every kind; picking `Cursor` really spawns a Cursor agent; a kind the `$PATH` search says is missing can't be picked; the `+` menu's `New agent` row opens the picker instead of spawning.
  - `work_surface::agents` / `settings::state` — label⇄`from_label` round-trip, pairwise-distinct binary names, and that Cursor resolves `cursor-agent` rather than `cursor` (the latter is the editor's launcher, which would report an agent as ready that this app cannot spawn).
- [x] `verify` capture — **not attached: no release build / live window was run in this session.**

## Screenshot

Not captured — see the Testing note above. The picker reuses the existing dropdown primitives (`render_dropdown_menu_row`, `theme::shadow::MENU`, `theme::zone::PLUS_MENU_WIDTH`) and the `+` menu's own open/close and anchoring pattern rather than introducing new visual language, but this does want a real look before merge.

## Architecture notes

No crate-boundary change. One new piece of pure state in the GPUI-free `work_surface::state` (`AgentPickerAnchor` plus the two picker-row helpers), with the rendering and click wiring one layer up in `work_surface::render`, matching that module's existing split.

The steel-blue agent tint keeps its `agent.local.*` token key even though Cursor now owns the hue: that key is the public override every built-in and user theme already writes (`assets/themes/*.toml`'s `[agent] local.fg`), so renaming it would break theme files for a cosmetic gain. The built-in themes' inline comments are updated to name Cursor.

## Verification still needed

`cursor-agent` is the binary name Cursor's CLI installer puts on `$PATH`, but it is **not installed on the machine this was written on**. Before merge this wants one real check against an installed `cursor-agent`: that a bare invocation in a worktree starts an interactive session, and that the Settings › Agents row resolves its path. If the real name differs, `AgentKind::binary_name` is the single line that changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
