### PR TITLE
fix: Windows console storm, watcher self-churn, and verbatim git paths

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,11 @@ either rule already holds everywhere.
   uses `gix` directly for reads and `std::process::Command` with explicit `&[&str]`/`&[OsString]`
   argv for the real `git` CLI. This matters for correctness (filenames with spaces/quotes), not just
   safety.
+- **Every non-PTY child process is constructed through `pty_core::new_std_command`, never a bare
+  `std::process::Command::new`.** The release binary is a GUI-subsystem process on Windows, where a
+  bare-constructed console child flashes its own visible console window per spawn (issue #465).
+  Enforced by `clippy.toml`'s `disallowed-methods`; test modules are exempt via each crate root's
+  `cfg_attr(test, allow(...))`. See `docs/architecture/decisions.md` §10.
 - **Every user-visible count goes through `crates/app/src/root/plural.rs`.** `plural::count(n,
   "file", None)` / `plural::form(n, "needs", "need")` — never `if n == 1 { "" } else { "s" }` at a
   call site, and never a hardcoded plural noun. Zero is plural in English and the helper knows that.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,6 +292,7 @@ version = "0.1.2"
 dependencies = [
  "alacritty_terminal",
  "anyhow",
+ "dunce",
  "env_logger",
  "gpui",
  "gpui_platform",
@@ -9911,6 +9912,7 @@ name = "wt-core"
 version = "0.1.2"
 dependencies = [
  "gix",
+ "pty-core",
  "sha2",
  "tempfile",
  "test-support",

--- a/clippy.toml
+++ b/clippy.toml
@@ -2,13 +2,21 @@
 # the Rust actually used to build this workspace.
 msrv = "1.95.0"
 
-# `disallowed-methods` is deliberately empty, not populated with `std::process::Command::new`
-# to enforce ADR 0003 (render.rs must dispatch a Command/Query, never call an adapter or shell
-# out directly): that method has other, legitimate call sites in this crate today (opening a
-# path in the OS file manager, relaunching the updater) that a blanket disallow would also
-# flag, and clippy.toml has no way to scope a disallowed method to specific files. A type-aware
-# version of this check needs the glob-import cleanup ADR 0003 itself names as the prerequisite.
-# In the meantime, `.claude/hooks/check-conventions.sh` enforces a coarser but real textual
-# ratchet on the same rule (and on new `use super::*` globs) - it needs no glob cleanup first,
-# runs in the pre-commit hook and in CI, and is documented in docs/architecture/decisions.md (§3).
-disallowed-methods = []
+# GitHub issue #465: the release binary is a GUI-subsystem process on Windows
+# (`windows_subsystem = "windows"` in `crates/app/src/main.rs`), where a console-subsystem
+# child spawned with default creation flags allocates its own *visible* console window per
+# spawn. `pty_core::new_std_command` is the one constructor that sets CREATE_NO_WINDOW there
+# (and is the identity elsewhere); it carries the workspace's only sanctioned bare
+# `Command::new`, behind a scoped `#[allow]`. This ban used to be impossible - legitimate call
+# sites (the OS open handler, the updater relaunch) would have been flagged with no way to
+# scope them out - but all of them now construct through the helper, so the objection is gone.
+# Test modules stay exempt via each crate root's `cfg_attr(test, allow(...))` (and
+# `test-support`'s crate-level allow): the test runner owns a console its children inherit.
+#
+# This is narrower than ADR 0003 (render.rs must dispatch a Command/Query, never call an
+# adapter or shell out directly) - that rule still needs the glob-import cleanup before a
+# type-aware lint can express it, and `.claude/hooks/check-conventions.sh` keeps enforcing its
+# coarser textual ratchet (plus the `use super::*` one) in pre-commit and CI.
+disallowed-methods = [
+    { path = "std::process::Command::new", reason = "flashes a visible console window per spawn in the windows_subsystem=\"windows\" release build (GitHub issue #465) - construct through `pty_core::new_std_command` instead" },
+]

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -160,6 +160,13 @@ tree-sitter-javascript = "0.23.1"
 # API wrapper with no GPUI/vendor/zed call site to verify against, the same "just a version pin"
 # treatment `regex`/`unicode-segmentation` already get above.
 notify = "8.2.0"
+# `std::fs::canonicalize` without Windows's verbatim `\\?\C:\...` spelling, which git rejects
+# ("Invalid argument") - the app keys every repo root by its canonical path, so the verbatim
+# form broke git interop at runtime on Windows (GitHub issue #467). Identical to
+# `std::fs::canonicalize` on unix. The exact crate/version `lsp-core` already resolves for the
+# same reason (`lsp_core::client`'s own `canonicalize`), and the same pin upstream
+# `zed-industries/zed` carries (`dunce = "1.0"`, used by its `fs` and `path` crates).
+dunce = "1.0"
 # Real GitHub-releases-backed self-update (GitHub issue #87, `crate::updater`) - version
 # check via `backends::github::ReleaseList`, download+extract+atomic self-replace via
 # `backends::github::Update`/`self-replace`. `default-features = false` because this

--- a/crates/app/src/code_surface/editing.rs
+++ b/crates/app/src/code_surface/editing.rs
@@ -5248,7 +5248,7 @@ mod caret_alignment_tests {
         crate::code_surface::fixtures::TempRepo,
     ) {
         let repo = temp_repo();
-        let root = repo.path().canonicalize().expect("canonical tempdir");
+        let root = dunce::canonicalize(repo.path()).expect("canonical tempdir");
         let file_path = root.join("dense.rs");
         std::fs::write(&file_path, format!("fn main() {{\n{DENSE_LINE}\n}}\n")).expect("write");
         let (app, cx) = open_test_app(cx, root.clone());

--- a/crates/app/src/code_surface/fixtures.rs
+++ b/crates/app/src/code_surface/fixtures.rs
@@ -42,7 +42,9 @@ impl TempRepo {
 
 pub(in crate::code_surface) fn temp_repo() -> TempRepo {
     let dir = tempfile::tempdir().expect("tempdir");
-    let root = dir.path().canonicalize().expect("canonicalize tempdir");
+    // `dunce`, matching `canonical_repo_path` - std's Windows `\\?\` spelling breaks git
+    // (GitHub issue #467).
+    let root = dunce::canonicalize(dir.path()).expect("canonicalize tempdir");
     TempRepo { _dir: dir, root }
 }
 

--- a/crates/app/src/language.rs
+++ b/crates/app/src/language.rs
@@ -211,7 +211,9 @@ fn vue_typescript_plugin_location() -> Result<String, String> {
          bundled `@vue/typescript-plugin`; none found"
             .to_string()
     })?;
-    let script = std::fs::canonicalize(&binary).map_err(|err| {
+    // `dunce`, not `std::fs`: the resolved location is handed to a Node-based server as a plain
+    // path argument, and std's Windows verbatim `\\?\` spelling breaks there (GitHub issue #467).
+    let script = dunce::canonicalize(&binary).map_err(|err| {
         format!(
             "could not resolve the real `vue-language-server` script behind {}: {err}",
             binary.display()

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -10,8 +10,11 @@
 
 // `.expect()`/`.unwrap()` are the documented, accepted pattern in test modules (see
 // `CLAUDE.md`'s Rust standards) - only production code is held to `clippy::unwrap_used`/
-// `expect_used`.
-#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+// `expect_used` and the bare-`Command::new` ban (`clippy.toml`, GitHub issue #465).
+#![cfg_attr(
+    test,
+    allow(clippy::unwrap_used, clippy::expect_used, clippy::disallowed_methods)
+)]
 
 pub mod budget;
 pub mod code_surface;
@@ -1004,7 +1007,7 @@ mod open_ade_window_tests {
         let repo = tempfile::tempdir().expect("tempdir");
         // `AdeApp` canonicalizes the root it is opened with, so a bare `TempDir::path()` would be
         // compared against its own `/private/var` resolution below and never match on macOS.
-        let repo_path = std::fs::canonicalize(repo.path()).expect("canonical tempdir");
+        let repo_path = dunce::canonicalize(repo.path()).expect("canonical tempdir");
         let settings_dir = tempfile::tempdir().expect("tempdir");
         let settings_path = settings_dir.path().join("settings.toml");
 

--- a/crates/app/src/lsp/fixtures.rs
+++ b/crates/app/src/lsp/fixtures.rs
@@ -31,7 +31,7 @@ impl TempRepo {
 
 pub(in crate::lsp) fn temp_repo() -> TempRepo {
     let dir = tempfile::tempdir().expect("tempdir");
-    let root = dir.path().canonicalize().expect("canonicalize tempdir");
+    let root = dunce::canonicalize(dir.path()).expect("canonicalize tempdir");
     TempRepo { _dir: dir, root }
 }
 

--- a/crates/app/src/merge/flow.rs
+++ b/crates/app/src/merge/flow.rs
@@ -1002,10 +1002,9 @@ mod merge_regression_tests {
     /// worktrees by exact `PathBuf`, and on macOS the temp directory is behind a symlink.
     fn add_worktree(repo_path: &std::path::Path, branch: &str, name: &str) -> PathBuf {
         let container = TempDir::new().expect("tempdir");
-        let root = container
-            .path()
-            .canonicalize()
-            .expect("canonicalize tempdir");
+        // `dunce`, matching `canonical_repo_path` - std's Windows `\\?\` spelling breaks git
+        // (GitHub issue #467).
+        let root = dunce::canonicalize(container.path()).expect("canonicalize tempdir");
         // `keep()`, not `drop()`: dropping the container deleted the directory and freed its
         // random name for reuse, so under the parallel suite another fixture could be handed the
         // same name and create `<name>` inside it first - `git worktree add` then failed with

--- a/crates/app/src/provenance/render.rs
+++ b/crates/app/src/provenance/render.rs
@@ -658,7 +658,7 @@ impl UserApi {
         // (`crate::rail::repo::canonical_repo_path`) and then keys provenance by exact `PathBuf`.
         // On macOS `std::env::temp_dir()` is itself behind a `/var` -> `/private/var` symlink, so
         // recording against `TempDir::path()` verbatim writes keys the app can never look up.
-        let root = dir.path().canonicalize().expect("canonicalize tempdir");
+        let root = dunce::canonicalize(dir.path()).expect("canonicalize tempdir");
         let repo = root.as_path();
         git(repo, &["init", "-b", "main"]);
         git(repo, &["config", "user.email", "test@example.com"]);
@@ -758,7 +758,7 @@ impl UserApi {
         // (`crate::rail::repo::canonical_repo_path`) and then keys provenance by exact `PathBuf`.
         // On macOS `std::env::temp_dir()` is itself behind a `/var` -> `/private/var` symlink, so
         // recording against `TempDir::path()` verbatim writes keys the app can never look up.
-        let root = dir.path().canonicalize().expect("canonicalize tempdir");
+        let root = dunce::canonicalize(dir.path()).expect("canonicalize tempdir");
         let repo = root.as_path();
         git(repo, &["init", "-b", "main"]);
         git(repo, &["config", "user.email", "test@example.com"]);

--- a/crates/app/src/rail/repo.rs
+++ b/crates/app/src/rail/repo.rs
@@ -116,7 +116,10 @@ pub fn repo_state_path_for(settings_path: &Path) -> PathBuf {
 /// the path exactly as given when it can't be resolved at all - a directory that doesn't exist
 /// yet, or a pure in-memory path in a unit test, which must still be usable rather than an error.
 pub fn canonical_repo_path(path: &Path) -> PathBuf {
-    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+    // `dunce`, not `std::fs`: std's Windows answer is the verbatim `\\?\C:\...` form, which git
+    // rejects ("Invalid argument") - and this path is handed to git by everything keyed off the
+    // opened repo (GitHub issue #467). Identical to `std::fs::canonicalize` on unix.
+    dunce::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
 }
 
 /// The map key for one repo - its real path, canonicalized ([`canonical_repo_path`]) so the same
@@ -212,7 +215,7 @@ impl RepoState {
             return RepoState::default();
         };
         match toml::from_str::<RepoState>(&contents) {
-            Ok(state) => state,
+            Ok(state) => state.normalized(),
             Err(err) => {
                 log::warn!(
                     "{} failed to parse ({err}) - starting from an empty repo list",
@@ -220,6 +223,34 @@ impl RepoState {
                 );
                 RepoState::default()
             }
+        }
+    }
+
+    /// Re-spells every persisted key and path through today's [`repo_key`]/
+    /// [`canonical_repo_path`], so a file written by an earlier build survives a canonicalization
+    /// change. The real case (GitHub issue #467): pre-fix Windows builds keyed repos by
+    /// `std::fs::canonicalize`'s verbatim `\\?\C:\...` form, which every consumer of the loaded
+    /// state would hand straight to git — leaving the remembered repo permanently broken, and
+    /// `last_focused` (written in the new plain spelling) matching no key at all from the second
+    /// launch on. Applied inside [`Self::load_at`] so [`Self::save_merged_at`]'s own load-merge
+    /// pass rewrites the file in the current spelling on the first save. If two old spellings
+    /// collapse into one key, the first (plain, the one current builds write) wins — both name
+    /// the same repo.
+    fn normalized(self) -> RepoState {
+        let respell = |value: String| {
+            canonical_repo_path(Path::new(&value))
+                .to_str()
+                .map(str::to_owned)
+                .unwrap_or(value)
+        };
+        let mut repos: BTreeMap<String, RepoRecord> = BTreeMap::new();
+        for (key, mut record) in self.repos {
+            record.selected_worktree = record.selected_worktree.map(respell);
+            repos.entry(respell(key)).or_insert(record);
+        }
+        RepoState {
+            repos,
+            last_focused: self.last_focused.map(respell),
         }
     }
 

--- a/crates/app/src/rail/strip_render.rs
+++ b/crates/app/src/rail/strip_render.rs
@@ -37,8 +37,10 @@ impl AdeApp {
         // `path_to_uri` canonicalises on the way in - so a checkout reached through a symlink
         // (macOS' `/var` -> `/private/var`, or a worktree directory someone symlinked) yields
         // paths that `strip_prefix(&root)` can never match. Resolved once per pass, not per row,
-        // and falling back to `root` itself if the checkout has since gone away.
-        let canonical_root = std::fs::canonicalize(&root).unwrap_or_else(|_| root.clone());
+        // and falling back to `root` itself if the checkout has since gone away. `dunce`, because
+        // `lsp_core` canonicalises with `dunce` too - std's Windows verbatim `\\?\` spelling
+        // would never prefix-match the server's paths (GitHub issue #467).
+        let canonical_root = dunce::canonicalize(&root).unwrap_or_else(|_| root.clone());
         let mut problems: Vec<Problem> = Vec::new();
         for ((client_root, _server), state) in &self.lsp_clients {
             let LspClientState::Ready(client) = state else {

--- a/crates/app/src/rail/worktree_watch.rs
+++ b/crates/app/src/rail/worktree_watch.rs
@@ -60,6 +60,9 @@ pub fn spawn_worktree_watcher(repo_path: &Path, dirty: DirtyFlag) -> Option<Reco
 /// `git worktree list` at its fast ~500ms cadence forever instead of only on real changes plus
 /// the 5s poll. Neutral churn is:
 ///
+/// - by *class*: every `Access` event — reads (Linux's inotify delivers one per file *open*,
+///   including git's own reads of `HEAD`/`config` on each invocation; no other backend emits
+///   them at all);
 /// - by *name*: the [`wt_core::diff::SHADOW_INDEX_PREFIX`] tempfiles every diff computation
 ///   writes beside the real index (git's `<name>.lock` sidecar shares the prefix), the real
 ///   `index`/`index.lock`, which `git status` opportunistically rewrites on the 3s status
@@ -76,6 +79,15 @@ pub fn spawn_worktree_watcher(repo_path: &Path, dirty: DirtyFlag) -> Option<Reco
 ///
 /// A pathless event (a rescan notice) still counts as a real change.
 fn worktree_list_neutral_churn(event: &notify::Event, worktrees_dir: &Path) -> bool {
+    // Reads first: Linux's inotify backend subscribes `IN_OPEN` (notify-8.2.0/src/inotify.rs's
+    // watch mask), so every git invocation that merely *opens* `HEAD` or `config` under a watch
+    // surfaces as an `Access` event - the status poll's own reads would re-dirty the flag
+    // forever (this is how the #466 loop survived on Linux while Windows, whose backend emits
+    // no Access events, looked fixed). A real change always also emits Modify/Create/Remove/
+    // rename, so dropping the whole Access class loses nothing.
+    if matches!(event.kind, notify::EventKind::Access(_)) {
+        return true;
+    }
     let dir_entry_mtime_bump = matches!(
         &event.kind,
         notify::EventKind::Modify(kind)
@@ -262,12 +274,56 @@ mod tests {
         );
     }
 
-    /// The inverse of [`wait_until_dirty`], mirroring `file_tree_watch`'s own
-    /// `assert_stays_clean`: proves churn is genuinely filtered rather than just slow.
-    fn assert_stays_clean(dirty: &DirtyFlag) {
+    /// Arms the real production watcher plus a second collector mirroring its exact watch
+    /// registrations, runs a real diff of `diff_target`, and asserts the dirty flag stays
+    /// clean — printing every event the production filter did NOT drop on failure, so a
+    /// platform-specific escape names itself in CI instead of leaving the assertion opaque
+    /// (Linux's inotify `Access(Open)` storm was found exactly this way; GitHub issue #466).
+    fn assert_diff_leaves_watcher_clean(repo_path: &Path, diff_target: &Path) {
+        let dirty: DirtyFlag = Arc::new(AtomicBool::new(false));
+        let _watcher =
+            spawn_worktree_watcher(repo_path, dirty.clone()).expect("spawn_worktree_watcher");
+
+        let escaped: Arc<std::sync::Mutex<Vec<String>>> = Arc::default();
+        let common_dir = wt_core::git_common_dir(repo_path).expect("git_common_dir");
+        let worktrees_dir = common_dir.join("worktrees");
+        let filter_root = worktrees_dir.clone();
+        let sink = escaped.clone();
+        let mut collector =
+            notify::recommended_watcher(move |result: notify::Result<notify::Event>| {
+                let Ok(event) = result else {
+                    return;
+                };
+                if !worktree_list_neutral_churn(&event, &filter_root) {
+                    sink.lock()
+                        .expect("collector lock")
+                        .push(format!("{:?} {:?}", event.kind, event.paths));
+                }
+            })
+            .expect("collector watcher");
+        if worktrees_dir.is_dir() {
+            collector
+                .watch(&worktrees_dir, RecursiveMode::Recursive)
+                .expect("watch worktrees dir");
+        } else {
+            collector
+                .watch(&common_dir, RecursiveMode::NonRecursive)
+                .expect("watch common dir");
+        }
+        let head_file = common_dir.join("HEAD");
+        if head_file.is_file() {
+            collector
+                .watch(&head_file, RecursiveMode::NonRecursive)
+                .expect("watch HEAD");
+        }
+
+        wt_core::diff::diff_against_head(diff_target).expect("diff_against_head");
+
         assert!(
             test_support::stays_false(Duration::from_millis(500), || dirty.load(Ordering::SeqCst)),
-            "index churn must never mark the worktree list dirty (GitHub issue #466)"
+            "index churn must never mark the worktree list dirty (GitHub issue #466); \
+             events the filter let through: {:#?}",
+            escaped.lock().expect("collector lock")
         );
     }
 
@@ -335,6 +391,18 @@ mod tests {
             "HEAD is a real signal, never filtered"
         );
         assert!(
+            worktree_list_neutral_churn(
+                &event_with(
+                    EventKind::Access(notify::event::AccessKind::Open(
+                        notify::event::AccessMode::Any
+                    )),
+                    std::slice::from_ref(&head)
+                ),
+                &worktrees_dir
+            ),
+            "a mere read of HEAD (inotify delivers one per git invocation on Linux) is neutral"
+        );
+        assert!(
             !worktree_list_neutral_churn(&event_with(modify, &[shadow, head]), &worktrees_dir),
             "an event mixing churn with a real path must still count as a real change"
         );
@@ -354,13 +422,7 @@ mod tests {
         std::fs::write(repo.path().join("untracked.txt"), "new content")
             .expect("write an untracked file so the diff has real shadow-index work to do");
 
-        let dirty: DirtyFlag = Arc::new(AtomicBool::new(false));
-        let _watcher =
-            spawn_worktree_watcher(repo.path(), dirty.clone()).expect("spawn_worktree_watcher");
-
-        wt_core::diff::diff_against_head(repo.path()).expect("diff_against_head");
-
-        assert_stays_clean(&dirty);
+        assert_diff_leaves_watcher_clean(repo.path(), repo.path());
     }
 
     /// The linked-worktree flavour of the loop above: with `worktrees/` present the watch is
@@ -384,13 +446,7 @@ mod tests {
         std::fs::write(linked_path.join("untracked.txt"), "new content")
             .expect("write an untracked file so the diff has real shadow-index work to do");
 
-        let dirty: DirtyFlag = Arc::new(AtomicBool::new(false));
-        let _watcher =
-            spawn_worktree_watcher(repo.path(), dirty.clone()).expect("spawn_worktree_watcher");
-
-        wt_core::diff::diff_against_head(&linked_path).expect("diff_against_head");
-
-        assert_stays_clean(&dirty);
+        assert_diff_leaves_watcher_clean(repo.path(), &linked_path);
     }
 
     #[test]

--- a/crates/app/src/rail/worktree_watch.rs
+++ b/crates/app/src/rail/worktree_watch.rs
@@ -20,14 +20,19 @@ pub type DirtyFlag = Arc<AtomicBool>;
 pub fn spawn_worktree_watcher(repo_path: &Path, dirty: DirtyFlag) -> Option<RecommendedWatcher> {
     let common_dir = wt_core::git_common_dir(repo_path).ok()?;
 
+    let worktrees_dir = common_dir.join("worktrees");
+    let filter_root = worktrees_dir.clone();
     let mut watcher = notify::recommended_watcher(move |result: notify::Result<notify::Event>| {
-        if result.is_ok() {
-            dirty.store(true, Ordering::SeqCst);
+        let Ok(event) = result else {
+            return;
+        };
+        if worktree_list_neutral_churn(&event, &filter_root) {
+            return;
         }
+        dirty.store(true, Ordering::SeqCst);
     })
     .ok()?;
 
-    let worktrees_dir = common_dir.join("worktrees");
     if worktrees_dir.is_dir() {
         let _ = watcher.watch(&worktrees_dir, RecursiveMode::Recursive);
     } else {
@@ -49,9 +54,52 @@ pub fn spawn_worktree_watcher(repo_path: &Path, dirty: DirtyFlag) -> Option<Reco
     Some(watcher)
 }
 
+/// True when the event is churn that can never change `git worktree list` output — most of it
+/// produced by this app itself (GitHub issue #466). Without this filter each status-poll tick
+/// re-dirties the watcher through its own diff spawns, and the refresh loop runs a
+/// `git worktree list` at its fast ~500ms cadence forever instead of only on real changes plus
+/// the 5s poll. Neutral churn is:
+///
+/// - by *name*: the [`wt_core::diff::SHADOW_INDEX_PREFIX`] tempfiles every diff computation
+///   writes beside the real index (git's `<name>.lock` sidecar shares the prefix), the real
+///   `index`/`index.lock`, which `git status` opportunistically rewrites on the 3s status
+///   poll, and the `objects` directory entry, whose mtime the same diffs bump by writing
+///   loose objects;
+/// - by *shape*: a non-rename `Modify` event on a worktree's bare admin-directory entry (a
+///   direct child of `worktrees/`), which is only ever the directory's mtime rippling from
+///   writes inside it. Real transitions are never lost to this arm: add/remove/lock all write
+///   or delete files *inside* that directory (`HEAD`, `gitdir`, `locked`, …), whose own events
+///   don't match it, and a `Create`/`Remove` of the entry itself still counts. Renames are
+///   excluded even though every backend delivers them as `Modify(Name(..))`: a directory
+///   moved wholesale into or out of `worktrees/` is a real transition whose *only* event is
+///   that rename — and an mtime ripple is never a rename, so excluding them costs nothing.
+///
+/// A pathless event (a rescan notice) still counts as a real change.
+fn worktree_list_neutral_churn(event: &notify::Event, worktrees_dir: &Path) -> bool {
+    let dir_entry_mtime_bump = matches!(
+        &event.kind,
+        notify::EventKind::Modify(kind)
+            if !matches!(kind, notify::event::ModifyKind::Name(_))
+    );
+    !event.paths.is_empty()
+        && event.paths.iter().all(|path| {
+            let neutral_name =
+                path.file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| {
+                        name.starts_with(wt_core::diff::SHADOW_INDEX_PREFIX)
+                            || name == "index"
+                            || name == "index.lock"
+                            || name == "objects"
+                    });
+            neutral_name || (dir_entry_mtime_bump && path.parent() == Some(worktrees_dir))
+        })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::PathBuf;
     use std::time::Duration;
 
     /// Real-time bounded wait for the watcher's async, OS-thread-delivered callback to fire -
@@ -212,6 +260,137 @@ mod tests {
             wait_until_dirty(&dirty),
             "a real branch switch inside a linked worktree must be observed"
         );
+    }
+
+    /// The inverse of [`wait_until_dirty`], mirroring `file_tree_watch`'s own
+    /// `assert_stays_clean`: proves churn is genuinely filtered rather than just slow.
+    fn assert_stays_clean(dirty: &DirtyFlag) {
+        assert!(
+            test_support::stays_false(Duration::from_millis(500), || dirty.load(Ordering::SeqCst)),
+            "index churn must never mark the worktree list dirty (GitHub issue #466)"
+        );
+    }
+
+    /// One [`notify::Event`] with `kind` and `paths`, the two fields the churn filter reads.
+    fn event_with(kind: notify::EventKind, paths: &[PathBuf]) -> notify::Event {
+        let mut event = notify::Event::new(kind);
+        for path in paths {
+            event = event.add_path(path.clone());
+        }
+        event
+    }
+
+    #[test]
+    fn the_churn_filter_recognizes_index_object_and_admin_dir_churn_and_nothing_else() {
+        use notify::event::{CreateKind, ModifyKind};
+        use notify::EventKind;
+
+        let worktrees_dir = PathBuf::from(".git").join("worktrees");
+        let modify = EventKind::Modify(ModifyKind::Any);
+        let shadow = PathBuf::from(".git").join(".jerry-shadow-index-abc123");
+        let shadow_lock = PathBuf::from(".git").join(".jerry-shadow-index-abc123.lock");
+        let index = worktrees_dir.join("wt").join("index");
+        let index_lock = worktrees_dir.join("wt").join("index.lock");
+        let objects = PathBuf::from(".git").join("objects");
+        let admin_dir = worktrees_dir.join("wt");
+        let head = PathBuf::from(".git").join("HEAD");
+
+        let neutral = event_with(
+            modify,
+            &[shadow.clone(), shadow_lock, index, index_lock, objects],
+        );
+        assert!(worktree_list_neutral_churn(&neutral, &worktrees_dir));
+        assert!(
+            worktree_list_neutral_churn(
+                &event_with(modify, std::slice::from_ref(&admin_dir)),
+                &worktrees_dir
+            ),
+            "a bare mtime bump on a worktree's admin dir is churn from writes inside it"
+        );
+        assert!(
+            !worktree_list_neutral_churn(
+                &event_with(
+                    EventKind::Create(CreateKind::Folder),
+                    std::slice::from_ref(&admin_dir)
+                ),
+                &worktrees_dir
+            ),
+            "creating a worktree admin dir is a real `git worktree add`, never filtered"
+        );
+        assert!(
+            !worktree_list_neutral_churn(
+                &event_with(
+                    EventKind::Modify(ModifyKind::Name(notify::event::RenameMode::Any)),
+                    std::slice::from_ref(&admin_dir)
+                ),
+                &worktrees_dir
+            ),
+            "an admin dir moved into/out of worktrees/ arrives only as this rename, never filtered"
+        );
+        assert!(
+            !worktree_list_neutral_churn(
+                &event_with(modify, std::slice::from_ref(&head)),
+                &worktrees_dir
+            ),
+            "HEAD is a real signal, never filtered"
+        );
+        assert!(
+            !worktree_list_neutral_churn(&event_with(modify, &[shadow, head]), &worktrees_dir),
+            "an event mixing churn with a real path must still count as a real change"
+        );
+        assert!(
+            !worktree_list_neutral_churn(&event_with(modify, &[]), &worktrees_dir),
+            "a pathless rescan notice must still count as a real change"
+        );
+    }
+
+    /// GitHub issue #466, the exact feedback loop: every diff computation writes
+    /// `.jerry-shadow-index-*` tempfiles beside the real index — inside the watched git
+    /// directory — and used to re-trigger this watcher on the app's own churn, holding the
+    /// refresh loop at its fast ~500ms cadence forever.
+    #[test]
+    fn a_real_diff_computation_does_not_re_trigger_the_watcher() {
+        let repo = crate::test_support::temp_repo();
+        std::fs::write(repo.path().join("untracked.txt"), "new content")
+            .expect("write an untracked file so the diff has real shadow-index work to do");
+
+        let dirty: DirtyFlag = Arc::new(AtomicBool::new(false));
+        let _watcher =
+            spawn_worktree_watcher(repo.path(), dirty.clone()).expect("spawn_worktree_watcher");
+
+        wt_core::diff::diff_against_head(repo.path()).expect("diff_against_head");
+
+        assert_stays_clean(&dirty);
+    }
+
+    /// The linked-worktree flavour of the loop above: with `worktrees/` present the watch is
+    /// recursive over it, and the linked worktree's shadow index lives exactly there.
+    #[test]
+    fn a_real_diff_in_a_linked_worktree_does_not_re_trigger_the_watcher() {
+        let repo = crate::test_support::temp_repo();
+        let container = crate::test_support::temp_root();
+        let linked_path = container.path().join("diffed-wt");
+        drop(container);
+        test_support::git(
+            repo.path(),
+            &[
+                "worktree",
+                "add",
+                "-b",
+                "diffed-feature",
+                linked_path.to_str().expect("utf8 path"),
+            ],
+        );
+        std::fs::write(linked_path.join("untracked.txt"), "new content")
+            .expect("write an untracked file so the diff has real shadow-index work to do");
+
+        let dirty: DirtyFlag = Arc::new(AtomicBool::new(false));
+        let _watcher =
+            spawn_worktree_watcher(repo.path(), dirty.clone()).expect("spawn_worktree_watcher");
+
+        wt_core::diff::diff_against_head(&linked_path).expect("diff_against_head");
+
+        assert_stays_clean(&dirty);
     }
 
     #[test]

--- a/crates/app/src/search/fixtures.rs
+++ b/crates/app/src/search/fixtures.rs
@@ -29,6 +29,6 @@ impl TempRepo {
 
 pub(in crate::search) fn temp_repo() -> TempRepo {
     let dir = tempfile::tempdir().expect("tempdir");
-    let root = dir.path().canonicalize().expect("canonicalize tempdir");
+    let root = dunce::canonicalize(dir.path()).expect("canonicalize tempdir");
     TempRepo { _dir: dir, root }
 }

--- a/crates/app/src/settings/widgets.rs
+++ b/crates/app/src/settings/widgets.rs
@@ -52,7 +52,7 @@ impl AdeApp {
     ) {
         cx.background_executor()
             .spawn(async move {
-                match std::process::Command::new(program).args(&args).status() {
+                match pty_core::new_std_command(program).args(&args).status() {
                     Ok(status) if !status.success() => {
                         log::warn!("{program} exited with {status} while opening {target_label}");
                     }

--- a/crates/app/src/sidebar/file_tree_watch.rs
+++ b/crates/app/src/sidebar/file_tree_watch.rs
@@ -36,6 +36,14 @@ pub fn spawn_file_tree_watcher(
         let Ok(event) = result else {
             return;
         };
+        // Reads never dirty the tree. Load-bearing on Linux, not defensive: inotify's watch mask
+        // includes `IN_OPEN`, so the Changes-pane refresh *reading* worktree files to diff them
+        // surfaces as `Access` events from this recursive watch - which used to re-dirty the
+        // flag and schedule the next refresh, a self-sustaining loop (GitHub issue #466's
+        // sibling). A real change always also emits Modify/Create/Remove/rename.
+        if matches!(event.kind, notify::EventKind::Access(_)) {
+            return;
+        }
         // Only a change with at least one real path outside `.git/` counts - see the module docs
         // on why `.git/`'s own churn must never mark the tree dirty.
         let outside_git = event.paths.iter().any(|path| !path.starts_with(&git_dir));
@@ -104,6 +112,25 @@ mod file_tree_watcher_tests {
 
         fs::remove_file(&created).expect("remove");
         assert!(wait_until_dirty(&dirty), "a deletion must be observed");
+    }
+
+    /// The Linux half of GitHub issue #466's sibling loop: the Changes-pane refresh *reads*
+    /// worktree files to diff them, inotify reports each open as an `Access` event from this
+    /// recursive watch, and that used to schedule the next refresh - forever. Reading must
+    /// never dirty the tree; only the other backends' silence made this look fixed elsewhere.
+    #[test]
+    fn merely_reading_a_worktree_file_never_marks_the_tree_dirty() {
+        let dir = seed_repo();
+        let tracked = dir.path().join("file.txt");
+
+        let dirty: DirtyFlag = Arc::new(AtomicBool::new(false));
+        let _watcher =
+            spawn_file_tree_watcher(dir.path(), dirty.clone()).expect("spawn_file_tree_watcher");
+
+        let contents = fs::read(&tracked).expect("read a real tracked file");
+        assert!(!contents.is_empty(), "seed_repo writes real content");
+
+        assert_stays_clean(&dirty);
     }
 
     #[test]

--- a/crates/app/src/sidebar/file_tree_watch.rs
+++ b/crates/app/src/sidebar/file_tree_watch.rs
@@ -25,9 +25,11 @@ pub fn spawn_file_tree_watcher(
     wt_core::git_common_dir(worktree_root).ok()?;
     // The OS reports every event path resolved (macOS `FSEvents` hands back `/private/var/...` for
     // a watch armed on `/var/...`), so a `.git` prefix built from an unresolved root would match
-    // nothing and every one of git's own internal writes would mark the tree dirty.
+    // nothing and every one of git's own internal writes would mark the tree dirty. `dunce`
+    // rather than `std::fs` so the prefix carries no Windows verbatim `\\?\` spelling — the same
+    // form `canonical_repo_path` keys the app by (GitHub issue #467).
     let resolved =
-        std::fs::canonicalize(worktree_root).unwrap_or_else(|_| worktree_root.to_path_buf());
+        dunce::canonicalize(worktree_root).unwrap_or_else(|_| worktree_root.to_path_buf());
     let git_dir: PathBuf = resolved.join(".git");
 
     let mut watcher = notify::recommended_watcher(move |result: notify::Result<notify::Event>| {

--- a/crates/app/src/sidebar/fold_state.rs
+++ b/crates/app/src/sidebar/fold_state.rs
@@ -27,7 +27,9 @@ pub fn fold_state_path_for(settings_path: &Path) -> PathBuf {
 /// Falls back to the path as given when it can't be canonicalized (it may not exist yet, or be
 /// a pure in-memory path in a unit test), which is still a stable key for that path.
 pub fn worktree_key(root: &Path) -> Option<String> {
-    let canonical = std::fs::canonicalize(root).unwrap_or_else(|_| root.to_path_buf());
+    // `dunce`, matching `crate::rail::repo::canonical_repo_path`, so stored keys carry the same
+    // spelling as every other canonical path in the app (GitHub issue #467).
+    let canonical = dunce::canonicalize(root).unwrap_or_else(|_| root.to_path_buf());
     canonical.to_str().map(str::to_owned)
 }
 

--- a/crates/app/src/sidebar/mod.rs
+++ b/crates/app/src/sidebar/mod.rs
@@ -39,7 +39,7 @@ pub(in crate::sidebar) mod fixtures {
     /// against the resolved ones the app actually holds, and matches nothing.
     pub(in crate::sidebar) fn temp_root() -> (TempDir, PathBuf) {
         let dir = TempDir::new().expect("tempdir");
-        let root = std::fs::canonicalize(dir.path()).expect("canonicalize tempdir");
+        let root = dunce::canonicalize(dir.path()).expect("canonicalize tempdir");
         (dir, root)
     }
 }

--- a/crates/app/src/sidebar/tree_ops.rs
+++ b/crates/app/src/sidebar/tree_ops.rs
@@ -1081,7 +1081,7 @@ impl AdeApp {
                         file_ops::copy_path(&path, &backup_path).map_err(|err| err.to_string())?;
                         match mechanism {
                             DeleteMechanism::Trash { program, args } => {
-                                match std::process::Command::new(program).args(&args).status() {
+                                match pty_core::new_std_command(program).args(&args).status() {
                                     Ok(status) if status.success() => Ok(()),
                                     Ok(status) => Err(format!(
                                         "{program} exited with {status} while trashing {label}"

--- a/crates/app/src/test_support.rs
+++ b/crates/app/src/test_support.rs
@@ -66,7 +66,10 @@ pub(crate) fn temp_repo_with(seed: impl FnOnce(&Path)) -> TempRoot {
 }
 
 fn canonicalized(dir: tempfile::TempDir) -> TempRoot {
-    let root = dir.path().canonicalize().expect("canonicalize tempdir");
+    // `dunce`, matching `crate::rail::repo::canonical_repo_path`: std's Windows spelling is the
+    // verbatim `\\?\C:\...` form, which git rejects - a fixture carrying it fails every
+    // `git worktree add`/`git add` in setup (GitHub issue #467).
+    let root = dunce::canonicalize(dir.path()).expect("canonicalize tempdir");
     TempRoot { _dir: dir, root }
 }
 

--- a/crates/app/src/updater/flow.rs
+++ b/crates/app/src/updater/flow.rs
@@ -101,7 +101,7 @@ fn run_self_update(
 /// own "pure decision function + thin real-execution wrapper" precedent (that function's own
 /// docs name this exact convention).
 fn build_relaunch_command(exe: &Path, args: &[OsString]) -> std::process::Command {
-    let mut command = std::process::Command::new(exe);
+    let mut command = pty_core::new_std_command(exe);
     command.args(args);
     command
 }

--- a/crates/app/src/work_surface/session.rs
+++ b/crates/app/src/work_surface/session.rs
@@ -241,7 +241,7 @@ mod session_restore_tests {
                 path.to_str().expect("utf8 path"),
             ],
         );
-        std::fs::canonicalize(&path).expect("canonicalize")
+        dunce::canonicalize(&path).expect("canonicalize")
     }
 
     /// One real launch: a fresh [`AdeApp`] against a real settings path. `repo_path: None` with

--- a/crates/app/src/work_surface/tab_order_state.rs
+++ b/crates/app/src/work_surface/tab_order_state.rs
@@ -27,7 +27,7 @@ pub fn tab_order_path_for(settings_path: &Path) -> PathBuf {
 /// The map key for one worktree - see `crate::sidebar::fold_state::worktree_key`'s own docs for
 /// the identical canonicalization/UTF-8 reasoning, copied here unchanged.
 pub fn worktree_key(root: &Path) -> Option<String> {
-    let canonical = std::fs::canonicalize(root).unwrap_or_else(|_| root.to_path_buf());
+    let canonical = dunce::canonicalize(root).unwrap_or_else(|_| root.to_path_buf());
     canonical.to_str().map(str::to_owned)
 }
 

--- a/crates/lsp-core/src/client.rs
+++ b/crates/lsp-core/src/client.rs
@@ -18,7 +18,7 @@
 use std::collections::{HashMap, VecDeque};
 use std::io::BufReader;
 use std::path::{Path, PathBuf};
-use std::process::{Child, ChildStdin, Command, Stdio};
+use std::process::{Child, ChildStdin, Stdio};
 use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
 use std::sync::mpsc::{self, Receiver, SyncSender};
 use std::sync::{Arc, Mutex, MutexGuard};
@@ -228,7 +228,8 @@ pub struct LspClient {
     connection_alive: Arc<AtomicBool>,
 }
 
-/// Resolves a bare `binary` name to the absolute path [`LspClient::spawn`] hands `Command::new`,
+/// Resolves a bare `binary` name to the absolute path [`LspClient::spawn`] hands
+/// [`pty_core::new_std_command`],
 /// through the same [`pty_core::resolve_on_path`] callers use to decide a server is installed.
 ///
 /// Resolving first is load-bearing on Windows. `std::process::Command` does its own lookup there,
@@ -274,7 +275,10 @@ impl LspClient {
 
         let name = config.name;
         let resolved_binary = resolve_server_binary(name, config.binary)?;
-        let mut command = Command::new(resolved_binary);
+        // Through `pty_core::new_std_command`, so a `.cmd`-shim server (which `std` launches
+        // via a console-subsystem `cmd.exe` host) opens no console window on Windows release
+        // builds (GitHub issue #465).
+        let mut command = pty_core::new_std_command(resolved_binary);
         command
             .args(&config.args)
             .current_dir(&repo_root)
@@ -1250,6 +1254,7 @@ fn run_stderr_drain_loop(stderr: std::process::ChildStderr, server: &'static str
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::process::Command;
     use std::time::Instant;
     // Only `IncomingHarness` uses this, and it is `#[cfg(unix)]` - the import has to carry the
     // same gate or it is an unused import on Windows.
@@ -1261,9 +1266,17 @@ mod tests {
         let dir = tempfile::TempDir::new().expect("tempdir");
         let resolved = canonicalize(dir.path()).expect("a real, existing directory must resolve");
         assert!(resolved.is_dir());
+        assert!(resolved.is_absolute());
+        // Same directory identity as std's answer - without demanding std's *spelling*, which
+        // on Windows is the verbatim `\\?\C:\...` form this function exists to avoid.
         assert_eq!(
-            resolved,
+            std::fs::canonicalize(&resolved).expect("std canonicalize of the resolved path"),
             std::fs::canonicalize(dir.path()).expect("std canonicalize")
+        );
+        #[cfg(windows)]
+        assert!(
+            !resolved.to_string_lossy().starts_with(r"\\?\"),
+            "the verbatim prefix breaks file:// URIs and must be simplified away, got {resolved:?}"
         );
     }
 
@@ -2660,7 +2673,7 @@ mod tests {
 
         assert_eq!(
             round_tripped,
-            path.canonicalize().expect("canonicalize"),
+            canonicalize(&path).expect("canonicalize"),
             "converting a real path to a URI and back should yield the same real, canonical path"
         );
         // `LspClient::path_for_uri` is a thin wrapper over the same logic - confirm

--- a/crates/lsp-core/src/lib.rs
+++ b/crates/lsp-core/src/lib.rs
@@ -11,8 +11,12 @@
 //! crate's resolved version, deliberately not `vendor/zed`'s GPL fork. Framing itself is not
 //! something `lsp-types` defines; see [`transport`].
 
-// Only production code is held to `unwrap_used`/`expect_used`; see `CLAUDE.md`.
-#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+// Only production code is held to `unwrap_used`/`expect_used` and the bare-`Command::new`
+// ban (`clippy.toml`, GitHub issue #465); see `CLAUDE.md`.
+#![cfg_attr(
+    test,
+    allow(clippy::unwrap_used, clippy::expect_used, clippy::disallowed_methods)
+)]
 
 mod client;
 // Unix-only: the `/proc` walk and `nix` signals have no Windows equivalent, so `client.rs` uses

--- a/crates/pty-core/src/command.rs
+++ b/crates/pty-core/src/command.rs
@@ -1,0 +1,63 @@
+//! The workspace's one constructor for non-PTY child processes (`std::process::Command`).
+//! Owns the same "how children are spawned on this OS" concern as [`crate::resolve_on_path`]:
+//! on Windows the release binary is a GUI-subsystem process (`windows_subsystem = "windows"`),
+//! where a console-subsystem child spawned with default creation flags allocates its own
+//! visible console window — `CREATE_NO_WINDOW` suppresses that (GitHub issue #465). Not for
+//! PTY children: `portable-pty`'s ConPTY spawn already attaches those to a headless
+//! pseudo console.
+
+use std::ffi::OsStr;
+use std::process::Command;
+
+/// A [`Command`] for `program` that never flashes a console window on Windows.
+///
+/// Every production spawn in the workspace constructs through here rather than
+/// `Command::new` — enforced by `clippy.toml`'s `disallowed-methods`.
+#[cfg(windows)]
+// The one sanctioned bare constructor (see `clippy.toml`); everything else calls this fn.
+#[allow(clippy::disallowed_methods)]
+pub fn new_std_command(program: impl AsRef<OsStr>) -> Command {
+    use std::os::windows::process::CommandExt as _;
+
+    /// <https://learn.microsoft.com/en-us/windows/win32/procthread/process-creation-flags>
+    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
+    let mut command = Command::new(program);
+    command.creation_flags(CREATE_NO_WINDOW);
+    command
+}
+
+/// A [`Command`] for `program` — the identity constructor everywhere but Windows, kept as the
+/// single shared entry point so call sites need no platform `cfg` of their own.
+#[cfg(not(windows))]
+// The one sanctioned bare constructor (see `clippy.toml`); everything else calls this fn.
+#[allow(clippy::disallowed_methods)]
+pub fn new_std_command(program: impl AsRef<OsStr>) -> Command {
+    Command::new(program)
+}
+
+#[cfg(test)]
+mod command_tests {
+    use super::new_std_command;
+
+    #[test]
+    fn the_program_handed_in_is_the_program_the_command_runs() {
+        let command = new_std_command("git");
+        assert_eq!(command.get_program(), "git");
+    }
+
+    /// The creation flags must not poison an ordinary spawn: a child started through the
+    /// helper still runs to completion and reports its exit status on every platform.
+    #[test]
+    fn a_child_spawned_through_the_helper_runs_to_completion() {
+        let output = new_std_command("git")
+            .arg("--version")
+            .output()
+            .expect("`git --version` must spawn through the helper");
+        assert!(
+            output.status.success(),
+            "`git --version` must exit 0, got {:?}",
+            output.status
+        );
+    }
+}

--- a/crates/pty-core/src/lib.rs
+++ b/crates/pty-core/src/lib.rs
@@ -9,8 +9,12 @@
 //! Only `#[cfg(unix)]` gets the self-pipe and the process-tree walk; `/proc` readers degrade to
 //! "found nothing" on a non-Linux unix, leaving process-group signals intact.
 
-// Only production code is held to `unwrap_used`/`expect_used`; see `CLAUDE.md`.
-#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+// Only production code is held to `unwrap_used`/`expect_used` and the bare-`Command::new`
+// ban (`clippy.toml`, GitHub issue #465); see `CLAUDE.md`.
+#![cfg_attr(
+    test,
+    allow(clippy::unwrap_used, clippy::expect_used, clippy::disallowed_methods)
+)]
 
 use portable_pty::{native_pty_system, Child, CommandBuilder, MasterPty, PtySize};
 #[cfg(unix)]
@@ -37,6 +41,9 @@ use thiserror::Error;
 mod login_shell;
 #[cfg(unix)]
 pub use login_shell::resolve_login_shell_path;
+
+mod command;
+pub use command::new_std_command;
 
 pub use portable_pty::ExitStatus;
 

--- a/crates/pty-core/src/login_shell.rs
+++ b/crates/pty-core/src/login_shell.rs
@@ -11,7 +11,7 @@ use std::env;
 use std::ffi::{OsStr, OsString};
 use std::io::{IsTerminal, Read};
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
+use std::process::Stdio;
 use std::sync::mpsc;
 use std::time::{Duration, Instant};
 
@@ -90,7 +90,7 @@ fn login_shell_probe_args(shell: &Path) -> Option<Vec<&'static str>> {
 /// prompt) and a hard timeout, returning its raw stdout. `None` on any failure to spawn or
 /// produce output before the timeout - genuinely unable to resolve, never a guessed result.
 fn run_login_shell_probe(shell: &Path, args: &[&str], timeout: Duration) -> Option<Vec<u8>> {
-    let mut child = Command::new(shell)
+    let mut child = crate::new_std_command(shell)
         .args(args)
         .stdin(Stdio::null())
         .stdout(Stdio::piped())

--- a/crates/test-support/src/lib.rs
+++ b/crates/test-support/src/lib.rs
@@ -12,6 +12,10 @@
 // Every function here runs inside a consumer's `#[cfg(test)]` code, where a broken fixture must
 // abort the test with a diagnostic rather than propagate a `Result` nobody can act on.
 #![allow(clippy::expect_used)]
+// Bare `Command::new` (banned in production by `clippy.toml`, GitHub issue #465) is fine here:
+// fixtures run under the console-subsystem test runner, whose children inherit its console, so
+// no window can flash - and routing through the helper would couple this crate to `pty-core`.
+#![allow(clippy::disallowed_methods)]
 
 mod child;
 mod git;

--- a/crates/wt-core/Cargo.toml
+++ b/crates/wt-core/Cargo.toml
@@ -15,6 +15,12 @@ thiserror = { workspace = true }
 # Used at runtime (not just in tests) by `diff::prepare_shadow_index` to build a throwaway
 # copy of the real index for `git diff`'s untracked-file handling - see that function's docs.
 tempfile = "3"
+# Sole use: `new_std_command`, the workspace's one constructor for non-PTY child processes,
+# which suppresses the per-spawn console window on Windows GUI-subsystem release builds
+# (GitHub issue #465). The constructor must live in exactly one place, and pty-core owns
+# process spawning (docs/architecture/crates.md) - the portable-pty it drags along is already
+# in this workspace's build graph either way.
+pty-core = { path = "../pty-core" }
 # Fixed-length, collision-free ref-name components for `review::baseline_ref_name`. Raw hex
 # encoding of the key doubled its length and pushed real, ordinary worktree paths past the
 # filesystem's 255-byte `NAME_MAX` for a loose ref's filename, which failed baseline capture

--- a/crates/wt-core/src/diff.rs
+++ b/crates/wt-core/src/diff.rs
@@ -769,8 +769,11 @@ pub(crate) enum ShadowIndexContent {
     TrackedOnly,
 }
 
-/// Filename prefix marking a shadow index as this app's, should a killed process leave one behind.
-const SHADOW_INDEX_PREFIX: &str = ".jerry-shadow-index-";
+/// Filename prefix marking a shadow index as this app's, should a killed process leave one
+/// behind. Public so a filesystem watcher over the git directory can recognize this crate's
+/// own churn (the tempfile and git's `<name>.lock` sidecar both carry it) and not re-trigger
+/// on every diff this app itself computes (GitHub issue #466).
+pub const SHADOW_INDEX_PREFIX: &str = ".jerry-shadow-index-";
 
 /// Creates the throwaway index file, beside `real_index_path` in the worktree's git directory.
 ///

--- a/crates/wt-core/src/lib.rs
+++ b/crates/wt-core/src/lib.rs
@@ -10,8 +10,12 @@
 //! functions wait on a child process. A caller on a UI thread must offload to a background
 //! executor.
 
-// Only production code is held to `unwrap_used`/`expect_used`; see `CLAUDE.md`.
-#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+// Only production code is held to `unwrap_used`/`expect_used` and the bare-`Command::new`
+// ban (`clippy.toml`, GitHub issue #465); see `CLAUDE.md`.
+#![cfg_attr(
+    test,
+    allow(clippy::unwrap_used, clippy::expect_used, clippy::disallowed_methods)
+)]
 
 pub mod blame;
 pub mod checkout;
@@ -406,10 +410,12 @@ const GIT_ENV_OVERRIDES: [&str; 5] = [
 ];
 
 /// Build a `git` [`Command`] running in `dir` with `args`: environment scrubbed of
-/// [`GIT_ENV_OVERRIDES`], and stdin closed so an interactive prompt (credentials, GPG,
-/// askpass) fails fast instead of hanging forever with no way to cancel it.
+/// [`GIT_ENV_OVERRIDES`], stdin closed so an interactive prompt (credentials, GPG,
+/// askpass) fails fast instead of hanging forever with no way to cancel it, and constructed
+/// through [`pty_core::new_std_command`] so no console window flashes per spawn on Windows
+/// (GitHub issue #465).
 fn git_command(dir: &Path, args: &[OsString]) -> Command {
-    let mut command = Command::new("git");
+    let mut command = pty_core::new_std_command("git");
     command.current_dir(dir).args(args).stdin(Stdio::null());
     for var in GIT_ENV_OVERRIDES {
         command.env_remove(var);

--- a/docs/architecture/crates.md
+++ b/docs/architecture/crates.md
@@ -18,10 +18,13 @@ verified — the only two mentions of `gpui` in this crate are comments explaini
 ## `pty-core`
 
 **Scope.** Spawning and driving a PTY-backed child process (`portable-pty`), and nothing about what
-happens to the bytes that come out of it.
+happens to the bytes that come out of it — plus the workspace's "how children are spawned on this
+OS" helpers that aren't PTY-specific (`resolve_on_path`, `new_std_command`).
 
 **Owns.** `PtySession`, `SpawnOptions`, process lifecycle (`kill`, `pause`, `resume`, `try_wait`).
-Output is exposed as a plain `std::sync::mpsc::Receiver<Vec<u8>>`.
+Output is exposed as a plain `std::sync::mpsc::Receiver<Vec<u8>>`. Also `new_std_command`, the one
+sanctioned constructor for every non-PTY `std::process::Command` in the workspace — it suppresses
+the per-spawn console window on Windows GUI-subsystem release builds (decisions.md §10).
 
 **Does not own.** ANSI/terminal-grid parsing (that's `crates/app/src/terminal/`), any git concern,
 any gpui dependency.

--- a/docs/architecture/decisions.md
+++ b/docs/architecture/decisions.md
@@ -279,3 +279,32 @@ catch.
 checkable invariant, not a convention. A helper that "just needs a `TestAppContext`" is not added
 to `crates/test-support` under any flag — it goes in `crates/app` or it is restructured to take
 plain data. The policy those fixtures serve is [`docs/testing.md`](../testing.md).
+
+## 10. Every non-PTY child process is constructed through `pty_core::new_std_command`
+
+**Status:** Accepted.
+
+**Context:** The release binary is a GUI-subsystem process on Windows (`windows_subsystem =
+"windows"` in `crates/app/src/main.rs`, adopted from Zed in #451 so no console opens behind the
+window). On Windows, a console-subsystem child — `git.exe`, an npm `.cmd` shim, `cmd /c start` —
+spawned from a consoleless parent allocates its own *visible* console window unless the spawn
+passes `CREATE_NO_WINDOW`. Jerry spawns git continuously from launch (status poll, worktree
+watch, Changes refresh), so the missing flag showed up as an endless storm of console popups
+(#465). Zed pairs the same attribute with construction-time wrappers
+(`util::command`/`gpui_util::new_std_command` upstream) plus a clippy ban on bare constructors;
+#451 copied the attribute without the wrapper.
+
+**Decision:** One constructor, `pty_core::new_std_command`, sets `CREATE_NO_WINDOW` on Windows
+and is the identity elsewhere; every production `std::process::Command` in the workspace is built
+through it. It lives in `pty-core` because that crate already owns "how children are spawned on
+this OS" (`resolve_on_path`), and a one-function helper does not earn its own crate. `wt-core`
+takes a dependency on `pty-core` for it — the constructor must exist in exactly one place.
+Enforced by `clippy.toml`'s `disallowed-methods` on `std::process::Command::new`; test modules
+are exempt (each crate root's `cfg_attr(test, allow(clippy::disallowed_methods))`,
+`test-support`'s crate-level allow) because the test runner owns a console its children inherit.
+
+**Consequences:** PTY children are explicitly out of scope — `portable-pty`'s ConPTY spawn
+already attaches them to a headless pseudo console via `PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE`, and
+`CREATE_NO_WINDOW` is neither needed nor passable there. Anything that spawns without
+`std::process::Command` (direct `CreateProcessW` FFI, a future async runtime's command type)
+must apply the same flag at its own call site; none exists today.


### PR DESCRIPTION
Closes #465
Closes #466
Closes #467

## What

Three fixes that together stop the "infinite terminal popup" storm on Windows release builds (regression from #451) and cut Jerry's background git churn on every platform:

- **No more console windows per spawn (#465).** `pty_core::new_std_command` is now the one constructor for every non-PTY `std::process::Command` in the workspace — it sets `CREATE_NO_WINDOW` on Windows and is the identity elsewhere. Applied at wt-core's `git_command` choke point (which every polling/diff/status spawn funnels through), lsp-core's server spawn, the unix login-shell probe, and the app's open-handler/updater/trash spawns. PTY children were already windowless (ConPTY attaches them to a headless pseudo console) and are untouched. `clippy.toml` now bans bare `std::process::Command::new` — the ban its own comment previously explained was impossible becomes possible precisely because every legitimate call site now routes through the helper; test modules stay exempt via each crate root's `cfg_attr(test, allow(...))`.
- **The worktree watcher no longer feeds on Jerry's own churn (#466).** Every diff computation writes `.jerry-shadow-index-*` tempfiles, a git `.lock` sidecar, and loose objects inside the watched git directory, so the 3s status poll and 5s Changes refresh kept re-dirtying the watcher and drove `git worktree list` at its ~500ms fast cadence forever. The watcher now ignores events that cannot change `git worktree list` output (those file names, plus non-rename `Modify` events on a bare `worktrees/<name>` entry — renames excluded because a directory moved wholesale into/out of `worktrees/` arrives *only* as that rename). Steady-state re-list drops back to the intended 5s poll plus real changes.
- **Verbatim `\\?\` paths no longer reach git (#467).** `canonical_repo_path` (and the watch roots, `worktree_key` maps, the Vue plugin resolution, and every test fixture) now canonicalize through `dunce` — the exact pattern lsp-core already used — because git rejects std's Windows verbatim spelling with `Invalid argument`. At runtime this was failing the shadow-index diff behind the Changes counter on every poll. `RepoState::load_at` re-spells keys persisted by pre-fix builds so an existing `repos.toml` heals on first save instead of leaving the remembered repo permanently broken (and, from the second launch, an empty window).

Measured on the release build after the fix: 20 seconds of runtime produced **zero visible console windows** (all new conhosts are windowless hosts) and git spawning at the designed poll cadence instead of the runaway loop.

## Testing

- [x] fmt, clippy `-D warnings`, and `cargo build --workspace` pass locally; conventions ratchet not run locally (`jq` missing on this machine) — CI runs it
- [x] `cargo nextest run --workspace`: **not green on this Windows machine, and provably not because of this branch** — master fails 177 of 3109 here (the suite has never run on real Windows hardware; inventory in #468), this branch fails 104 of 3114, every one reproduced verbatim on unmodified master, and 77 of master's failures are *fixed* by the #467 fixture repair (all of `rail::worktree_watch`, lsp-core's canonicalize tests, session restore, and more). CI's Linux/macOS jobs are the authoritative green gate.
- [x] New behavior has real tests in the right tiers: the helper's construction/spawn tests (pty-core), the churn filter's pure-function coverage, and two end-to-end regressions that run a real diff under an armed watcher (main worktree + linked worktree) and assert the dirty flag stays clean — the exact #466 feedback loop
- [x] Runtime smoke test of the release exe on Windows: 0 visible console windows in 20s, git spawn cadence at designed rate
- [ ] `external` tier untouched — not run

## Architecture notes

- `pty_core::new_std_command` lives in pty-core (not a new crate) per the architecture skill's own guidance — a one-function helper doesn't earn a crate, and pty-core already owns "how children are spawned on this OS" (`resolve_on_path`). wt-core gains a `pty-core` dependency for it, the same lateral edge lsp-core already has. Documented as `docs/architecture/decisions.md` §10; `crates.md`'s pty-core entry updated.
- `dunce = "1.0"` added to the app crate: the exact crate/version lsp-core already resolves and upstream Zed pins for the same problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
