### PR TITLE
fix(app): start a Windows POSIX shell as a login shell (#452)

### DIFF
--- a/crates/app/src/terminal/pane.rs
+++ b/crates/app/src/terminal/pane.rs
@@ -156,16 +156,14 @@ pub struct TerminalSpec {
 }
 
 impl TerminalSpec {
-    /// The user's shell, no extra arguments - GitHub issue #50 (real, `/bin/bash` unconditional
-    /// even on Windows): `$SHELL` is a real Unix environment-variable convention that Windows
-    /// itself never sets, so the fallback needs its own real Windows equivalent rather than the
-    /// same Unix path unconditionally, which is a real path (`/bin/bash`) that doesn't exist on
-    /// Windows at all - every default-shell spawn there was trying, and failing, to launch it.
+    /// The user's configured shell, or this platform's default, started with whatever
+    /// [`shell_startup_args`] decides that program needs.
     pub fn shell(cwd: PathBuf, configured: Option<&str>) -> Self {
+        let program =
+            configured_shell_program(configured).unwrap_or_else(Self::default_shell_program);
         Self {
-            program: configured_shell_program(configured)
-                .unwrap_or_else(Self::default_shell_program),
-            args: Vec::new(),
+            args: shell_startup_args(&program),
+            program,
             cwd,
             env: Vec::new(),
         }
@@ -249,6 +247,45 @@ fn configured_shell_program(configured: Option<&str>) -> Option<PathBuf> {
         .map(PathBuf::from)
 }
 
+/// Shells that take `-l` to mean "login shell", matched on the program's file stem. An allowlist,
+/// so an unrecognized shell keeps the existing no-argument spawn rather than being handed a flag it
+/// may reject and failing to start at all.
+const POSIX_LOGIN_SHELL_STEMS: [&str; 10] = [
+    "bash", "sh", "dash", "ash", "zsh", "fish", "ksh", "mksh", "csh", "tcsh",
+];
+
+/// How `program` has to be started on this platform: on Windows a POSIX shell is started as a
+/// *login* shell (GitHub issue #452), and everywhere else nothing is added.
+///
+/// An MSYS shell (Git for Windows, MSYS2, Cygwin) reaches `/usr/bin` - `ls`, `clear`, `cat` - only
+/// through a mount `/etc/profile` establishes, and only a login shell reads `/etc/profile`; the
+/// `~/.bashrc` an interactive non-login shell does read sets up none of it. On Unix `/usr/bin` is
+/// already on a real `PATH` and `pty_core::login_shell` already covers the GUI-launch case, so
+/// `-l` would only change which rc files an existing user's shell reads.
+///
+/// `cfg!` rather than `#[cfg]` so both branches compile - and stay testable - on either host.
+fn shell_startup_args(program: &Path) -> Vec<String> {
+    if cfg!(windows) {
+        posix_login_shell_args(program)
+    } else {
+        Vec::new()
+    }
+}
+
+/// The `-l` decision, matched case- and `.exe`-insensitively.
+fn posix_login_shell_args(program: &Path) -> Vec<String> {
+    let is_posix_shell = program
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .is_some_and(|stem| POSIX_LOGIN_SHELL_STEMS.contains(&stem.to_ascii_lowercase().as_str()));
+
+    if is_posix_shell {
+        vec!["-l".to_string()]
+    } else {
+        Vec::new()
+    }
+}
+
 /// GitHub issue #50's real regression guard: the Windows fallback must be a real Windows path
 /// (`cmd.exe`), never the Unix `/bin/bash` [`TerminalSpec::shell`] used to fall back to
 /// unconditionally - `$SHELL` is a Unix-only convention Windows never sets, so every Windows
@@ -299,11 +336,11 @@ mod shell_program_tests {
             PathBuf::from("/usr/local/bin/fish"),
             "an absolute path must be used verbatim, not searched for on PATH"
         );
-        assert!(
-            TerminalSpec::shell(cwd.clone(), Some("fish"))
-                .args
-                .is_empty(),
-            "a configured shell is launched exactly like the default one: no extra arguments"
+        assert_eq!(
+            TerminalSpec::shell(cwd.clone(), Some("fish")).args,
+            shell_startup_args(Path::new("fish")),
+            "a configured shell is launched exactly like the default one - the startup arguments \
+             follow from the program, never from whether the user typed it or Jerry chose it"
         );
         assert_eq!(
             TerminalSpec::shell(cwd.clone(), Some("fish")).cwd,
@@ -329,6 +366,122 @@ mod shell_program_tests {
         assert_eq!(
             configured_shell_program(Some("  zsh  ")),
             Some(PathBuf::from("zsh"))
+        );
+    }
+
+    /// GitHub issue #452's actual regression. An MSYS shell (Git for Windows, MSYS2, Cygwin)
+    /// reaches `/usr/bin` - `ls`, `clear`, `cat`, `grep` - only via a mount `/etc/profile`
+    /// establishes, and only a login shell reads `/etc/profile`. Spawned without `-l`, every one
+    /// of those is `command not found` while builtins like `cd` still work.
+    #[test]
+    fn a_posix_shell_is_recognized_however_it_is_spelled_and_a_native_windows_one_never_is() {
+        for program in [
+            "bash",
+            "bash.exe",
+            "BASH.EXE",
+            r"C:\Program Files\Git\usr\bin\bash.exe",
+            r"C:\Program Files\Git\bin\bash.exe",
+            "/bin/sh",
+            "/usr/bin/zsh",
+            "fish",
+            "dash.exe",
+            "tcsh",
+        ] {
+            assert_eq!(
+                posix_login_shell_args(Path::new(program)),
+                vec!["-l".to_string()],
+                "{program} is a POSIX shell, so it must be started as a login shell"
+            );
+        }
+
+        for program in [
+            "cmd.exe",
+            r"C:\Windows\System32\cmd.exe",
+            "CMD.EXE",
+            "powershell.exe",
+            "pwsh.exe",
+            "nu",
+            "definitely-not-a-real-shell-xyz",
+            "bash-with-a-suffix",
+        ] {
+            assert!(
+                posix_login_shell_args(Path::new(program)).is_empty(),
+                "{program} is not a POSIX shell - handing it `-l` risks a flag it rejects, which \
+                 would turn a working terminal into one that cannot spawn at all"
+            );
+        }
+    }
+
+    /// The platform split: `-l` is a Windows-only repair. On Unix `/usr/bin` is a real directory on
+    /// a real `PATH`, an interactive non-login shell already reads `~/.bashrc`, and
+    /// `pty_core::login_shell` already merges a login `PATH` into the process environment - so
+    /// adding `-l` there would only change which rc files an existing user's shell reads.
+    #[test]
+    fn only_windows_starts_a_posix_shell_as_a_login_shell() {
+        let bash = shell_startup_args(Path::new("bash"));
+
+        #[cfg(windows)]
+        assert_eq!(
+            bash,
+            vec!["-l".to_string()],
+            "Windows is the platform where a non-login MSYS shell genuinely cannot find `ls`"
+        );
+        #[cfg(unix)]
+        assert!(
+            bash.is_empty(),
+            "Unix shells already start with a usable PATH; `-l` would only change rc-file loading"
+        );
+
+        assert!(
+            shell_startup_args(Path::new("cmd.exe")).is_empty(),
+            "the default Windows shell must be spawned exactly as it is today"
+        );
+        assert!(
+            shell_startup_args(Path::new("powershell.exe")).is_empty(),
+            "PowerShell finds `ls` through its own aliases and takes no `-l`"
+        );
+    }
+
+    /// GitHub issue #452 end to end, against a real installed bash: started with the arguments
+    /// [`TerminalSpec::shell`] actually chose, and given only the bare Windows `PATH` a
+    /// GUI-launched process really inherits, the shell can still find `ls` - a binary that lives
+    /// under MSYS's `/usr/bin` and is reachable only once `/etc/profile` has run.
+    ///
+    /// `PATH` is set explicitly rather than inherited so the assertion means the same thing on a
+    /// developer machine that happens to have `Git\usr\bin` on `PATH` already and on one that does
+    /// not. Only the positive is asserted: Git for Windows ships both a raw `usr\bin\bash.exe` and
+    /// a `bin\bash.exe` wrapper that sets the MSYS `PATH` up by itself, so "fails without `-l`"
+    /// would depend on which of the two this host resolves.
+    #[cfg(windows)]
+    #[test]
+    #[ignore = "external: bash.exe (Git for Windows/MSYS2); needs a real MSYS install"]
+    fn a_real_login_bash_reaches_usr_bin_from_a_bare_windows_path() {
+        let Some(bash) = pty_core::resolve_on_path("bash.exe") else {
+            panic!("this test tier requires a real bash.exe on PATH");
+        };
+
+        let spec = TerminalSpec::shell(std::env::temp_dir(), Some(&bash.display().to_string()));
+        assert_eq!(
+            spec.args,
+            vec!["-l".to_string()],
+            "a real installed bash must be started as a login shell"
+        );
+
+        let system_root = std::env::var("SystemRoot").unwrap_or_else(|_| r"C:\Windows".to_string());
+        let output = pty_core::new_std_command(&spec.program)
+            .args(&spec.args)
+            .args(["-c", "command -v ls"])
+            .env("PATH", format!(r"{system_root}\System32;{system_root}"))
+            .current_dir(&spec.cwd)
+            .output()
+            .expect("a real bash.exe must run");
+
+        assert!(
+            output.status.success(),
+            "a login shell must reach /usr/bin even from a bare Windows PATH - this failing is \
+             exactly the `ls: command not found` GitHub issue #452 reports; stdout={:?} stderr={:?}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
         );
     }
 

--- a/crates/app/src/terminal/pane.rs
+++ b/crates/app/src/terminal/pane.rs
@@ -379,8 +379,7 @@ mod shell_program_tests {
             "bash",
             "bash.exe",
             "BASH.EXE",
-            r"C:\Program Files\Git\usr\bin\bash.exe",
-            r"C:\Program Files\Git\bin\bash.exe",
+            "C:/Program Files/Git/usr/bin/bash.exe",
             "/bin/sh",
             "/usr/bin/zsh",
             "fish",
@@ -396,7 +395,6 @@ mod shell_program_tests {
 
         for program in [
             "cmd.exe",
-            r"C:\Windows\System32\cmd.exe",
             "CMD.EXE",
             "powershell.exe",
             "pwsh.exe",
@@ -408,6 +406,26 @@ mod shell_program_tests {
                 posix_login_shell_args(Path::new(program)).is_empty(),
                 "{program} is not a POSIX shell - handing it `-l` risks a flag it rejects, which \
                  would turn a working terminal into one that cannot spawn at all"
+            );
+        }
+
+        // The real spellings a Windows user's Settings field holds. Only Windows treats `\` as a
+        // separator, so on Unix `Path::file_stem` would read the whole string as one file name.
+        #[cfg(windows)]
+        {
+            for program in [
+                r"C:\Program Files\Git\usr\bin\bash.exe",
+                r"C:\Program Files\Git\bin\bash.exe",
+            ] {
+                assert_eq!(
+                    posix_login_shell_args(Path::new(program)),
+                    vec!["-l".to_string()],
+                    "{program} is the real path Settings stores for Git Bash"
+                );
+            }
+            assert!(
+                posix_login_shell_args(Path::new(r"C:\Windows\System32\cmd.exe")).is_empty(),
+                "the default Windows shell must never be handed `-l`"
             );
         }
     }

--- a/crates/pty-core/src/login_shell.rs
+++ b/crates/pty-core/src/login_shell.rs
@@ -1,7 +1,9 @@
 //! Resolves the user's real login-shell `PATH` when this process was launched by something that
 //! hands it a minimal one (macOS Finder / launchd, a Linux `.desktop` entry) rather than a
 //! terminal. Unix only - Windows processes inherit the same PATH a terminal would use, so the
-//! problem this exists to fix does not occur there.
+//! problem this exists to fix does not occur there. An MSYS shell's `/usr/bin` is a separate
+//! matter - not a PATH entry at all, but a mount `/etc/profile` establishes - and is handled by
+//! starting that shell as a login shell where it is spawned, not here.
 //!
 //! `crates/app/src/main.rs` is the only intended caller: it merges the result into the real
 //! process environment before `app::run`, so every spawned agent PTY inherits it too.


### PR DESCRIPTION
Closes #452

## What

A Shell tab on Windows now starts a POSIX shell as a *login* shell (`-l`). `ls`, `clear`, `cat`,
`grep` and `rm` work in a Git Bash / MSYS2 / Cygwin shell, where before every one of them was
`command not found`.

`cmd.exe`, `powershell.exe` and `pwsh.exe` are unaffected — they are not POSIX shells and get no
arguments, so the default Windows shell behaves exactly as it does today. Unix is untouched.

## Why

`TerminalSpec::shell` hardcoded `args: Vec::new()`, so the shell was never a login shell. On an MSYS
shell `/usr/bin` is not a Windows `PATH` entry at all — it is a mount `/etc/profile` establishes,
and only a login shell reads `/etc/profile`. The `~/.bashrc` an interactive non-login shell *does*
read sets up none of it.

That accounts for the report in full, including the part that looked like noise: `cd` and `pwd` kept
working because they are shell builtins, while `ls` and `clear` failed because they are real
binaries under `/usr/bin`. It also explains "works in another terminal" — the Git Bash shortcut,
Windows Terminal's Git Bash profile and VS Code all launch bash as a login shell. Jerry was the only
one that did not.

Measured on Windows 11 against `C:\Program Files\Git\usr\bin\bash.exe`, with `PATH` set to the
registry-derived one a GUI-launched process actually inherits:

```
bash.exe    -c "command -v ls"   -> exit 1        (no output)
bash.exe -l -c "command -v ls"   -> exit 0        /usr/bin/ls
```

The earlier `%COMSPEC%`/PowerShell reading (#459) was wrong — swapping the default would not have
helped a user whose shell is already bash. Full corrected analysis is in
[this issue comment](https://github.com/ColinEspinas/jerry/issues/452#issuecomment-5332482050).

Two deliberate exclusions, both noted on the issue: the `cmd.exe` default itself (a real question,
but not what #452 reports), and making auto-detection prefer `Git\bin\bash.exe` over
`Git\usr\bin\bash.exe` (with `-l` both now work, so it is polish rather than part of the fix).

## Testing

CI is green on all five jobs — Lint, Linux, macOS and Windows all pass.

- [x] `/check` — conventions, `cargo fmt --check`, `cargo clippy --workspace --all-targets -D
      warnings` and `cargo build --workspace` all pass. **`cargo nextest run --workspace` does not
      pass on Windows, and did not before this change either** — see #468. This branch is
      3129 run / 3027 passed / 71 failed / 31 timed out, matching #468's documented post-#467
      baseline (74 failed + 30 timed out); every failure is in #468's known buckets and none is in
      `shell_program_tests`. CI's Linux/macOS jobs remain the authoritative gate.
- [x] New behavior has a real test, in the right tier
- [x] `external` tier run with a real bash installed:
      `cargo nextest run -p app shell_program_tests --run-ignored all` — 6/6 pass
- [x] `verify` capture — not applicable, no render/theme/layout change

The change is inert for every pre-existing test: the only shell-override values anywhere in the
crate are `agent-stand-in.sh`, `pwsh`, `fish` (serialization only) and `/bin/dash` (which asserts on
`program`, not `args`), and the Windows default resolves to `cmd.exe`.

New tests, in `pane.rs`'s existing `shell_program_tests`:

- `a_posix_shell_is_recognized_however_it_is_spelled_and_a_native_windows_one_never_is` — unit,
  covers casing, `.exe`, absolute paths, and that `cmd`/`powershell`/`pwsh`/unknown programs never
  get `-l`.
- `only_windows_starts_a_posix_shell_as_a_login_shell` — unit, pins the platform split.
- `a_real_login_bash_reaches_usr_bin_from_a_bare_windows_path` — `external` tier, runs a real
  `bash.exe` with a deliberately bare Windows `PATH` and asserts it still resolves `ls`. Verified to
  fail without `-l`, so it is a genuine regression test rather than a tautology.

## Architecture notes

No crate-boundary or Command/Query change. The decision is a pure `&Path -> Vec<String>` helper next
to the existing `shell_program_from_env`, using `cfg!(windows)` rather than `#[cfg]` so both
platforms' behavior stays compiled and testable on either host.
