### PR TITLE
perf: fix the four verified hot-path hazards (#470-#473)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6155,6 +6155,7 @@ dependencies = [
  "anyhow",
  "filedescriptor",
  "libc",
+ "log",
  "nix",
  "portable-pty",
  "tempfile",

--- a/crates/app/src/code_surface/tabs.rs
+++ b/crates/app/src/code_surface/tabs.rs
@@ -48,11 +48,15 @@ impl AdeApp {
     /// five git queries take on a large worktree, so an ungated call would cancel its own
     /// still-running predecessor on every tick (assigning [`Self::_load_diff_task`] drops the
     /// previous task) and the pane could starve indefinitely while an agent keeps writing.
-    pub(crate) fn refresh_diff_if_idle(&mut self, cx: &mut Context<Self>) {
+    /// Returns whether a reload really started - `false` means the skip-as-busy path ran, and a
+    /// caller tracking "has the state I observed been reloaded" (the poll fingerprint,
+    /// GitHub issue #473) must not mark it observed.
+    pub(crate) fn refresh_diff_if_idle(&mut self, cx: &mut Context<Self>) -> bool {
         if self.diff_reload_in_flight {
-            return;
+            return false;
         }
         self.refresh_diff(cx);
+        true
     }
 
     /// The real background git reload both [`Self::load_diff`] and [`Self::refresh_diff`] run -

--- a/crates/app/src/lsp/client.rs
+++ b/crates/app/src/lsp/client.rs
@@ -402,6 +402,39 @@ impl AdeApp {
         }
     }
 
+    /// Removes and returns every Ready client rooted exactly at `root`, pruning the same
+    /// per-root caches [`Self::evict_stale_lsp_clients`] prunes. For the worktree discard flow
+    /// (GitHub issue #470), which must shut these servers down *sequenced before* deleting the
+    /// directory - their cwd and open file handles are inside it - rather than on eviction's
+    /// detached teardown task. `Spawning`/`Failed` entries hold no process and are dropped;
+    /// an in-flight `Spawning` that later re-inserts is caught by the next eviction pass,
+    /// exactly as eviction's own docs describe.
+    pub(crate) fn take_lsp_clients_for_root(
+        &mut self,
+        root: &Path,
+    ) -> Vec<std::sync::Arc<lsp_core::LspClient>> {
+        let doomed_keys: Vec<LspClientKey> = self
+            .lsp_clients
+            .keys()
+            .filter(|(client_root, _)| client_root == root)
+            .cloned()
+            .collect();
+        if doomed_keys.is_empty() {
+            return Vec::new();
+        }
+        self.lsp_opened_files.retain(|path| !path.starts_with(root));
+        self.lsp_document_versions
+            .retain(|path, _| !path.starts_with(root));
+        self.lsp_uri_cache.retain(|path, _| !path.starts_with(root));
+        doomed_keys
+            .into_iter()
+            .filter_map(|key| match self.lsp_clients.remove(&key) {
+                Some(LspClientState::Ready(client)) => Some(client),
+                _ => None,
+            })
+            .collect()
+    }
+
     /// Tears one real server down without blocking the GPUI thread - the shared body behind both
     /// [`Self::evict_stale_lsp_clients`] and [`Self::restart_lsp_clients`], so the
     /// `try_unwrap`-then-`shutdown`-else-`drop` rule lives in exactly one place. See

--- a/crates/app/src/rail/strip_render.rs
+++ b/crates/app/src/rail/strip_render.rs
@@ -2,12 +2,23 @@
 //! real switch behind it, and the Problems view it switches to.
 
 use super::*;
+use std::path::Path;
+
 use crate::icons::{IconRow, IconSize};
 use crate::lsp::client::LspClientState;
 use crate::lsp::diagnostics as diagnostics_view;
 use crate::rail::strip::{self, Problem, ProblemTally, SidebarView, StripCell, StripMarker};
 use crate::root::scrollbar;
 use crate::root::widgets::text_tooltip;
+
+/// Memo behind [`AdeApp::worktree_problems`] - see `AdeApp::problems_cache`'s own field docs.
+/// Holds the derived list plus exactly the inputs whose movement invalidates it.
+#[derive(Default)]
+pub(crate) struct ProblemsCache {
+    root: Option<std::path::PathBuf>,
+    generations: Vec<(std::path::PathBuf, &'static str, u64)>,
+    problems: std::rc::Rc<Vec<Problem>>,
+}
 
 impl AdeApp {
     /// Switches the sidebar to `view`.
@@ -28,11 +39,56 @@ impl AdeApp {
     }
 
     /// Every diagnostic the app really knows about in the currently selected worktree, worst
-    /// first, then by file and position.
-    pub(in crate::rail) fn worktree_problems(&self) -> Vec<Problem> {
+    /// first, then by file and position — memoized on `AdeApp::problems_cache`, recomputed only
+    /// when the worktree or some Ready client's diagnostics generation moved. This runs on
+    /// every render, and the uncached version cloned every diagnostic and `stat`ed every
+    /// diagnosed file per frame (GitHub issue #471).
+    pub(in crate::rail) fn worktree_problems(&self) -> std::rc::Rc<Vec<Problem>> {
         let Some(root) = self.current_worktree_path() else {
-            return Vec::new();
+            return std::rc::Rc::default();
         };
+        let mut generations: Vec<(PathBuf, &'static str, u64)> = self
+            .lsp_clients
+            .iter()
+            .filter_map(|((client_root, server), state)| match state {
+                LspClientState::Ready(client) if client_root == &root => Some((
+                    client_root.clone(),
+                    *server,
+                    client.diagnostics_generation(),
+                )),
+                _ => None,
+            })
+            .collect();
+        // `lsp_clients` is a `HashMap`; a stable order is what makes generation equality mean
+        // "nothing changed" rather than "same clients, different iteration order".
+        generations.sort();
+        {
+            let cache = self.problems_cache.borrow();
+            if cache.root.as_ref() == Some(&root) && cache.generations == generations {
+                return std::rc::Rc::clone(&cache.problems);
+            }
+        }
+        let problems = std::rc::Rc::new(self.compute_worktree_problems(&root));
+        *self.problems_cache.borrow_mut() = ProblemsCache {
+            root: Some(root),
+            generations,
+            problems: std::rc::Rc::clone(&problems),
+        };
+        problems
+    }
+
+    /// Drops the memo so the next [`Self::worktree_problems`] call recomputes. Called by the
+    /// file-tree watcher's event arm: diagnostics generations can't see *worktree* changes, and
+    /// the existence filter below must re-run once a published-about file may have been
+    /// deleted out from under its server (the watcher is how the real app notices that).
+    pub(crate) fn invalidate_problems_cache(&self) {
+        self.problems_cache.borrow_mut().root = None;
+    }
+
+    /// The real recomputation behind [`Self::worktree_problems`] — the only place the
+    /// per-diagnostic clones and the per-file existence `stat`s happen.
+    fn compute_worktree_problems(&self, root: &Path) -> Vec<Problem> {
+        let root = root.to_path_buf();
         // A diagnostic's uri is whatever real path the *server* opened, and `lsp_core`'s own
         // `path_to_uri` canonicalises on the way in - so a checkout reached through a symlink
         // (macOS' `/var` -> `/private/var`, or a worktree directory someone symlinked) yields
@@ -927,8 +983,8 @@ mod problems_view_tests {
     /// The list the view is really showing, as `(file, line, severity)` triples.
     fn rows(app: &AdeApp) -> Vec<(String, u32, diagnostics_view::Severity)> {
         app.worktree_problems()
-            .into_iter()
-            .map(|problem| (problem.file, problem.line, problem.severity))
+            .iter()
+            .map(|problem| (problem.file.clone(), problem.line, problem.severity))
             .collect()
     }
 
@@ -1265,7 +1321,16 @@ mod problems_view_tests {
         let root = repo.path().to_path_buf();
         let (doomed, doomed_uri) = real_file(&root, "src/scratch.rs", "fn tmp() {}\n");
 
-        let (app, cx) = crate::test_support::open_test_app(cx, root.clone());
+        // A real settings path, not `open_test_app`'s `None`: `start_file_tree_watch` refuses to
+        // arm without one, and this test's whole subject is that watcher noticing the deletion
+        // (see the problems memo, GitHub issue #471).
+        let settings_dir = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app_with_settings(
+            cx,
+            root.clone(),
+            crate::settings::store::Settings::default(),
+            Some(settings_dir.path().join("settings.toml")),
+        );
         cx.run_until_parked();
 
         let server = spawn_fake_server(&root, "rust-analyzer", "normal");
@@ -1286,17 +1351,25 @@ mod problems_view_tests {
         );
 
         // The server is never told. This is the real condition: an agent (or a `git checkout`)
-        // removes a file, and the server's own published map still names it.
+        // removes a file, and the server's own published map still names it. The problems memo
+        // (GitHub issue #471) only re-checks existence once the real file-tree watcher notices
+        // the worktree changed, so this drives that whole path: the deletion reaches the OS
+        // watcher in real time (`wait_until`'s bounded real-time loop), and `advance_clock`
+        // ticks the watch loop's own timer arm.
         std::fs::remove_file(&doomed).expect("remove the file");
+        let gone = test_support::wait_until(std::time::Duration::from_secs(5), || {
+            cx.executor()
+                .advance_clock(std::time::Duration::from_millis(600));
+            cx.run_until_parked();
+            app.read_with(cx, |app, _| app.worktree_problems().is_empty())
+        });
+        assert!(
+            gone,
+            "the server still publishes it; the checkout no longer contains it - the row must \
+             drop once the file-tree watcher reports the deletion"
+        );
         app.update(cx, |_app, cx| cx.notify());
         cx.run_until_parked();
-
-        app.read_with(cx, |app, _| {
-            assert!(
-                app.worktree_problems().is_empty(),
-                "the server still publishes it; the checkout no longer contains it"
-            );
-        });
         assert!(
             cx.debug_bounds("sidebar-problems-row-0").is_none(),
             "so the row must be gone"

--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -459,6 +459,11 @@ pub struct AdeApp {
     /// [`Self::current_diff`]'s docs for exactly which [`DiffLoadState`]/[`DiffBase`]
     /// combinations count).
     pub(crate) diff_totals: Option<(u32, u32)>,
+    /// Memoized [`Self::worktree_problems`] output, keyed by worktree root and each Ready LSP
+    /// client's diagnostics generation - recomputed only when one of those moves, where it used
+    /// to clone every diagnostic and `stat` every diagnosed file on **every frame**
+    /// (GitHub issue #471). `RefCell` because render paths hold `&self`.
+    pub(crate) problems_cache: std::cell::RefCell<crate::rail::strip_render::ProblemsCache>,
     /// Whether a `Self::spawn_diff_reload` task is running right now, so the watcher-driven
     /// refresh behind GitHub issue #415 can skip a tick instead of cancelling a reload that is
     /// still working - see [`Self::refresh_diff_if_idle`].
@@ -1378,6 +1383,11 @@ pub struct AdeApp {
     /// newer one" structurally impossible - there can never be a second one in flight to race
     /// with.
     pub(crate) worktree_history_op_in_flight: Option<worktree_history::WorktreeHistoryOpKind>,
+    /// The worktree an in-flight discard is deleting, if any. Spawn paths
+    /// (`new_agent`/`respawn_agent`) refuse to start a process whose cwd would be this
+    /// directory: a child spawned mid-delete holds the directory open on Windows and executes
+    /// in an unlinked cwd on unix - the exact half-failed removal GitHub issue #470 closes.
+    pub(crate) discarding_worktree: Option<PathBuf>,
     /// Feedback from the most recent "keep all changes"/"discard worktree" operation, shown in
     /// the status bar
     /// (`status_bar::render::AdeApp::render_status_worktree_history_notice`) until the next one -

--- a/crates/app/src/root/state.rs
+++ b/crates/app/src/root/state.rs
@@ -342,6 +342,7 @@ impl AdeApp {
             find_bar_focus_handle: cx.focus_handle(),
             diff_state: DiffLoadState::Loading,
             diff_totals: None,
+            problems_cache: std::cell::RefCell::default(),
             diff_reload_in_flight: false,
             agent_reviews: HashMap::new(),
             review_baseline_state,
@@ -543,6 +544,7 @@ impl AdeApp {
             prune_confirm_armed: false,
             prune_in_flight: false,
             worktree_history_op_in_flight: None,
+            discarding_worktree: None,
             worktree_history_status: None,
             update_state: updater::state::UpdateState::Idle,
             update_check_in_flight: false,
@@ -1325,7 +1327,9 @@ impl AdeApp {
         self.start_file_tree_watch(cx);
     }
 
-    /// Walks [`Self::file_tree_root`] and applies the result, off the foreground thread.
+    /// Loads [`Self::file_tree_root`]'s listing and applies the result, off the foreground
+    /// thread — from git's own content answer, walking the filesystem only for a non-git root
+    /// (see `file_tree::build_worktree_file_tree`, GitHub issue #472).
     pub(crate) fn load_file_tree(&mut self, root: PathBuf, cx: &mut Context<Self>) {
         self.set_file_tree_root(root.clone(), cx);
         let task = cx.spawn(async move |this, cx| {
@@ -1333,7 +1337,7 @@ impl AdeApp {
                 .background_executor()
                 .spawn({
                     let root = root.clone();
-                    async move { file_tree::build_file_tree(&root) }
+                    async move { file_tree::build_worktree_file_tree(&root) }
                 })
                 .await;
 
@@ -1360,12 +1364,25 @@ impl AdeApp {
                 }
             };
 
-            let Ok(Some(marks)) = this.update(cx, |this, _| {
-                (this.file_tree_root == root)
-                    .then(|| palette_render::file_diff_marks(this.current_diff()))
+            let Ok(Some((marks, unchanged))) = this.update(cx, |this, _| {
+                (this.file_tree_root == root).then(|| {
+                    // The steady-state poll usually re-derives an identical listing; applying
+                    // it anyway would rebuild every palette candidate and re-render the whole
+                    // window for no visible change (GitHub issue #472).
+                    let unchanged = this.file_tree_error.is_none()
+                        && this.file_tree_complete == listing.is_complete()
+                        && this.file_tree == listing.tree;
+                    (
+                        palette_render::file_diff_marks(this.current_diff()),
+                        unchanged,
+                    )
+                })
             }) else {
                 return;
             };
+            if unchanged {
+                return;
+            }
 
             let complete = listing.is_complete();
             let (tree, candidates) = cx
@@ -1430,6 +1447,12 @@ impl AdeApp {
 
         let task = cx.spawn(async move |this, cx| {
             let mut last_refresh = Instant::now();
+            // GitHub issue #473: what the last *poll-arm* diff reload saw of the git-side state.
+            // The poll arm exists only for `.git/`-internal changes the content watcher filters
+            // out, so when this fingerprint is unchanged the ~10-git-spawn reload is provably
+            // redundant and skipped. Reset (never trusted) across watcher firings - worktree
+            // content is outside the fingerprint's scope by contract.
+            let mut last_poll_fingerprint: Option<wt_core::diff::ChangesFingerprint> = None;
             loop {
                 cx.background_executor().timer(FILE_TREE_WATCH_TICK).await;
 
@@ -1448,12 +1471,53 @@ impl AdeApp {
                 }
                 last_refresh = Instant::now();
 
+                // The fingerprint gate's contract holds only while a real content watcher is
+                // armed (`changes_fingerprint`'s own docs): `spawn_file_tree_watcher` can
+                // genuinely fail - inotify watch exhaustion being the classic case - and this
+                // loop then runs on the poll arm alone, which must behave exactly as it did
+                // before the gate existed: reloading, and re-checking problem rows,
+                // unconditionally.
+                let watcher_armed = this
+                    .read_with(cx, |this, _| this._file_tree_watcher.is_some())
+                    .unwrap_or(false);
+
+                // `Some` only when this firing observed a fresh git-side fingerprint no reload
+                // has covered yet - committed below only once a reload really starts, so a
+                // skip-as-busy retries next poll instead of marking the change seen forever.
+                let mut pending_fingerprint: Option<Option<wt_core::diff::ChangesFingerprint>> =
+                    None;
+                let refresh_diff = if watcher_fired || !watcher_armed {
+                    last_poll_fingerprint = None;
+                    true
+                } else {
+                    let fingerprint_root = root.clone();
+                    let fingerprint =
+                        cx.background_executor()
+                            .spawn(async move {
+                                wt_core::diff::changes_fingerprint(&fingerprint_root).ok()
+                            })
+                            .await;
+                    // An unreadable fingerprint (`None`) always reloads: erring toward one
+                    // redundant reload beats a stale Changes counter.
+                    let changed = fingerprint.is_none() || fingerprint != last_poll_fingerprint;
+                    if changed {
+                        pending_fingerprint = Some(fingerprint);
+                    }
+                    changed
+                };
+
                 let updated = this.update(cx, |this, cx| {
                     // The active worktree may have changed since this loop's own last tick (a
                     // fresh loop for the new root already started - see this method's own docs -
                     // so this one only needs to stop cleanly rather than reload the wrong root).
                     if this.file_tree_root != root {
-                        return false;
+                        return None;
+                    }
+                    if watcher_fired || !watcher_armed {
+                        // A worktree change can delete a file a server still publishes
+                        // diagnostics about - see `Self::invalidate_problems_cache`. With no
+                        // watcher armed, the poll is the only path that ever notices.
+                        this.invalidate_problems_cache();
                     }
                     this.load_file_tree(root.clone(), cx);
                     // GitHub issue #415: the Changes pane and the sidebar's `+n`/`-n` totals used
@@ -1463,13 +1527,20 @@ impl AdeApp {
                     // watcher covers both halves: the watcher arm catches working-tree writes
                     // within one tick, and the poll arm catches the `.git/`-only changes
                     // (`git add`, `git commit`) that `spawn_file_tree_watcher` deliberately
-                    // filters out and would otherwise never report.
-                    this.refresh_diff_if_idle(cx);
-                    true
+                    // filters out and would otherwise never report - now only when
+                    // `changes_fingerprint` says that git-side state really moved (issue #473).
+                    let reload_started = refresh_diff && this.refresh_diff_if_idle(cx);
+                    Some(reload_started)
                 });
                 match updated {
-                    Ok(true) => {}
-                    Ok(false) | Err(_) => break,
+                    Ok(Some(reload_started)) => {
+                        if reload_started {
+                            if let Some(fingerprint) = pending_fingerprint.take() {
+                                last_poll_fingerprint = fingerprint;
+                            }
+                        }
+                    }
+                    Ok(None) | Err(_) => break,
                 }
             }
         });

--- a/crates/app/src/sidebar/file_tree.rs
+++ b/crates/app/src/sidebar/file_tree.rs
@@ -125,6 +125,179 @@ impl FileTreeListing {
 /// gracefully. Anything cut off here marks the listing [`FileTreeListing::partial`].
 pub const MAX_DEPTH: usize = 64;
 
+/// The listing the Files tab and palette actually load: git's own answer to "what does this
+/// worktree contain" (`wt_core::worktree_files`, decisions.md §6) - tracked plus
+/// untracked-unignored files - falling back to the real [`build_file_tree`] walk for a root
+/// that is not a git worktree.
+///
+/// Sourcing from git rather than walking is what keeps this from descending into gitignored
+/// build output: on a checkout with a populated `target/` (or the vendored zed tree) the walk
+/// was hundreds of thousands of `read_dir` results per reload, re-run at least every 5s
+/// (GitHub issue #472). The visible delta is deliberate and matches decisions.md §6's
+/// definition of content: gitignored files and empty directories no longer appear.
+pub fn build_worktree_file_tree(root: &Path) -> io::Result<FileTreeListing> {
+    build_worktree_file_tree_inner(root, SUBMODULE_RECURSION_BUDGET)
+}
+
+/// How many levels of nested submodules are grafted before the listing is marked partial
+/// instead - a defensive bound against a submodule cycle, not a product decision.
+const SUBMODULE_RECURSION_BUDGET: usize = 8;
+
+fn build_worktree_file_tree_inner(
+    root: &Path,
+    submodule_budget: usize,
+) -> io::Result<FileTreeListing> {
+    let list = match wt_core::worktree_files::list_worktree_files(root) {
+        Ok(list) => list,
+        // Only a genuinely non-git root falls back to the walk. Inside a real repository a
+        // transient git failure must surface as the error it is - silently swapping to the
+        // gitignore-blind walk for one cycle would flash a tree with target/ in it and pay
+        // the full-walk cost issue #472 removes.
+        Err(err) if root.join(".git").exists() => {
+            return Err(io::Error::other(err.to_string()));
+        }
+        Err(_) => return build_file_tree(root),
+    };
+    // A submodule's gitlink record is indistinguishable from a file in the plain listing, and
+    // its contents are a separate repository the listing never descends into - so gitlinks are
+    // typed as directories here and their own listings grafted underneath, preserving what the
+    // old filesystem walk showed. Failing to enumerate them (an older git, a corrupt module)
+    // only loses the typing, which the grafting loop then records as a partial listing.
+    let submodules = wt_core::worktree_files::list_submodule_paths(root).unwrap_or_default();
+    let (mut entries, mut partial) = entries_from_git_listing(root, &list, &submodules);
+
+    for submodule in &submodules {
+        let sub_root: PathBuf = {
+            let mut path = root.to_path_buf();
+            path.extend(submodule.split('/'));
+            path
+        };
+        let Some(index) = entries
+            .iter()
+            .position(|entry| entry.is_dir && entry.path == sub_root)
+        else {
+            // Dot-filtered or depth-cut - already accounted for at insertion.
+            continue;
+        };
+        if submodule_budget == 0 {
+            partial = true;
+            continue;
+        }
+        match build_worktree_file_tree_inner(&sub_root, submodule_budget - 1) {
+            Ok(child) => {
+                partial |= child.partial;
+                let base_depth = entries[index].depth + 1;
+                let grafted: Vec<FileTreeEntry> = child
+                    .tree
+                    .iter()
+                    .cloned()
+                    .map(|mut entry| {
+                        entry.depth += base_depth;
+                        entry
+                    })
+                    .collect();
+                entries.splice(index + 1..index + 1, grafted);
+            }
+            // An uninitialized or unreadable submodule keeps its directory row but its
+            // contents are genuinely unknown.
+            Err(_) => partial = true,
+        }
+    }
+
+    Ok(FileTreeListing {
+        tree: FileTree::new(entries),
+        partial,
+    })
+}
+
+/// [`entries_from_git_listing`] wrapped as a finished listing, with no submodule typing - the
+/// pure, directly-testable shape.
+#[cfg(test)]
+fn from_git_listing(
+    root: &Path,
+    list: &wt_core::worktree_files::WorktreeFileList,
+) -> FileTreeListing {
+    let (entries, partial) = entries_from_git_listing(root, list, &[]);
+    FileTreeListing {
+        tree: FileTree::new(entries),
+        partial,
+    }
+}
+
+/// Assembles pre-order entries from `list`'s worktree-relative `/`-separated paths: the same
+/// dirs-first-then-alphabetical order and the same dot-prefixed-name filter as the
+/// [`build_file_tree`] walk, so the two sources render identically where they overlap. Paths in
+/// `submodules` are typed as directories (their content is grafted by the caller). A path
+/// deeper than [`MAX_DEPTH`] is dropped at insertion - bounding the trie itself, not just the
+/// emission - and marks the listing partial.
+fn entries_from_git_listing(
+    root: &Path,
+    list: &wt_core::worktree_files::WorktreeFileList,
+    submodules: &[String],
+) -> (Vec<FileTreeEntry>, bool) {
+    #[derive(Default)]
+    struct Node {
+        children: std::collections::BTreeMap<String, Node>,
+        is_dir: bool,
+    }
+
+    let mut top = Node::default();
+    let mut partial = list.truncated;
+    let mut insert = |path: &str, force_dir: bool, partial: &mut bool| {
+        if path
+            .split('/')
+            .any(|component| component.starts_with('.') || component.is_empty())
+        {
+            return;
+        }
+        if path.split('/').count() > MAX_DEPTH {
+            *partial = true;
+            return;
+        }
+        let mut node = &mut top;
+        let mut components = path.split('/').peekable();
+        while let Some(component) = components.next() {
+            let is_last = components.peek().is_none();
+            node = node.children.entry(component.to_string()).or_default();
+            node.is_dir |= !is_last || force_dir;
+        }
+    };
+    for file in &list.files {
+        insert(file, false, &mut partial);
+    }
+    for submodule in submodules {
+        insert(submodule, true, &mut partial);
+    }
+
+    fn emit(node: &Node, dir: &Path, depth: usize, walk: &mut Walk) {
+        if depth >= MAX_DEPTH {
+            walk.partial = true;
+            return;
+        }
+        let (dirs, files): (Vec<_>, Vec<_>) =
+            node.children.iter().partition(|(_, child)| child.is_dir);
+        for (name, child) in dirs.into_iter().chain(files) {
+            let path = dir.join(name);
+            walk.entries.push(FileTreeEntry {
+                path: path.clone(),
+                name: name.clone(),
+                depth,
+                is_dir: child.is_dir,
+            });
+            if child.is_dir {
+                emit(child, &path, depth + 1, walk);
+            }
+        }
+    }
+
+    let mut walk = Walk {
+        entries: Vec::new(),
+        partial,
+    };
+    emit(&top, root, 0, &mut walk);
+    (walk.entries, walk.partial)
+}
+
 /// Recursively lists `root`'s contents (directories first, then alphabetically within each
 /// group) as a flattened, depth-annotated list suitable for indented rendering.
 pub fn build_file_tree(root: &Path) -> io::Result<FileTreeListing> {
@@ -279,6 +452,161 @@ pub fn indent_guide_x(level: usize) -> f32 {
 
 /// `render_tree_caret`'s real width - see [`indent_guide_x`].
 const CARET_WIDTH: f32 = 8.0;
+
+#[cfg(test)]
+mod git_listing_tree_tests {
+    use crate::sidebar::file_tree::{build_worktree_file_tree, from_git_listing, MAX_DEPTH};
+    use std::fs;
+    use std::path::Path;
+    use tempfile::TempDir;
+    use wt_core::worktree_files::WorktreeFileList;
+
+    fn listing_of(files: &[&str]) -> WorktreeFileList {
+        WorktreeFileList {
+            files: files.iter().map(|file| file.to_string()).collect(),
+            truncated: false,
+        }
+    }
+
+    #[test]
+    fn assembles_dirs_first_then_files_with_depths_from_git_paths() {
+        let root = Path::new("root");
+        let tree = from_git_listing(
+            root,
+            &listing_of(&["src/nested/a.rs", "src/lib.rs", "b.txt", "README.md"]),
+        );
+        assert!(tree.is_complete());
+        let shape: Vec<(&str, usize, bool)> = tree
+            .tree
+            .iter()
+            .map(|entry| (entry.name.as_str(), entry.depth, entry.is_dir))
+            .collect();
+        assert_eq!(
+            shape,
+            vec![
+                ("src", 0, true),
+                ("nested", 1, true),
+                ("a.rs", 2, false),
+                ("lib.rs", 1, false),
+                ("README.md", 0, false),
+                ("b.txt", 0, false),
+            ],
+            "same dirs-first, alphabetical-within-group order the walk produces"
+        );
+        assert_eq!(
+            tree.tree.iter().next().expect("first entry").path,
+            root.join("src")
+        );
+    }
+
+    #[test]
+    fn a_dot_prefixed_component_hides_the_whole_path_matching_the_walks_filter() {
+        let tree = from_git_listing(
+            Path::new("root"),
+            &listing_of(&[".github/ci.yml", "src/.hidden/x.rs", "src/real.rs"]),
+        );
+        let names: Vec<&str> = tree.tree.iter().map(|entry| entry.name.as_str()).collect();
+        assert_eq!(names, vec!["src", "real.rs"]);
+    }
+
+    #[test]
+    fn a_truncated_git_listing_is_an_incomplete_inventory() {
+        let mut listing = listing_of(&["a.txt"]);
+        listing.truncated = true;
+        assert!(
+            !from_git_listing(Path::new("root"), &listing).is_complete(),
+            "fold-state pruning must never treat a byte-capped listing as the whole truth"
+        );
+    }
+
+    #[test]
+    fn a_pathologically_deep_path_is_cut_at_max_depth_and_marked_partial() {
+        let deep = vec!["d"; MAX_DEPTH + 5].join("/") + "/file.txt";
+        let tree = from_git_listing(Path::new("root"), &listing_of(&[deep.as_str()]));
+        assert!(!tree.is_complete());
+        assert!(tree.tree.iter().all(|entry| entry.depth < MAX_DEPTH));
+    }
+
+    #[test]
+    fn a_real_repos_gitignored_build_output_is_not_walked_or_listed() {
+        let repo = test_support::seed_repo();
+        fs::write(repo.path().join(".gitignore"), "target/\n").expect("write");
+        test_support::git(repo.path(), &["add", ".gitignore"]);
+        test_support::git(repo.path(), &["commit", "-q", "-m", "ignore target"]);
+        fs::create_dir_all(repo.path().join("target/debug")).expect("mkdir");
+        fs::write(repo.path().join("target/debug/artifact.o"), "junk").expect("write");
+        fs::write(repo.path().join("untracked.rs"), "// new").expect("write");
+
+        let tree = build_worktree_file_tree(repo.path()).expect("build_worktree_file_tree");
+        let names: Vec<&str> = tree.tree.iter().map(|entry| entry.name.as_str()).collect();
+        assert!(
+            !names.contains(&"target"),
+            "gitignored build output must not appear (decisions.md §6), got {names:?}"
+        );
+        assert!(
+            names.contains(&"untracked.rs"),
+            "an untracked, unignored file is real content and must appear, got {names:?}"
+        );
+    }
+
+    #[test]
+    fn a_submodules_contents_are_grafted_under_a_directory_typed_row() {
+        let sub = test_support::seed_empty_repo();
+        fs::write(sub.path().join("inner.rs"), "// inner\n").expect("write");
+        test_support::git(sub.path(), &["add", "inner.rs"]);
+        test_support::git(sub.path(), &["commit", "-q", "-m", "inner"]);
+
+        let outer = test_support::seed_repo();
+        test_support::git(
+            outer.path(),
+            &[
+                "-c",
+                "protocol.file.allow=always",
+                "submodule",
+                "add",
+                sub.path().to_str().expect("utf8 path"),
+                "vendored",
+            ],
+        );
+
+        let tree = build_worktree_file_tree(outer.path()).expect("build_worktree_file_tree");
+        let vendored = tree
+            .tree
+            .iter()
+            .find(|entry| entry.name == "vendored")
+            .expect("the submodule must appear");
+        assert!(
+            vendored.is_dir,
+            "a gitlink is a directory, not a file with a language chip"
+        );
+        let inner = tree
+            .tree
+            .iter()
+            .find(|entry| entry.name == "inner.rs")
+            .expect("the submodule's own contents must appear, as the old walk showed them");
+        assert_eq!(inner.depth, vendored.depth + 1);
+    }
+
+    #[test]
+    fn a_git_failure_inside_a_real_repo_is_an_error_not_a_silent_walk() {
+        let dir = TempDir::new().expect("tempdir");
+        // A `.git` directory that is not a repository: `git ls-files` fails here, and the
+        // fallback walk must NOT paper over that - it would silently show a differently-shaped
+        // (gitignore-blind) tree for one cycle.
+        fs::create_dir(dir.path().join(".git")).expect("mkdir");
+        fs::write(dir.path().join("loose.txt"), "x").expect("write");
+        assert!(build_worktree_file_tree(dir.path()).is_err());
+    }
+
+    #[test]
+    fn a_plain_non_git_directory_still_lists_via_the_walk_fallback() {
+        let dir = TempDir::new().expect("tempdir");
+        fs::write(dir.path().join("loose.txt"), "x").expect("write");
+        let tree = build_worktree_file_tree(dir.path()).expect("build_worktree_file_tree");
+        let names: Vec<&str> = tree.tree.iter().map(|entry| entry.name.as_str()).collect();
+        assert_eq!(names, vec!["loose.txt"]);
+    }
+}
 
 #[cfg(test)]
 mod file_tree_walk_tests {

--- a/crates/app/src/terminal/pane.rs
+++ b/crates/app/src/terminal/pane.rs
@@ -656,6 +656,20 @@ impl TerminalPane {
         }
     }
 
+    /// Hands the live session to the caller for teardown *sequenced with other work*, unlike
+    /// [`Self::shutdown`]'s detached fire-and-forget. The one caller is the worktree discard
+    /// flow (GitHub issue #470), which must have every process in the worktree confirmed dead
+    /// **before** deleting the directory - on Windows a live child's cwd holds an open handle
+    /// that makes the removal half-fail. The pane renders as exited from this point on.
+    pub fn take_session_for_teardown(
+        &mut self,
+        cx: &mut Context<Self>,
+    ) -> Option<pty_core::PtySession> {
+        self._task = None;
+        cx.notify();
+        self.session.take()
+    }
+
     /// `true` while a child process is alive (spawned and not yet observed to have exited).
     /// The rail's status derivation (`crate::rail::status::derive_status`) uses this to distinguish
     /// a still-running session from one that has exited or never started.

--- a/crates/app/src/work_surface/render.rs
+++ b/crates/app/src/work_surface/render.rs
@@ -74,6 +74,14 @@ impl AdeApp {
         let Some(cwd) = self.current_worktree_path() else {
             return;
         };
+        // See `AdeApp::discarding_worktree` - spawning into a directory mid-delete would
+        // reproduce the half-failed removal GitHub issue #470 closes.
+        if self.discarding_worktree.as_deref() == Some(cwd.as_path()) {
+            self.worktree_history_status =
+                Some("this worktree is being discarded - nothing can be spawned into it".into());
+            cx.notify();
+            return;
+        }
         // GitHub issue #239 phase 2: a Claude agent is spawned against this instance's generated
         // `--settings` file and told, through its environment, where to report its hooks. Taken as
         // an owned snapshot because `self.agents.spawn` borrows `self.agents` mutably - see
@@ -498,6 +506,15 @@ impl AdeApp {
         };
         let kind = agent.kind;
         let cwd = agent.cwd.clone();
+        // See `AdeApp::discarding_worktree` - the taken-down pane's own footer offers Resume,
+        // and honouring it mid-delete would respawn into the directory being removed
+        // (GitHub issue #470).
+        if self.discarding_worktree.as_deref() == Some(cwd.as_path()) {
+            self.worktree_history_status =
+                Some("this worktree is being discarded - nothing can be spawned into it".into());
+            cx.notify();
+            return;
+        }
         self.close_agent(id, window, cx);
         // A respawned agent is a freshly spawned one in every other respect, so it gets the same
         // real hook injection - otherwise "Retry" would silently produce an agent whose status

--- a/crates/app/src/worktree_history/flow.rs
+++ b/crates/app/src/worktree_history/flow.rs
@@ -168,11 +168,55 @@ impl AdeApp {
         self.worktree_history_status = Some(format!("discarding {branch_display}\u{2026}"));
         cx.notify();
 
+        // GitHub issue #470: every process this app started inside the worktree must be dead
+        // *before* the directory is deleted - on Windows a live child's cwd holds an open handle
+        // that makes `git worktree remove` half-fail, and on unix a surviving process keeps
+        // executing (and recreating files) in an unlinked cwd. Agent PTY sessions and the
+        // worktree's language servers are both taken here and shut down inside the same
+        // background hop that then runs the discard, so the ordering holds by construction; the
+        // one spawn source left is the user starting something new mid-delete, which
+        // `Self::discarding_worktree` (set below) makes `new_agent`/`respawn_agent` refuse.
+        // The panes render as exited; the tabs themselves still close only in the success arm
+        // below (and deliberately stay, showing the dead pane, when the discard fails).
+        self.discarding_worktree = Some(worktree_path.clone());
+        let doomed_panes: Vec<gpui::Entity<crate::terminal::pane::TerminalPane>> = self
+            .agents
+            .iter_for_cwd(worktree_path.clone())
+            .map(|agent| agent.pane.clone())
+            .collect();
+        let mut doomed_sessions = Vec::with_capacity(doomed_panes.len());
+        for pane in doomed_panes {
+            if let Some(session) = pane.update(cx, |pane, cx| pane.take_session_for_teardown(cx)) {
+                doomed_sessions.push(session);
+            }
+        }
+        let doomed_lsp_clients = self.take_lsp_clients_for_root(&worktree_path);
+
         let discarded_path = worktree_path.clone();
         let task = cx.spawn(async move |this, cx| {
             let result = cx
                 .background_executor()
-                .spawn(async move { wt_core::undo::discard_worktree(&repo_path, &worktree_path) })
+                .spawn(async move {
+                    for mut session in doomed_sessions {
+                        if let Err(err) = session.shutdown() {
+                            log::warn!("failed to shut down a doomed agent session: {err}");
+                        }
+                    }
+                    for client in doomed_lsp_clients {
+                        // The same try_unwrap-then-shutdown-else-drop rule as
+                        // `AdeApp::shutdown_lsp_client_off_thread`, run here so the server's
+                        // process tree is down before the delete rather than on a detached task.
+                        match std::sync::Arc::try_unwrap(client) {
+                            Ok(mut client) => {
+                                if let Err(err) = client.shutdown() {
+                                    log::warn!("failed to shut down a doomed server: {err}");
+                                }
+                            }
+                            Err(client) => drop(client),
+                        }
+                    }
+                    wt_core::undo::discard_worktree(&repo_path, &worktree_path)
+                })
                 .await;
             // `update_in` (not plain `update`): a successful discard closes the now-cwd-less
             // agent tab, and `Self::close_agent` needs a real `Window` to move focus off it -
@@ -181,6 +225,7 @@ impl AdeApp {
             // relies on for the identical reason.
             let _ = this.update_in(cx, |this, window, cx| {
                 this.worktree_history_op_in_flight = None;
+                this.discarding_worktree = None;
                 match result {
                     Ok(snapshot) => {
                         // `wt_core::undo::DiscardSnapshot::had_ignored_content` is a real,

--- a/crates/lsp-core/src/client.rs
+++ b/crates/lsp-core/src/client.rs
@@ -19,7 +19,7 @@ use std::collections::{HashMap, VecDeque};
 use std::io::BufReader;
 use std::path::{Path, PathBuf};
 use std::process::{Child, ChildStdin, Stdio};
-use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, Ordering};
 use std::sync::mpsc::{self, Receiver, SyncSender};
 use std::sync::{Arc, Mutex, MutexGuard};
 use std::thread::JoinHandle;
@@ -192,6 +192,10 @@ pub struct LspClient {
     next_id: AtomicI64,
     pending: Arc<Mutex<HashMap<i64, SyncSender<PendingResponse>>>>,
     diagnostics: Arc<Mutex<HashMap<String, Vec<lsp_types::Diagnostic>>>>,
+    /// Bumped on every write to [`Self::diagnostics`] (push and pull paths alike), so a caller
+    /// can memoize anything derived from [`Self::published_diagnostics`] and recompute only when
+    /// this moves — that derivation used to run every frame (GitHub issue #471).
+    diagnostics_generation: Arc<AtomicU64>,
     /// Subscribed notifications in arrival order, `params` left raw since this crate knows
     /// nothing about what any of them mean.
     ///
@@ -330,6 +334,7 @@ impl LspClient {
             Arc::new(Mutex::new(HashMap::new()));
         let diagnostics: Arc<Mutex<HashMap<String, Vec<lsp_types::Diagnostic>>>> =
             Arc::new(Mutex::new(HashMap::new()));
+        let diagnostics_generation = Arc::new(AtomicU64::new(0));
         let custom_notifications: Arc<Mutex<VecDeque<(String, serde_json::Value)>>> =
             Arc::new(Mutex::new(VecDeque::new()));
         let capabilities = Mutex::new(ServerCapabilities::default());
@@ -343,6 +348,7 @@ impl LspClient {
         let reader_thread = std::thread::spawn({
             let pending = Arc::clone(&pending);
             let diagnostics = Arc::clone(&diagnostics);
+            let diagnostics_generation = Arc::clone(&diagnostics_generation);
             let custom_notifications = Arc::clone(&custom_notifications);
             let stdin_for_replies = Arc::clone(&stdin);
             let connection_alive = Arc::clone(&connection_alive);
@@ -352,6 +358,7 @@ impl LspClient {
                     IncomingSinks {
                         pending,
                         diagnostics,
+                        diagnostics_generation,
                         custom_notifications,
                         custom_notification_methods,
                         wake_tx,
@@ -375,6 +382,7 @@ impl LspClient {
             next_id: AtomicI64::new(1),
             pending,
             diagnostics,
+            diagnostics_generation,
             custom_notifications,
             diagnostics_version: Mutex::new(HashMap::new()),
             capabilities,
@@ -558,6 +566,7 @@ impl LspClient {
                 versions.insert(uri.as_str().to_string(), version);
                 drop(versions);
                 lock(&self.diagnostics).insert(uri.as_str().to_string(), items);
+                self.diagnostics_generation.fetch_add(1, Ordering::Relaxed);
                 let _ = self.wake_tx.try_send(());
             }
         }
@@ -636,6 +645,12 @@ impl LspClient {
     /// fabricating a path for it.
     pub fn path_for_uri(uri: &Uri) -> Result<PathBuf, LspError> {
         uri_to_path(uri)
+    }
+
+    /// The current [diagnostics](Self::published_diagnostics) generation — bumped on every
+    /// stored update, so equality means "nothing derived from them can have changed".
+    pub fn diagnostics_generation(&self) -> u64 {
+        self.diagnostics_generation.load(Ordering::Relaxed)
     }
 
     pub fn diagnostics_for_uri(&self, uri: &Uri) -> Option<Vec<lsp_types::Diagnostic>> {
@@ -885,10 +900,20 @@ impl LspClient {
         proc::terminate_tree(self.pid, SHUTDOWN_GRACE_PERIOD);
     }
 
-    /// Windows equivalent: kills the direct child only, with no grace period or tree walk, so its
-    /// `cargo check`/`rustc` descendants survive.
+    /// Windows equivalent: `taskkill /T` walks and terminates the whole tree synchronously
+    /// (no grace period - Windows has no `SIGTERM` tier), then the direct kill as backstop.
+    /// Without the tree walk a `.cmd`-shim server's real `node.exe`, and rust-analyzer's
+    /// `cargo check`/`rustc` children, survive with their cwd handles inside the worktree
+    /// (GitHub issues #468/#470).
     #[cfg(windows)]
     fn kill_process_tree(&mut self) {
+        match pty_core::new_std_command("taskkill")
+            .args(["/T", "/F", "/PID", &self.pid.to_string()])
+            .output()
+        {
+            Ok(_) => {}
+            Err(err) => log::warn!("taskkill /T /F /PID {} could not run: {err}", self.pid),
+        }
         if let Some(child) = self.child.as_mut() {
             let _ = child.kill();
         }
@@ -907,10 +932,21 @@ impl Drop for LspClient {
                     proc::signal_pid(*pid, nix::sys::signal::Signal::SIGKILL);
                 }
             }
-            // Windows has no process tree, so `child.kill()` leaves descendants orphaned.
+            // Fire-and-forget `taskkill /T` (spawned, never waited - `Drop` must not block),
+            // then the direct kill as backstop; see `kill_process_tree`. Stdio nulled so the
+            // detached child can't hold inherited pipes open - under `cargo nextest` an
+            // inherited stdout is reported as the test leaking.
             #[cfg(windows)]
-            if let Some(child) = self.child.as_mut() {
-                let _ = child.kill();
+            {
+                let _ = pty_core::new_std_command("taskkill")
+                    .args(["/T", "/F", "/PID", &self.pid.to_string()])
+                    .stdin(Stdio::null())
+                    .stdout(Stdio::null())
+                    .stderr(Stdio::null())
+                    .spawn();
+                if let Some(child) = self.child.as_mut() {
+                    let _ = child.kill();
+                }
             }
 
             let reaped_immediately = self
@@ -1032,6 +1068,8 @@ fn uri_to_path(uri: &Uri) -> Result<PathBuf, LspError> {
 struct IncomingSinks {
     pending: Arc<Mutex<HashMap<i64, SyncSender<PendingResponse>>>>,
     diagnostics: Arc<Mutex<HashMap<String, Vec<lsp_types::Diagnostic>>>>,
+    /// See `LspClient::diagnostics_generation` — bumped alongside every `diagnostics` write.
+    diagnostics_generation: Arc<AtomicU64>,
     custom_notifications: Arc<Mutex<VecDeque<(String, serde_json::Value)>>>,
     /// See [`ServerSpawnConfig::custom_notification_methods`].
     custom_notification_methods: Vec<&'static str>,
@@ -1163,6 +1201,7 @@ fn handle_incoming(value: serde_json::Value, sinks: &IncomingSinks) {
             return;
         };
         lock(&sinks.diagnostics).insert(parsed.uri.as_str().to_string(), parsed.diagnostics);
+        sinks.diagnostics_generation.fetch_add(1, Ordering::Relaxed);
         let _ = sinks.wake_tx.try_send(());
         return;
     }
@@ -1511,6 +1550,7 @@ mod tests {
                 sinks: IncomingSinks {
                     pending: Arc::new(Mutex::new(HashMap::new())),
                     diagnostics: Arc::new(Mutex::new(HashMap::new())),
+                    diagnostics_generation: Arc::new(AtomicU64::new(0)),
                     custom_notifications: Arc::new(Mutex::new(VecDeque::new())),
                     custom_notification_methods: subscribed.to_vec(),
                     wake_tx,

--- a/crates/pty-core/Cargo.toml
+++ b/crates/pty-core/Cargo.toml
@@ -13,6 +13,9 @@ workspace = true
 portable-pty = "0.9.0"
 thiserror = { workspace = true }
 anyhow = { workspace = true }
+# One warn-level line when Windows's `taskkill /T` tree-kill cannot run at all (see
+# `windows_terminate_process_tree`) - the same version every other crate here pins.
+log = "0.4"
 # The self-pipe (unix) `PtySession::shutdown_write` field's type - a real, already-resolved
 # transitive dep of `portable-pty` 0.9.0 on every platform (its own Windows backend uses it
 # too, see `portable-pty-0.9.0/src/win/conpty.rs`), so this is unconditional even though only

--- a/crates/pty-core/src/lib.rs
+++ b/crates/pty-core/src/lib.rs
@@ -517,15 +517,15 @@ impl PtySession {
         Ok(())
     }
 
-    /// Terminates the direct child only.
-    ///
-    /// A known regression against the unix path, not a cosmetic gap: any grandchild the killed
-    /// child spawned survives as an orphan. Windows has no signal-based process group without job
-    /// objects, whose `unsafe` FFI this project rules out.
+    /// Terminates the child's whole process tree via [`windows_terminate_process_tree`], then
+    /// the direct child itself as the backstop.
     #[cfg(windows)]
     pub fn kill(&mut self) -> Result<(), PtyError> {
         if self.exited.is_some() {
             return Ok(());
+        }
+        if let Some(pid) = self.process_id() {
+            windows_terminate_process_tree(pid);
         }
         if let Some(child) = self.child.as_mut() {
             let _ = child.kill();
@@ -652,6 +652,9 @@ impl PtySession {
     #[cfg(windows)]
     pub fn shutdown(&mut self) -> Result<(), PtyError> {
         if self.exited.is_none() {
+            if let Some(pid) = self.process_id() {
+                windows_terminate_process_tree(pid);
+            }
             if let Some(child) = self.child.as_mut() {
                 let _ = child.kill();
                 let status = child.wait().map_err(PtyError::Wait)?;
@@ -675,6 +678,26 @@ impl PtySession {
     }
 }
 
+/// Terminates `pid` and every descendant, synchronously: `taskkill /T` walks the parent-pid
+/// chain, the closest Windows equivalent of the unix process-group signal plus descendant walk,
+/// without the job-object `unsafe` FFI this project rules out. Best-effort by nature (a
+/// descendant that re-parented is missed; one that exited already is fine) - but without it a
+/// bare `TerminateProcess` on the direct child orphans every grandchild, which is how an npm
+/// `.cmd`-shim agent's real `node.exe` survived kills (GitHub issue #468) and how a discarded
+/// worktree's directory stayed open-handled through its own deletion (GitHub issue #470).
+/// `taskkill` ships with every Windows since XP; a failure to run it is logged and the direct
+/// kill still proceeds.
+#[cfg(windows)]
+fn windows_terminate_process_tree(pid: u32) {
+    match crate::new_std_command("taskkill")
+        .args(["/T", "/F", "/PID", &pid.to_string()])
+        .output()
+    {
+        Ok(_) => {}
+        Err(err) => log::warn!("taskkill /T /F /PID {pid} could not run: {err}"),
+    }
+}
+
 impl Drop for PtySession {
     fn drop(&mut self) {
         if self.exited.is_none() {
@@ -683,10 +706,23 @@ impl Drop for PtySession {
                 // Zero grace: `Drop` must not block the caller.
                 terminate_process_tree(pid, Duration::ZERO);
             }
-            // Windows has no process tree, so `child.kill()` below leaves grandchildren orphaned.
+            // Fire-and-forget `taskkill /T` (spawned, never waited - `Drop` must not block),
+            // then the direct kill as the backstop; see `windows_terminate_process_tree`.
+            // Stdio nulled so the detached child can't hold inherited pipes open - under
+            // `cargo nextest` an inherited stdout is reported as the test leaking.
             #[cfg(windows)]
-            if let Some(child) = self.child.as_mut() {
-                let _ = child.kill();
+            {
+                if let Some(pid) = self.process_id() {
+                    let _ = crate::new_std_command("taskkill")
+                        .args(["/T", "/F", "/PID", &pid.to_string()])
+                        .stdin(std::process::Stdio::null())
+                        .stdout(std::process::Stdio::null())
+                        .stderr(std::process::Stdio::null())
+                        .spawn();
+                }
+                if let Some(child) = self.child.as_mut() {
+                    let _ = child.kill();
+                }
             }
 
             let reaped_immediately = self

--- a/crates/wt-core/src/diff.rs
+++ b/crates/wt-core/src/diff.rs
@@ -558,6 +558,12 @@ pub fn ahead_behind_against_base(worktree_path: &Path) -> Result<Option<AheadBeh
     // `refs/remotes/origin/HEAD`, a bare `main...HEAD` resolves to a local `refs/heads/main`
     // first, which may be stale and would under-report how far behind the worktree is.
     // `...` computes the merge-base itself and reports `<behind>\t<ahead>`.
+    //
+    // A deliberate CLI holdout from GitHub issue #473's gix migration: gix 0.68's
+    // `rev_walk(..).with_pruned(..)` stops at the pruned *tip* plus a commit-time cutoff rather
+    // than excluding the pruned side's full ancestry the way `--not` does, so it counts
+    // common-history commits and cannot reproduce `--left-right --count` (verified against this
+    // module's own diverged-history tests).
     let args: Vec<OsString> = vec![
         "rev-list".into(),
         "--left-right".into(),
@@ -579,6 +585,97 @@ fn parse_ahead_behind_counts(text: &str) -> Option<AheadBehind> {
     let behind = parts.next().and_then(|part| part.parse::<usize>().ok())?;
     let ahead = parts.next().and_then(|part| part.parse::<usize>().ok())?;
     Some(AheadBehind { ahead, behind })
+}
+
+/// A cheap, spawn-free fingerprint of the git-side inputs the Changes panel's reload reads:
+/// `HEAD`'s resolved commit, the real index file's identity, every ref (loose and packed,
+/// common-dir wide, so another worktree moving the base branch registers too), and
+/// merge/rebase state.
+///
+/// **Worktree content is deliberately out of scope** — a plain file edit changes none of this —
+/// so a caller may only skip work on an unchanged fingerprint when a filesystem watcher covers
+/// the working tree itself (GitHub issue #473).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChangesFingerprint {
+    head_commit: Option<String>,
+    /// The `HEAD` *file* itself, not just its peeled commit: a same-tip branch switch
+    /// (`git switch main` while the feature branch sits on main's commit) rewrites only this
+    /// file, yet flips [`diff_against_base`]'s whole on-base/off-base answer.
+    head_file: Option<(std::time::SystemTime, u64)>,
+    /// The main worktree's `HEAD`, which [`detect_default_base`]'s last resort reads.
+    main_head_file: Option<(std::time::SystemTime, u64)>,
+    index: Option<(std::time::SystemTime, u64)>,
+    packed_refs: Option<(std::time::SystemTime, u64)>,
+    loose_refs: Vec<(PathBuf, std::time::SystemTime, u64)>,
+    /// `config` (diff/base behavior can hinge on it) and `shallow` (history depth) - cheap to
+    /// stat, expensive to be stale about.
+    config: Option<(std::time::SystemTime, u64)>,
+    shallow: Option<(std::time::SystemTime, u64)>,
+    merge_head: bool,
+    rebase_merge: bool,
+    rebase_apply: bool,
+}
+
+/// Computes [`ChangesFingerprint`] for `worktree_path`. Blocking (gix open + a handful of
+/// `stat`s over `refs/`), but never a child process.
+pub fn changes_fingerprint(worktree_path: &Path) -> Result<ChangesFingerprint, Error> {
+    let repo = open_repo(worktree_path)?;
+    let mut head = repo
+        .head()
+        .map_err(|source| Error::Head(Box::new(source)))?;
+    let head_commit = head
+        .try_peel_to_id_in_place()
+        .map_err(|source| Error::PeelHead(Box::new(source)))?
+        .map(|id| id.to_string());
+
+    let meta = |path: &Path| -> Option<(std::time::SystemTime, u64)> {
+        let metadata = std::fs::metadata(path).ok()?;
+        Some((metadata.modified().ok()?, metadata.len()))
+    };
+
+    let index = meta(&repo.index_path());
+    let common_dir = repo.common_dir().to_path_buf();
+    let packed_refs = meta(&common_dir.join("packed-refs"));
+    let mut loose_refs = Vec::new();
+    collect_loose_ref_meta(&common_dir.join("refs"), &mut loose_refs);
+    loose_refs.sort();
+
+    let git_dir = repo.git_dir();
+    Ok(ChangesFingerprint {
+        head_commit,
+        head_file: meta(&git_dir.join("HEAD")),
+        main_head_file: meta(&common_dir.join("HEAD")),
+        index,
+        packed_refs,
+        loose_refs,
+        config: meta(&common_dir.join("config")),
+        shallow: meta(&common_dir.join("shallow")),
+        merge_head: git_dir.join("MERGE_HEAD").exists(),
+        rebase_merge: git_dir.join("rebase-merge").exists(),
+        rebase_apply: git_dir.join("rebase-apply").exists(),
+    })
+}
+
+/// Recursively records `(path, mtime, len)` for every file under `dir` — the loose-ref store is
+/// dozens of tiny files at most, so this stays trivially cheap. Unreadable entries are skipped:
+/// a fingerprint that errs toward "changed" only costs one extra reload.
+fn collect_loose_ref_meta(dir: &Path, out: &mut Vec<(PathBuf, std::time::SystemTime, u64)>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if file_type.is_dir() {
+            collect_loose_ref_meta(&path, out);
+        } else if let Ok(metadata) = entry.metadata() {
+            if let Ok(modified) = metadata.modified() {
+                out.push((path, modified, metadata.len()));
+            }
+        }
+    }
 }
 
 /// Detects the repository's default branch and its tip, per the module docs' order.
@@ -812,19 +909,13 @@ pub(crate) fn prepare_shadow_index(
     worktree_path: &Path,
     content: ShadowIndexContent,
 ) -> Result<tempfile::TempPath, Error> {
-    let index_path_args: Vec<OsString> =
-        vec!["rev-parse".into(), "--git-path".into(), "index".into()];
-    let output = run_git(worktree_path, &index_path_args)?;
-    check_success(&index_path_args, &output)?;
-    let printed = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    let real_index_path = {
-        let candidate = PathBuf::from(&printed);
-        if candidate.is_absolute() {
-            candidate
-        } else {
-            worktree_path.join(candidate)
-        }
-    };
+    // gix, not a `git rev-parse --git-path index` child: this runs inside every diff of every
+    // worktree/agent on the app's 3s status poll and 5s Changes refresh, so the answer must not
+    // cost a process spawn (GitHub issue #473). `Repository::index_path()` resolves a linked
+    // worktree's private `.git/worktrees/<name>/index` the same way rev-parse does; the
+    // `GIT_INDEX_FILE` override rev-parse would honour is already scrubbed from every git child
+    // this crate spawns (`GIT_ENV_OVERRIDES`), so the two never disagreed here.
+    let real_index_path = open_repo(worktree_path)?.index_path();
 
     let shadow = shadow_index_file(&real_index_path)?;
     // Decided here, acted on only after the handle is closed below.
@@ -2429,6 +2520,78 @@ index 0000000..fedcba9
             "well-formed output must still parse normally"
         );
     }
+
+    #[test]
+    fn changes_fingerprint_is_stable_until_git_state_moves_and_ignores_plain_edits() {
+        let repo = test_support::seed_repo();
+        let first = changes_fingerprint(repo.path()).expect("fingerprint");
+        assert_eq!(
+            first,
+            changes_fingerprint(repo.path()).expect("fingerprint"),
+            "an untouched repository must fingerprint identically twice"
+        );
+
+        // The documented contract: worktree content is out of scope, the watcher covers it.
+        std::fs::write(repo.path().join("file.txt"), "edited, not staged").expect("write");
+        assert_eq!(
+            first,
+            changes_fingerprint(repo.path()).expect("fingerprint"),
+            "a plain, unstaged file edit must not change the fingerprint"
+        );
+
+        test_support::git(repo.path(), &["add", "file.txt"]);
+        let staged = changes_fingerprint(repo.path()).expect("fingerprint");
+        assert_ne!(
+            first, staged,
+            "staging rewrites the index and must register"
+        );
+
+        test_support::git(repo.path(), &["commit", "-q", "-m", "edit"]);
+        let committed = changes_fingerprint(repo.path()).expect("fingerprint");
+        assert_ne!(staged, committed, "a commit moves HEAD and must register");
+
+        // A same-tip branch switch rewrites only the HEAD file - no ref moves (the branch
+        // already exists), no new commit - yet flips diff_against_base's on-base/off-base
+        // answer, so it must register.
+        test_support::git(repo.path(), &["branch", "same-tip"]);
+        let before_switch = changes_fingerprint(repo.path()).expect("fingerprint");
+        test_support::git(repo.path(), &["switch", "-q", "same-tip"]);
+        assert_ne!(
+            before_switch,
+            changes_fingerprint(repo.path()).expect("fingerprint"),
+            "a branch switch to the same commit must register via the HEAD file itself"
+        );
+    }
+
+    #[test]
+    fn changes_fingerprint_registers_a_ref_moved_from_another_worktree() {
+        let repo = test_support::seed_repo();
+        let container = test_support::TempDir::new().expect("tempdir");
+        let linked = container.path().join("other-wt");
+        test_support::git(
+            repo.path(),
+            &[
+                "worktree",
+                "add",
+                "-b",
+                "other-branch",
+                linked.to_str().expect("utf8 path"),
+            ],
+        );
+
+        let before = changes_fingerprint(repo.path()).expect("fingerprint");
+        test_support::write_file(&linked, "other.txt", "content");
+        test_support::git(&linked, &["add", "other.txt"]);
+        test_support::git(&linked, &["commit", "-q", "-m", "moved elsewhere"]);
+
+        assert_ne!(
+            before,
+            changes_fingerprint(repo.path()).expect("fingerprint"),
+            "a branch tip moved from another worktree lives in the shared common dir and must \
+             register - it can change this worktree's base diff"
+        );
+    }
+
     /// A feature branch with one real commit of its own plus one still-uncommitted edit - the
     /// shape that makes the three Changes-panel scopes give three genuinely different answers
     /// (GitHub issue #285).

--- a/crates/wt-core/src/worktree_files.rs
+++ b/crates/wt-core/src/worktree_files.rs
@@ -30,6 +30,11 @@ pub struct WorktreeFileList {
 
 /// `Err` when this is not a git worktree, or `git` could not run at all; a caller that must work
 /// outside a repository needs its own fallback.
+///
+/// A tracked file deleted from disk but not yet staged is **excluded**: `--cached` alone would
+/// keep listing it, but a file that is not on disk is not something the worktree *contains* -
+/// rendering it as an ordinary row (with nothing behind it to open) is the phantom this
+/// subtraction removes.
 pub fn list_worktree_files(worktree_path: &Path) -> Result<WorktreeFileList, Error> {
     let args: Vec<OsString> = vec![
         "ls-files".into(),
@@ -41,6 +46,14 @@ pub fn list_worktree_files(worktree_path: &Path) -> Result<WorktreeFileList, Err
     let (output, truncated) =
         capture_git_stdout(worktree_path, &args, MAX_LIST_OUTPUT_BYTES, None)?;
 
+    let deleted_args: Vec<OsString> = vec!["ls-files".into(), "--deleted".into(), "-z".into()];
+    let (deleted_output, deleted_truncated) =
+        capture_git_stdout(worktree_path, &deleted_args, MAX_LIST_OUTPUT_BYTES, None)?;
+    let deleted: std::collections::HashSet<&[u8]> = deleted_output
+        .split(|byte| *byte == 0)
+        .filter(|record| !record.is_empty())
+        .collect();
+
     let mut records: Vec<&[u8]> = output.split(|byte| *byte == 0).collect();
     if truncated {
         // The final slice may be a path sliced in half, and there is no way to tell that from a
@@ -50,11 +63,45 @@ pub fn list_worktree_files(worktree_path: &Path) -> Result<WorktreeFileList, Err
 
     let files = records
         .into_iter()
-        .filter(|record| !record.is_empty())
+        .filter(|record| !record.is_empty() && !deleted.contains(record))
         .map(|record| String::from_utf8_lossy(record).into_owned())
         .collect();
 
-    Ok(WorktreeFileList { files, truncated })
+    Ok(WorktreeFileList {
+        files,
+        // A truncated deleted-set means some phantoms may have survived the subtraction, which
+        // is the same "not the whole truth" callers must not prune against.
+        truncated: truncated || deleted_truncated,
+    })
+}
+
+/// Worktree-relative paths of this worktree's submodules (gitlink index entries), in git's own
+/// `/`-separated format. Empty for the overwhelmingly common no-submodule case, gated by a
+/// single `.gitmodules` stat so the extra `--stage` listing is never paid for it.
+///
+/// Callers need this because a plain `ls-files` prints a submodule as one pathless-of-content
+/// record: without the mode there is no way to tell it from an ordinary file.
+pub fn list_submodule_paths(worktree_path: &Path) -> Result<Vec<String>, Error> {
+    if !worktree_path.join(".gitmodules").is_file() {
+        return Ok(Vec::new());
+    }
+    let args: Vec<OsString> = vec![
+        "ls-files".into(),
+        "--cached".into(),
+        "--stage".into(),
+        "-z".into(),
+    ];
+    let (output, _truncated) =
+        capture_git_stdout(worktree_path, &args, MAX_LIST_OUTPUT_BYTES, None)?;
+    Ok(output
+        .split(|byte| *byte == 0)
+        .filter_map(|record| {
+            // `<mode> <object> <stage>\t<path>` - a gitlink's mode is exactly 160000.
+            let record = std::str::from_utf8(record).ok()?;
+            let (meta, path) = record.split_once('\t')?;
+            meta.starts_with("160000 ").then(|| path.to_string())
+        })
+        .collect())
 }
 
 #[cfg(test)]
@@ -119,6 +166,65 @@ mod tests {
             "an explicitly tracked path must not disappear just because a later .gitignore rule \
              would otherwise hide it - `git status` does not hide it either: {:?}",
             listing.files
+        );
+    }
+
+    #[test]
+    fn a_tracked_file_deleted_from_disk_but_not_staged_is_not_content() {
+        let dir = seed_empty_repo();
+        let root = dir.path();
+        fs::write(root.join("kept.rs"), "// kept\n").expect("write");
+        fs::write(root.join("doomed.rs"), "// doomed\n").expect("write");
+        git(root, &["add", "kept.rs", "doomed.rs"]);
+        git(root, &["commit", "-q", "-m", "both"]);
+
+        fs::remove_file(root.join("doomed.rs")).expect("remove");
+
+        let listing = list_worktree_files(root).expect("a real git worktree");
+        assert!(
+            listing.files.contains(&"kept.rs".to_string()),
+            "the surviving file stays: {:?}",
+            listing.files
+        );
+        assert!(
+            !listing.files.contains(&"doomed.rs".to_string()),
+            "an unstaged deletion is still tracked by the index, but the worktree does not \
+             contain it - listing it renders a phantom row: {:?}",
+            listing.files
+        );
+    }
+
+    #[test]
+    fn a_real_submodule_is_reported_as_a_gitlink_path() {
+        let sub = seed_empty_repo();
+        fs::write(sub.path().join("inner.rs"), "// inner\n").expect("write");
+        git(sub.path(), &["add", "inner.rs"]);
+        git(sub.path(), &["commit", "-q", "-m", "inner"]);
+
+        let outer = seed_empty_repo();
+        git(
+            outer.path(),
+            &[
+                "-c",
+                // Modern git refuses local-path submodules without this opt-in; the test is
+                // exactly the local case.
+                "protocol.file.allow=always",
+                "submodule",
+                "add",
+                sub.path().to_str().expect("utf8 path"),
+                "vendored",
+            ],
+        );
+
+        let submodules = list_submodule_paths(outer.path()).expect("submodule listing");
+        assert_eq!(submodules, vec!["vendored".to_string()]);
+
+        let no_modules = seed_empty_repo();
+        assert!(
+            list_submodule_paths(no_modules.path())
+                .expect("no-submodule repo")
+                .is_empty(),
+            "the common case pays one .gitmodules stat and no extra git spawn"
         );
     }
 

--- a/docs/architecture/decisions.md
+++ b/docs/architecture/decisions.md
@@ -246,10 +246,12 @@ this crate streams.
 - **Input goes through a writer thread.** A full pty write buffer would otherwise block whichever
   thread called `write_input`, plausibly a key handler on the main thread.
 
-**Windows is narrower, and untested on real hardware** (reasoned from `portable-pty` 0.9.0 and
-`filedescriptor` 0.8.3 sources plus `cargo check --target x86_64-pc-windows-gnu`). `kill()`
-terminates the direct child only — job objects are the only alternative and need `unsafe` FFI, so
-grandchildren can survive as orphans. There is no self-pipe either: `WSAPoll` accepts only sockets
+**Windows is narrower** (originally reasoned from `portable-pty` 0.9.0 and
+`filedescriptor` 0.8.3 sources plus `cargo check --target x86_64-pc-windows-gnu`; now exercised on
+real hardware — see issues #465–#468). `kill()`/`shutdown()` terminate the whole tree via
+`taskkill /T` — the no-`unsafe` alternative to job objects; best-effort against re-parented
+descendants, with the direct kill as backstop (an orphaned tree was how npm `.cmd`-shim agents'
+real `node.exe` survived, #468). There is no self-pipe either: `WSAPoll` accepts only sockets
 and a ConPTY master is a named pipe, so the reader blocks until `master` itself drops, *not* when
 the child is reaped. Callers must therefore poll `try_wait` rather than wait for the output channel
 to disconnect. These paths are `#[cfg(windows)]`, never `#[cfg(not(unix))]`, so an unsupported


### PR DESCRIPTION
Closes #470
Closes #471
Closes #472
Closes #473

Stacked on #469 (targets its branch; retargets to master when it merges).

## What

The four hazards the post-incident performance audit confirmed, fixed without removing behavior — plus the fixes for everything a second adversarial review of this diff itself confirmed (15 findings, 7 major, all addressed or consciously accepted below):

- **Discard kills before it deletes (#470).** Agent PTY sessions *and* the worktree's language servers are shut down inside the same background hop that then runs `discard_worktree`, so nothing the app started holds the directory open on Windows or keeps executing in an unlinked cwd on unix. Spawning into the doomed worktree mid-delete (including the taken-down pane's own Resume button) is refused with an honest status line. The review also proved the Windows kill paths only terminated the *direct* child — an npm `.cmd`-shim agent's real `node.exe` always survived — so pty-core's and lsp-core's Windows kill/shutdown/Drop paths now tree-kill via `taskkill /T` (no job-object `unsafe`), which is also the #468 orphan-leak family. decisions.md §8's Windows paragraph updated to match.
- **The Problems list stops burning a frame budget (#471).** `worktree_problems` was a per-frame canonicalize + one stat per diagnosed file + a full clone of every diagnostic (12k–36k syscalls/s at 120fps mid-check). It is now memoized on (root, per-client diagnostics generation — a new `AtomicU64` in lsp-core bumped at both write sites), invalidated by the file-tree watcher (or unconditionally by the poll when no watcher could be armed), so a file deleted out from under its server still drops its rows — the regression test drives the real watcher end-to-end via `advance_clock`.
- **The file tree stops walking build output (#472).** Tree + palette candidates now come from `wt_core::worktree_files` (decisions.md §6's canonical "what does this worktree contain") instead of an uncapped walk of `target/`/`vendor/` (~300k entries at least every 5s, ~2×/s during agent builds). Review-driven hardening: unstaged deletions subtracted (no phantom rows), submodules typed as directories with their own listings grafted underneath (parity with the old walk), unchanged listings skip the palette rebuild + whole-window notify, a git failure inside a real repo errors instead of silently swapping to the gitignore-blind walk, path depth is bounded at construction. **Deliberate visible delta:** gitignored files and empty directories no longer appear in the Files tab or palette — §6's definition of content, and the entire point.
- **The idle spawn floor drops (#473).** The single highest-frequency spawn (`git rev-parse --git-path index`, twice in every shadow-index diff on the 3s poll) is now `gix` `index_path()`. The Changes reload's poll arm re-runs its ~10-spawn pass only when a zero-spawn `changes_fingerprint` (HEAD commit + HEAD-file identity, index, every ref common-dir-wide, config/shallow, merge/rebase state) moved since a reload last *actually ran* — skip-as-busy retries instead of going stale, and a failed watcher disables the gate so the poll fallback behaves exactly as before it existed. `is_dirty` and ahead/behind stay CLI **deliberately**: gix 0.68 can't compute HEAD-vs-index status (upstream TODO in its source) and `with_pruned` can't reproduce `--not` ancestry exclusion (it counts common-history commits — caught by wt-core's own diverged-history tests before reverting); both documented at the call sites and on #473.

Consciously accepted from the review (documented, not fixed): serial per-session shutdown grace during discard (bounded, discard is already seconds); the Err-arm's dead-but-open tabs (Retry works, worktree still exists); non-UTF-8 filenames remain lossy in the listing (pre-existing in `worktree_files`); `list_worktree_files` now costs 2 spawns per reload (+1 with `.gitmodules`) — noise against the ~300k-entry walks and unconditional reloads removed.

## Testing

- [x] fmt, clippy `-D warnings`, `cargo build --workspace` pass locally; conventions ratchet runs in CI (`jq` missing locally)
- [x] Full suite on this Windows machine: **3021/3123 passing, zero regressions** vs the pre-change baseline (remaining failures are #468's pre-existing platform set; the four names differing between runs are order-sensitive and fail identically on unmodified master in isolation)
- [x] New behavior has real tests in the right tiers: fingerprint stability/change/same-tip-switch/cross-worktree-ref tests, phantom-deletion and submodule listing tests (wt-core); git-listing tree shape/dot-filter/depth-cap/truncation/submodule-graft/fallback-gate tests, and the deleted-file Problems-row regression driven through the real watcher (app)
- [ ] `external` tier untouched — not run

## Architecture notes

- lsp-core gains `diagnostics_generation()` (gpui-free, `AtomicU64`) so the app can memoize derived views; wt-core gains `changes_fingerprint`/`list_submodule_paths` and subtracts unstaged deletions in `list_worktree_files` (§6 semantics tightened to "on disk").
- pty-core/lsp-core Windows kill paths now shell out to `taskkill /T` through `new_std_command` — argv-vector, no `unsafe`, documented in decisions.md §8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
