### PR TITLE
fix(app): stop the update check reaching GitHub during tests (#360)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,10 @@ env:
   # holds for whatever this workflow grows to run - see
   # `crate::budget::state::DISABLE_PROVIDER_POLL_ENV`.
   JERRY_DISABLE_PROVIDER_POLL: "1"
+  # The update check hits the public GitHub releases API. No credential is involved, but it still
+  # makes the suite depend on network reachability and GitHub's rate limiter. Same crate-boundary
+  # reasoning as the variable above - see `crate::updater::state::DISABLE_UPDATE_CHECK_ENV`.
+  JERRY_DISABLE_UPDATE_CHECK: "1"
 
 jobs:
   # The platform-independent half of the gate, and the only job that is not tied to an OS.

--- a/crates/app/src/updater/flow.rs
+++ b/crates/app/src/updater/flow.rs
@@ -113,8 +113,11 @@ impl AdeApp {
     /// subsequent tick. No-op while a check is already in flight (mirrors
     /// [`Self::worktree_history_op_in_flight`]'s own single-flight-per-feature discipline), so a
     /// manual palette click during the periodic loop's own in-flight check can never spawn a
-    /// second, racing one.
+    /// second, racing one. Also a no-op unless [`state::update_check_enabled`].
     pub(crate) fn check_for_update(&mut self, cx: &mut Context<Self>) {
+        if !state::update_check_enabled() {
+            return;
+        }
         if self.update_check_in_flight {
             return;
         }
@@ -162,8 +165,16 @@ impl AdeApp {
     /// `Self::new_with_settings`, right after `Self::start_worktree_watch`. Runs
     /// [`Self::check_for_update`] immediately (the real "startup" trigger), then again every
     /// [`state::UPDATE_CHECK_INTERVAL`] for as long as the app runs, mirroring
-    /// `Self::start_worktree_watch`'s own tick-loop shape.
+    /// `Self::start_worktree_watch`'s own tick-loop shape. Starts nothing unless
+    /// [`state::update_check_enabled`].
     pub(crate) fn start_update_check_loop(&mut self, cx: &mut Context<Self>) {
+        // [`Self::check_for_update`] would no-op on its own, but a disabled check should not leave
+        // a timer task running behind it either - a `#[gpui::test]` app that parks the executor
+        // would otherwise still be holding a live 6h tick loop.
+        // A disabled check must not leave a live 6h tick loop behind it either.
+        if !state::update_check_enabled() {
+            return;
+        }
         self.check_for_update(cx);
         let task = cx.spawn(async move |this, cx| loop {
             cx.background_executor()
@@ -281,5 +292,30 @@ mod relaunch_command_tests {
         let exe = Path::new("/usr/local/bin/jerry");
         let command = build_relaunch_command(exe, &[]);
         assert_eq!(command.get_args().count(), 0);
+    }
+}
+
+#[cfg(test)]
+mod update_check_offline_tests {
+    use crate::test_support::open_test_app;
+    use gpui::TestAppContext;
+
+    #[gpui::test]
+    fn opening_an_app_starts_no_update_check_and_no_tick_loop(cx: &mut TestAppContext) {
+        let repo = test_support::seed_repo();
+
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+
+        app.read_with(cx, |app, _| {
+            assert!(
+                !app.update_check_in_flight,
+                "opening a test app must not start a real GitHub release check"
+            );
+            assert!(
+                app._update_check_task.is_none(),
+                "and must not leave a periodic re-check task running behind it either"
+            );
+        });
     }
 }

--- a/crates/app/src/updater/state.rs
+++ b/crates/app/src/updater/state.rs
@@ -14,6 +14,30 @@ use std::time::Duration;
 /// command added on top (a user would have to invoke it dozens of times an hour to matter).
 pub(crate) const UPDATE_CHECK_INTERVAL: Duration = Duration::from_secs(6 * 60 * 60);
 
+/// Whether this build compiles the update check in at all.
+pub(crate) const UPDATE_CHECK_ENABLED: bool = !cfg!(test);
+
+/// Runtime kill switch, for anything linking `app` across a crate boundary that `cfg(test)` can
+/// not reach.
+pub(crate) const DISABLE_UPDATE_CHECK_ENV: &str = "JERRY_DISABLE_UPDATE_CHECK";
+
+/// Whether a real GitHub release check may happen in this process, right now.
+pub(crate) fn update_check_enabled() -> bool {
+    update_check_enabled_from(
+        UPDATE_CHECK_ENABLED,
+        std::env::var_os(DISABLE_UPDATE_CHECK_ENV),
+    )
+}
+
+/// The pure half of [`update_check_enabled`], split out because `std::env::set_var` is unsound to
+/// race in a threaded test binary.
+pub(crate) fn update_check_enabled_from(
+    compiled_in: bool,
+    disable_env: Option<std::ffi::OsString>,
+) -> bool {
+    compiled_in && disable_env.is_none()
+}
+
 /// A real GitHub release this app could update to - built from `self_update::update::Release`
 /// (see `crate::updater::flow`'s own docs for exactly how, since that struct has no `tag_name`/
 /// `html_url` field of its own to read directly).
@@ -83,6 +107,37 @@ pub(crate) fn is_remote_version_newer(current: &str, remote_tag: &str) -> bool {
             );
             false
         }
+    }
+}
+
+#[cfg(test)]
+mod update_check_gate_tests {
+    use crate::updater::state::{update_check_enabled, update_check_enabled_from};
+    use std::ffi::OsString;
+
+    #[test]
+    fn a_release_build_with_no_override_checks_for_updates() {
+        assert!(update_check_enabled_from(true, None));
+    }
+
+    #[test]
+    fn a_test_build_never_checks_for_updates() {
+        assert!(!update_check_enabled_from(false, None));
+    }
+
+    #[test]
+    fn the_environment_override_wins_over_a_release_build() {
+        assert!(!update_check_enabled_from(true, Some(OsString::from("1"))));
+        // The variable's presence is the whole signal, so an empty value still disables.
+        assert!(!update_check_enabled_from(true, Some(OsString::from(""))));
+    }
+
+    #[test]
+    fn this_very_test_binary_may_not_check_for_updates() {
+        assert!(
+            !update_check_enabled(),
+            "the compiled-in gate must hold for the app crate's own test targets"
+        );
     }
 }
 


### PR DESCRIPTION
Closes #360

## What

The update check no longer runs in a test build. `check_for_update` returns early unless `updater::state::update_check_enabled()`, which is `cfg!(test)`-off for this crate's own test targets and additionally killable at runtime with `JERRY_DISABLE_UPDATE_CHECK` for anything that links `app` across a crate boundary a `cfg` cannot reach. CI exports that variable for every job.

The gate sits in `check_for_update` rather than only in `start_update_check_loop`, so it also covers the startup check and the palette's manual "Check for Updates" command — both reachable from a test. `start_update_check_loop` checks it a second time so a disabled check does not leave a live 6h tick task behind it either.

A distinct variable rather than sharing `JERRY_DISABLE_PROVIDER_POLL`: this endpoint is public and credential-free, so naming it after the credentialed provider poll would misdescribe both.

## Testing

- [x] New/changed behavior has a real test, in the right tier
  - `updater::state::update_check_gate_tests` — 4 `unit` tests over the pure `update_check_enabled_from`, plus one asserting the compiled-in gate really holds in this very test binary.
  - `updater::flow::update_check_offline_tests` — one `ui` test asserting a freshly opened app has neither an in-flight check nor a live tick task. **Verified it fails without the fix**: with the loop guard removed it panics on `and must not leave a periodic re-check task running behind it either`.
- [x] `cargo fmt --all -- --check` and `cargo clippy --workspace --all-targets -- -D warnings` pass
- [ ] `cargo nextest run --workspace` — **not run to completion locally**: this is a Windows machine and the suite is not Windows-clean (#468). `updater::` is green (12/12). CI's Linux/macOS jobs are the authoritative gate here.
- [x] Conventions ratchet: no new `use super::*`, no `render.rs` adapter calls added. (The local hook self-skips — `jq` is not installed on this machine — so this was checked by hand; CI runs it for real.)

Logic-only, no UI surface, so no `verify` capture.
