### PR TITLE
fix(app): worktree removal has one entry point, and it refuses the main checkout

### DIFF
--- a/crates/app/src/code_surface/tabs.rs
+++ b/crates/app/src/code_surface/tabs.rs
@@ -327,7 +327,6 @@ impl AdeApp {
         cx: &mut Context<Self>,
     ) {
         self.prune_confirm_armed = false;
-        self.discard_confirm_armed = None;
         // Clear any stale pending cursor line from an abandoned navigation;
         // `open_file_at_line` re-sets it right after this if it has a target line.
         self.pending_cursor_line = None;
@@ -397,7 +396,6 @@ impl AdeApp {
         self.dismiss_completions();
         self.code_cursor = None;
         self.prune_confirm_armed = false;
-        self.discard_confirm_armed = None;
         self.close_tab_confirm_armed = None;
         // `push_open_file` above can genuinely add a tab here (see this method's own docs on why
         // it calls it at all), so this is a real session change, not just an activation.
@@ -475,7 +473,6 @@ impl AdeApp {
             }
         }
         self.prune_confirm_armed = false;
-        self.discard_confirm_armed = None;
         // A closed file tab must stay closed across a relaunch - see
         // `crate::work_surface::session`.
         self.record_worktree_session(cx);

--- a/crates/app/src/graph_view/render.rs
+++ b/crates/app/src/graph_view/render.rs
@@ -74,7 +74,6 @@ impl AdeApp {
         self.plus_menu_open = false;
         self.title_menu_open = None;
         self.prune_confirm_armed = false;
-        self.discard_confirm_armed = None;
 
         // Opening the graph tab replaces the right sidebar's Files/Changes panel with Commit/
         // Branches (`Self::render_right_sidebar`), unrendering the file tree exactly the way

--- a/crates/app/src/hooks/flow.rs
+++ b/crates/app/src/hooks/flow.rs
@@ -90,7 +90,6 @@ impl AdeApp {
         // will itself be resumable again after the next quit. See `crate::work_surface::session`.
         self.record_worktree_session(cx);
         self.prune_confirm_armed = false;
-        self.discard_confirm_armed = None;
         cx.notify();
         true
     }

--- a/crates/app/src/merge/flow.rs
+++ b/crates/app/src/merge/flow.rs
@@ -76,7 +76,6 @@ impl AdeApp {
             state: merge::MergeFlowState::Running,
         });
         self.prune_confirm_armed = false;
-        self.discard_confirm_armed = None;
         cx.notify();
 
         let task = cx.spawn(async move |this, cx| {
@@ -147,7 +146,6 @@ impl AdeApp {
             state: merge::MergeFlowState::Running,
         });
         self.prune_confirm_armed = false;
-        self.discard_confirm_armed = None;
         self.graph_state.status_message = Some(format!("Merging {source_branch}\u{2026}"));
         self.select_agent(agent_id, window, cx);
         cx.notify();
@@ -193,7 +191,6 @@ impl AdeApp {
         cx: &mut Context<Self>,
     ) {
         self.prune_confirm_armed = false;
-        self.discard_confirm_armed = None;
         let Some(flow) = self.merge_flow.as_mut() else {
             return;
         };
@@ -292,7 +289,6 @@ impl AdeApp {
     /// and refreshes worktree/diff state to reflect the merge that just happened.
     pub(in crate::merge) fn complete_merge_flow(&mut self, cx: &mut Context<Self>) {
         self.prune_confirm_armed = false;
-        self.discard_confirm_armed = None;
         if self.merge_op_in_flight {
             return;
         }
@@ -358,7 +354,6 @@ impl AdeApp {
     /// is left in an `Error` state describing that rather than pretending it succeeded.
     pub(in crate::merge) fn abort_merge_flow(&mut self, cx: &mut Context<Self>) {
         self.prune_confirm_armed = false;
-        self.discard_confirm_armed = None;
         if self.merge_op_in_flight {
             return;
         }
@@ -435,7 +430,6 @@ impl AdeApp {
         self.merge_flow = None;
         self.clear_merge_edit_state();
         self.prune_confirm_armed = false;
-        self.discard_confirm_armed = None;
         cx.notify();
     }
 

--- a/crates/app/src/palette/render.rs
+++ b/crates/app/src/palette/render.rs
@@ -414,7 +414,6 @@ impl AdeApp {
                 // `Self::open_palette`'s docs); the other branches already do this via the
                 // methods they call, so this one clears it explicitly.
                 self.prune_confirm_armed = false;
-                self.discard_confirm_armed = None;
                 self.set_right_sidebar_view(
                     next_right_sidebar_view(self.right_sidebar_view),
                     window,
@@ -456,7 +455,6 @@ impl AdeApp {
         // Every palette selection counts as a fresh gesture that disarms a pending prune
         // confirmation (see `Self::open_palette`'s docs).
         self.prune_confirm_armed = false;
-        self.discard_confirm_armed = None;
         let relative = path
             .strip_prefix(&self.file_tree_root)
             .map(|p| p.to_path_buf())

--- a/crates/app/src/rail/menu.rs
+++ b/crates/app/src/rail/menu.rs
@@ -81,11 +81,18 @@ pub const REMOVE_WORKTREE_HINT: &str = "Removes the checkout. Uncommitted and un
 pub const ARCHIVE_RUN_HINT: &str = "Ends the run. It stays in History with its transcript, \
                                     diffstat and notes; the files it wrote are untouched.";
 
+/// Why `Remove worktree…` is disabled on a repository's own main checkout (GitHub issue #462) -
+/// `git worktree remove` refuses it, so the row is gated here rather than left to fail after
+/// `crate::worktree_history::flow`'s discard has already torn down the worktree's agents.
+pub const REMOVE_MAIN_WORKTREE_REASON: &str =
+    "this is the repository's main checkout - git cannot remove it";
+
 /// The worktree row menu (§4's list, in §4's order).
 pub fn worktree_menu_groups(
     branch: Option<&str>,
     agent_count: usize,
     remove_armed: bool,
+    is_main: bool,
 ) -> Vec<Vec<MenuEntry<RailMenuAction>>> {
     let archive = if agent_count == 0 {
         MenuEntry::new(
@@ -118,7 +125,8 @@ pub fn worktree_menu_groups(
         vec![MenuEntry::new(
             RailMenuAction::RemoveWorktree,
             // The armed state re-labels *this* row rather than adding a second one - one
-            // command, one row, whichever click it is on.
+            // command, one row, whichever click it is on. A main checkout never arms, so its
+            // row keeps the resting label under the gate below.
             if remove_armed {
                 "Remove worktree \u{2014} click again"
             } else {
@@ -126,6 +134,7 @@ pub fn worktree_menu_groups(
             },
         )
         .tooltip(REMOVE_WORKTREE_HINT)
+        .gated(!is_main, REMOVE_MAIN_WORKTREE_REASON)
         .destructive()],
     ]
 }
@@ -196,9 +205,12 @@ pub fn menu_rows(
     agent_count: usize,
     remove_armed: bool,
     agent_running: bool,
+    is_main: bool,
 ) -> Vec<MenuRow<RailMenuAction>> {
     crate::menu::model::menu_rows(match target {
-        RailMenuTarget::Worktree(_) => worktree_menu_groups(branch, agent_count, remove_armed),
+        RailMenuTarget::Worktree(_) => {
+            worktree_menu_groups(branch, agent_count, remove_armed, is_main)
+        }
         RailMenuTarget::WorktreeOpenIn(_) => open_in_menu_groups(),
         RailMenuTarget::Agent(_) => agent_menu_groups(agent_running),
     })
@@ -218,7 +230,7 @@ mod tests {
     #[test]
     fn the_worktree_menu_is_the_row_set_the_revision_lists() {
         assert_eq!(
-            labels(&worktree_menu_groups(Some("fix/auth"), 2, false)),
+            labels(&worktree_menu_groups(Some("fix/auth"), 2, false, false)),
             vec![
                 vec!["New agent here", "Archive 2 agents"],
                 vec!["Copy branch name", "Copy path", "Open in\u{2026}"],
@@ -234,7 +246,7 @@ mod tests {
             RailMenuTarget::WorktreeOpenIn(PathBuf::from("/wt")),
             RailMenuTarget::Agent(1),
         ] {
-            let rows = menu_rows(&target, Some("main"), 1, false, true);
+            let rows = menu_rows(&target, Some("main"), 1, false, true, false);
             assert!(
                 !matches!(rows.first(), Some(MenuRow::Separator)),
                 "a leading divider is what a stripped title row leaves behind: {target:?}"
@@ -245,10 +257,10 @@ mod tests {
 
     #[test]
     fn the_archive_row_counts_the_worktrees_real_agents_and_disables_itself_at_zero() {
-        let one = worktree_menu_groups(Some("main"), 1, false);
+        let one = worktree_menu_groups(Some("main"), 1, false, false);
         assert_eq!(one[0][1].label, "Archive 1 agent");
         assert!(one[0][1].enabled);
-        let none = worktree_menu_groups(Some("main"), 0, false);
+        let none = worktree_menu_groups(Some("main"), 0, false, false);
         assert_eq!(none[0][1].label, "No agents to archive");
         assert!(!none[0][1].enabled);
         assert!(none[0][1].disabled_reason.is_some());
@@ -256,17 +268,17 @@ mod tests {
 
     #[test]
     fn copy_branch_name_is_disabled_without_a_branch() {
-        let detached = worktree_menu_groups(None, 1, false);
+        let detached = worktree_menu_groups(None, 1, false, false);
         let row = &detached[1][0];
         assert_eq!(row.action, RailMenuAction::CopyBranchName);
         assert!(!row.enabled);
         assert!(row.disabled_reason.is_some());
-        assert!(worktree_menu_groups(Some("main"), 1, false)[1][0].enabled);
+        assert!(worktree_menu_groups(Some("main"), 1, false, false)[1][0].enabled);
     }
 
     #[test]
     fn only_remove_worktree_is_destructive_and_arming_relabels_it() {
-        let groups = worktree_menu_groups(Some("main"), 2, false);
+        let groups = worktree_menu_groups(Some("main"), 2, false, false);
         let destructive: Vec<&str> = groups
             .iter()
             .flatten()
@@ -275,11 +287,35 @@ mod tests {
             .collect();
         assert_eq!(destructive, vec!["Remove worktree\u{2026}"]);
 
-        let armed = worktree_menu_groups(Some("main"), 2, true);
+        let armed = worktree_menu_groups(Some("main"), 2, true, false);
         assert_eq!(armed.len(), groups.len());
         assert_eq!(armed[2].len(), 1, "arming must not add a row");
         assert_eq!(armed[2][0].label, "Remove worktree \u{2014} click again");
         assert!(armed[2][0].destructive);
+    }
+
+    #[test]
+    fn remove_worktree_is_disabled_on_the_main_checkout() {
+        let main = worktree_menu_groups(Some("main"), 1, false, true);
+        let row = &main[2][0];
+        assert_eq!(row.action, RailMenuAction::RemoveWorktree);
+        assert_eq!(
+            row.label, "Remove worktree\u{2026}",
+            "the row stays, so the menu is the same shape on every worktree row"
+        );
+        assert!(
+            !row.enabled,
+            "git worktree remove refuses the main checkout"
+        );
+        assert_eq!(
+            row.disabled_reason.as_deref(),
+            Some(REMOVE_MAIN_WORKTREE_REASON),
+            "and says why, rather than being a row that silently does nothing"
+        );
+        assert!(
+            worktree_menu_groups(Some("feature"), 1, false, false)[2][0].enabled,
+            "every other worktree keeps a real, runnable row"
+        );
     }
 
     #[test]
@@ -343,7 +379,7 @@ mod tests {
         let bindings = crate::default_key_bindings();
         let mut all: Vec<MenuEntry<RailMenuAction>> = Vec::new();
         all.extend(
-            worktree_menu_groups(Some("main"), 2, false)
+            worktree_menu_groups(Some("main"), 2, false, false)
                 .into_iter()
                 .flatten(),
         );

--- a/crates/app/src/rail/menu.rs
+++ b/crates/app/src/rail/menu.rs
@@ -53,8 +53,7 @@ pub enum RailMenuAction {
     OpenIn,
     OpenInFileManager,
     OpenInTerminal,
-    /// The app's one worktree-deletion entry point (the Changes panel deliberately has none) -
-    /// two clicks, routed into the existing discard flow. See
+    /// The app's only worktree-deletion entry point - two clicks, routed into
     /// `crate::worktree_history::flow::AdeApp::request_discard_worktree_path`.
     RemoveWorktree,
     /// Switch to this agent's tab.
@@ -81,9 +80,7 @@ pub const REMOVE_WORKTREE_HINT: &str = "Removes the checkout. Uncommitted and un
 pub const ARCHIVE_RUN_HINT: &str = "Ends the run. It stays in History with its transcript, \
                                     diffstat and notes; the files it wrote are untouched.";
 
-/// Why `Remove worktree…` is disabled on a repository's own main checkout (GitHub issue #462) -
-/// `git worktree remove` refuses it, so the row is gated here rather than left to fail after
-/// `crate::worktree_history::flow`'s discard has already torn down the worktree's agents.
+/// Why `Remove worktree…` is disabled on a repository's own main checkout.
 pub const REMOVE_MAIN_WORKTREE_REASON: &str =
     "this is the repository's main checkout - git cannot remove it";
 
@@ -125,8 +122,7 @@ pub fn worktree_menu_groups(
         vec![MenuEntry::new(
             RailMenuAction::RemoveWorktree,
             // The armed state re-labels *this* row rather than adding a second one - one
-            // command, one row, whichever click it is on. A main checkout never arms, so its
-            // row keeps the resting label under the gate below.
+            // command, one row, whichever click it is on.
             if remove_armed {
                 "Remove worktree \u{2014} click again"
             } else {

--- a/crates/app/src/rail/menu_render.rs
+++ b/crates/app/src/rail/menu_render.rs
@@ -457,14 +457,9 @@ mod rail_menu_tests {
         id
     }
 
-    /// Opens `worktree_path`'s row menu at a fixed anchor, without going through its rail row.
-    ///
-    /// The sibling tests here right-click the real painted row and are the right shape for
-    /// *that* wiring; this exists for tests about the popover's own rows, because the rail's
-    /// worktree rows do not paint under `TestAppContext` on Windows (GitHub issue #468 - every
-    /// test in this module that calls [`right_click_worktree_row`] is red there). The popover
-    /// itself paints on every platform, so a test anchored here still measures a real, painted,
-    /// really-clicked menu row.
+    /// Opens `worktree_path`'s row menu at a fixed anchor, without going through its rail row -
+    /// for tests about the popover's own rows. The rail's worktree rows do not paint under
+    /// `TestAppContext` on Windows (issue #468); the popover does, on every platform.
     fn open_worktree_menu(
         app: &gpui::Entity<AdeApp>,
         cx: &mut gpui::VisualTestContext,
@@ -881,9 +876,8 @@ mod rail_menu_tests {
         });
     }
 
-    /// GitHub issue #462: `git worktree remove` refuses a repository's own main checkout, and
-    /// `execute_discard_worktree_path` kills the worktree's agents and language servers on its
-    /// way to finding that out - so the row has to refuse first.
+    /// The row has to refuse before [`AdeApp::execute_discard_worktree_path`] tears down the
+    /// checkout's agents and language servers on its way to git refusing anyway.
     #[gpui::test]
     fn remove_worktree_is_disabled_on_the_main_checkout(cx: &mut TestAppContext) {
         let repo = crate::test_support::temp_repo();

--- a/crates/app/src/rail/menu_render.rs
+++ b/crates/app/src/rail/menu_render.rs
@@ -149,12 +149,19 @@ impl AdeApp {
             RailMenuTarget::Agent(id) => self.rail_agent_is_running(*id, cx),
             RailMenuTarget::Worktree(_) | RailMenuTarget::WorktreeOpenIn(_) => false,
         };
+        let is_main = match target {
+            RailMenuTarget::Worktree(path) | RailMenuTarget::WorktreeOpenIn(path) => {
+                self.is_main_worktree_path(path)
+            }
+            RailMenuTarget::Agent(_) => false,
+        };
         rail_menu::menu_rows(
             target,
             branch.as_deref(),
             agent_count,
             remove_armed,
             agent_running,
+            is_main,
         )
     }
 
@@ -448,6 +455,26 @@ mod rail_menu_tests {
         });
         cx.run_until_parked();
         id
+    }
+
+    /// Opens `worktree_path`'s row menu at a fixed anchor, without going through its rail row.
+    ///
+    /// The sibling tests here right-click the real painted row and are the right shape for
+    /// *that* wiring; this exists for tests about the popover's own rows, because the rail's
+    /// worktree rows do not paint under `TestAppContext` on Windows (GitHub issue #468 - every
+    /// test in this module that calls [`right_click_worktree_row`] is red there). The popover
+    /// itself paints on every platform, so a test anchored here still measures a real, painted,
+    /// really-clicked menu row.
+    fn open_worktree_menu(
+        app: &gpui::Entity<AdeApp>,
+        cx: &mut gpui::VisualTestContext,
+        worktree_path: &Path,
+    ) {
+        let target = RailMenuTarget::Worktree(worktree_path.to_path_buf());
+        app.update_in(cx, |app, window, cx| {
+            app.open_rail_row_menu(target, 200.0, 200.0, window, cx);
+        });
+        cx.run_until_parked();
     }
 
     /// Right-clicks agent `id`'s real painted row.
@@ -851,6 +878,57 @@ mod rail_menu_tests {
         app.read_with(cx, |app, _| {
             assert!(app.rail_row_menu.is_none(), "and close the menu");
             assert!(app.remove_worktree_confirm_armed.is_none());
+        });
+    }
+
+    /// GitHub issue #462: `git worktree remove` refuses a repository's own main checkout, and
+    /// `execute_discard_worktree_path` kills the worktree's agents and language servers on its
+    /// way to finding that out - so the row has to refuse first.
+    #[gpui::test]
+    fn remove_worktree_is_disabled_on_the_main_checkout(cx: &mut TestAppContext) {
+        let repo = crate::test_support::temp_repo();
+        let feature = add_worktree(repo.path(), "feature", "feature");
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+        let agent_id = spawn_agent(&app, cx);
+        app.read_with(cx, |app, _| {
+            assert!(
+                app.is_main_worktree_path(repo.path()),
+                "premise: the opened repo's own path must really be its main checkout"
+            );
+            assert!(
+                !app.is_main_worktree_path(&feature),
+                "premise: and a linked worktree must not be"
+            );
+        });
+
+        open_worktree_menu(&app, cx, repo.path());
+        // The row still paints, in the same place - a menu that changes shape per row costs more
+        // than a visibly disabled row with its reason attached.
+        click_menu_row(cx, "rail-row-menu", "Remove worktree\u{2026}");
+
+        app.read_with(cx, |app, _| {
+            assert!(
+                app.remove_worktree_confirm_armed.is_none(),
+                "a disabled row must not even arm the confirmation"
+            );
+            assert!(
+                app.agents.iter().any(|agent| agent.id == agent_id),
+                "and must not have torn down the agents living in that checkout"
+            );
+        });
+        assert!(repo.path().exists(), "the main checkout is untouched");
+
+        // The same menu on a worktree git *will* remove still arms on its first click, so this
+        // test cannot pass on a `Remove worktree…` that stopped working everywhere.
+        open_worktree_menu(&app, cx, &feature);
+        click_menu_row(cx, "rail-row-menu", "Remove worktree\u{2026}");
+        app.read_with(cx, |app, _| {
+            assert_eq!(
+                app.remove_worktree_confirm_armed.as_deref(),
+                Some(feature.as_path()),
+                "a linked worktree's row is still a real, runnable one"
+            );
         });
     }
 

--- a/crates/app/src/rail/render.rs
+++ b/crates/app/src/rail/render.rs
@@ -206,7 +206,6 @@ impl AdeApp {
         };
         if changed {
             self.prune_confirm_armed = false;
-            self.discard_confirm_armed = None;
             cx.notify();
             cx.stop_propagation();
         }
@@ -594,7 +593,6 @@ impl AdeApp {
 
         if candidates.is_empty() {
             self.prune_confirm_armed = false;
-            self.discard_confirm_armed = None;
             self.prune_status = Some("nothing to prune".to_string());
             cx.notify();
             return;
@@ -608,7 +606,6 @@ impl AdeApp {
         }
 
         self.prune_confirm_armed = false;
-        self.discard_confirm_armed = None;
         self.execute_prune(candidates, cx);
     }
 
@@ -856,7 +853,6 @@ impl AdeApp {
         widgets::TextFieldHandle::new(|app: &mut AdeApp| Some(&mut app.filter_query)).on_changed(
             |app: &mut AdeApp, _cx| {
                 app.prune_confirm_armed = false;
-                app.discard_confirm_armed = None;
             },
         )
     }

--- a/crates/app/src/review/render.rs
+++ b/crates/app/src/review/render.rs
@@ -46,7 +46,6 @@ impl AdeApp {
         self.plus_menu_open = false;
         self.title_menu_open = None;
         self.prune_confirm_armed = false;
-        self.discard_confirm_armed = None;
 
         // Same "leaving Files"/"leaving the code surface" sweep `open_git_graph` performs, for the
         // identical reason: `self.open_change = None` above just unrendered the code surface, and

--- a/crates/app/src/root/focus.rs
+++ b/crates/app/src/root/focus.rs
@@ -72,7 +72,6 @@ impl AdeApp {
         self.palette_query.reset();
         self.palette_selected = 0;
         self.prune_confirm_armed = false;
-        self.discard_confirm_armed = None;
         window.focus(&self.palette_focus_handle, cx);
         cx.notify();
     }
@@ -144,7 +143,6 @@ impl AdeApp {
         self.settings_open = true;
         self.settings_focus.capture(window, &self.agents, cx);
         self.prune_confirm_armed = false;
-        self.discard_confirm_armed = None;
         self.custom_theme_remove_armed = None;
         window.focus(&self.settings_focus_handle, cx);
         self.load_agent_rows(cx);

--- a/crates/app/src/root/menu_commands.rs
+++ b/crates/app/src/root/menu_commands.rs
@@ -74,16 +74,6 @@ impl AdeApp {
                     && self.worktree_history_op_in_flight
                         != Some(worktree_history::WorktreeHistoryOpKind::Keep)
             }
-            // GitHub issue #462: the active agent's own checkout has to be one git will really
-            // remove. The main checkout is not, so this row is disabled on it rather than left to
-            // fail after the discard has already torn that agent down.
-            MenuCommand::DiscardWorktree => {
-                self.agents
-                    .active()
-                    .is_some_and(|agent| !self.is_main_worktree_path(&agent.cwd))
-                    && self.worktree_history_op_in_flight
-                        != Some(worktree_history::WorktreeHistoryOpKind::Discard)
-            }
             MenuCommand::OpenFile
             | MenuCommand::OpenFolder
             | MenuCommand::NewWindow
@@ -221,20 +211,6 @@ impl AdeApp {
                 if let Some(id) = self.agents.active_id() {
                     self.title_menu_open = None;
                     self.keep_all_changes(id, cx);
-                }
-            }
-            MenuCommand::DiscardWorktree => {
-                if let Some(id) = self.agents.active_id() {
-                    self.request_discard_worktree(id, window, cx);
-                    // The first click only arms confirmation
-                    // (`AdeApp::discard_confirm_armed`) - keep the menu open so its own row can
-                    // swap to "confirm discard?" for a real second click, mirroring the agent
-                    // footer's identical two-step button and the pre-issue-#235 popover's own
-                    // `agent_menu_rows` handler for this exact row.
-                    if self.discard_confirm_armed != Some(id) {
-                        self.title_menu_open = None;
-                    }
-                    cx.notify();
                 }
             }
             MenuCommand::Documentation => {
@@ -386,15 +362,6 @@ impl AdeApp {
         self.perform_menu_command(MenuCommand::KeepAllChanges, window, cx);
     }
 
-    pub(crate) fn handle_discard_worktree_menu_command(
-        &mut self,
-        _: &DiscardWorktree,
-        window: &mut Window,
-        cx: &mut Context<Self>,
-    ) {
-        self.perform_menu_command(MenuCommand::DiscardWorktree, window, cx);
-    }
-
     pub(crate) fn handle_open_documentation_menu_command(
         &mut self,
         _: &OpenDocumentation,
@@ -493,65 +460,6 @@ mod menu_command_tests {
                 .menu_command_enabled(MenuCommand::ArchiveAgent)),
             "Archive Agent must be disabled once every real agent has been archived"
         );
-    }
-
-    /// GitHub issue #462: the Agent menu's `Discard Worktree` is the third door onto
-    /// `crate::worktree_history::flow`'s discard, and `git worktree remove` refuses the main
-    /// checkout - so an agent sitting in it must not be offered the row.
-    #[gpui::test]
-    fn discard_worktree_is_disabled_for_an_agent_in_the_main_checkout(cx: &mut TestAppContext) {
-        let repo = crate::test_support::temp_repo();
-        let container = crate::test_support::temp_root();
-        let feature = container.path().join("feature-wt");
-        test_support::git(
-            repo.path(),
-            &[
-                "worktree",
-                "add",
-                "-b",
-                "feature",
-                feature.to_str().expect("utf8 path"),
-            ],
-        );
-        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
-        cx.run_until_parked();
-
-        app.read_with(cx, |app, _| {
-            assert_eq!(
-                app.agents.active().map(|agent| agent.cwd.clone()),
-                Some(repo.path().to_path_buf()),
-                "premise: the startup agent really sits in the repo's own main checkout"
-            );
-            assert!(
-                !app.menu_command_enabled(MenuCommand::DiscardWorktree),
-                "Discard Worktree must be disabled on the one checkout git refuses to remove"
-            );
-        });
-
-        app.update_in(cx, |app, window, cx| {
-            app.agents.spawn(
-                crate::work_surface::agents::ProcessKind::Shell,
-                feature.clone(),
-                app.settings.appearance.terminal_font_size,
-                app.settings.terminal.shell_override(),
-                None,
-                window,
-                cx,
-            );
-        });
-        cx.run_until_parked();
-
-        app.read_with(cx, |app, _| {
-            assert_eq!(
-                app.agents.active().map(|agent| agent.cwd.clone()),
-                Some(feature.clone()),
-                "premise: the new agent really sits in the linked worktree"
-            );
-            assert!(
-                app.menu_command_enabled(MenuCommand::DiscardWorktree),
-                "and a worktree git will really remove keeps a real, runnable row"
-            );
-        });
     }
 
     #[gpui::test]

--- a/crates/app/src/root/menu_commands.rs
+++ b/crates/app/src/root/menu_commands.rs
@@ -74,8 +74,13 @@ impl AdeApp {
                     && self.worktree_history_op_in_flight
                         != Some(worktree_history::WorktreeHistoryOpKind::Keep)
             }
+            // GitHub issue #462: the active agent's own checkout has to be one git will really
+            // remove. The main checkout is not, so this row is disabled on it rather than left to
+            // fail after the discard has already torn that agent down.
             MenuCommand::DiscardWorktree => {
-                self.agents.active_id().is_some()
+                self.agents
+                    .active()
+                    .is_some_and(|agent| !self.is_main_worktree_path(&agent.cwd))
                     && self.worktree_history_op_in_flight
                         != Some(worktree_history::WorktreeHistoryOpKind::Discard)
             }
@@ -488,6 +493,65 @@ mod menu_command_tests {
                 .menu_command_enabled(MenuCommand::ArchiveAgent)),
             "Archive Agent must be disabled once every real agent has been archived"
         );
+    }
+
+    /// GitHub issue #462: the Agent menu's `Discard Worktree` is the third door onto
+    /// `crate::worktree_history::flow`'s discard, and `git worktree remove` refuses the main
+    /// checkout - so an agent sitting in it must not be offered the row.
+    #[gpui::test]
+    fn discard_worktree_is_disabled_for_an_agent_in_the_main_checkout(cx: &mut TestAppContext) {
+        let repo = crate::test_support::temp_repo();
+        let container = crate::test_support::temp_root();
+        let feature = container.path().join("feature-wt");
+        test_support::git(
+            repo.path(),
+            &[
+                "worktree",
+                "add",
+                "-b",
+                "feature",
+                feature.to_str().expect("utf8 path"),
+            ],
+        );
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+
+        app.read_with(cx, |app, _| {
+            assert_eq!(
+                app.agents.active().map(|agent| agent.cwd.clone()),
+                Some(repo.path().to_path_buf()),
+                "premise: the startup agent really sits in the repo's own main checkout"
+            );
+            assert!(
+                !app.menu_command_enabled(MenuCommand::DiscardWorktree),
+                "Discard Worktree must be disabled on the one checkout git refuses to remove"
+            );
+        });
+
+        app.update_in(cx, |app, window, cx| {
+            app.agents.spawn(
+                crate::work_surface::agents::ProcessKind::Shell,
+                feature.clone(),
+                app.settings.appearance.terminal_font_size,
+                app.settings.terminal.shell_override(),
+                None,
+                window,
+                cx,
+            );
+        });
+        cx.run_until_parked();
+
+        app.read_with(cx, |app, _| {
+            assert_eq!(
+                app.agents.active().map(|agent| agent.cwd.clone()),
+                Some(feature.clone()),
+                "premise: the new agent really sits in the linked worktree"
+            );
+            assert!(
+                app.menu_command_enabled(MenuCommand::DiscardWorktree),
+                "and a worktree git will really remove keeps a real, runnable row"
+            );
+        });
     }
 
     #[gpui::test]

--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -189,7 +189,6 @@ actions!(
         ArchiveAgent,
         ReviewAgent,
         KeepAllChanges,
-        DiscardWorktree,
         OpenDocumentation,
         ReportIssue,
         About,
@@ -792,9 +791,9 @@ pub struct AdeApp {
     /// affordance (`×`, middle-click, or `Ctrl+W` - GitHub issue #26), cleared by the confirming
     /// second gesture on the same `path` (which then really closes it) or by most other tab/file
     /// navigation in the meantime - the same real two-gesture confirmation idiom
-    /// [`Self::prune_confirm_armed`]/[`Self::discard_confirm_armed`] already establish for this
-    /// app's other destructive-feeling actions. A clean (non-dirty) tab never arms this at all -
-    /// see [`crate::code_surface::tabs::AdeApp::request_close_file_tab`]'s own docs for why an
+    /// [`Self::prune_confirm_armed`]/[`Self::remove_worktree_confirm_armed`] already establish
+    /// for this app's other destructive-feeling actions. A clean (non-dirty) tab never arms this
+    /// at all - see [`crate::code_surface::tabs::AdeApp::request_close_file_tab`]'s docs for why an
     /// unsaved-changes prompt for a tab with nothing unsaved would be real, unnecessary friction.
     pub(crate) close_tab_confirm_armed: Option<PathBuf>,
     /// Cached `DiffFile` for whichever path [`Self::open_change`] names (`None` if it has no
@@ -1371,11 +1370,11 @@ pub struct AdeApp {
     /// spawning, reset in that same task's completion handler.
     pub(crate) prune_in_flight: bool,
     /// `Some(kind)` for the duration of any in-flight "keep all changes"/"discard worktree"
-    /// operation, naming *which* one - not just a bare `bool` - so `Self::render_pty_footer`'s
-    /// busy label ("keeping…"/"discarding…") can honestly reflect what's actually running instead
-    /// of guessing from which button happens to be visible (a real, live-reproduced bug an audit
-    /// caught: a running "keep all changes" made every visible `Discard worktree` button across
-    /// every agent read "discarding…"). A single field shared across both, not two independent
+    /// operation, naming *which* one - not just a bare `bool` - so a busy label reflects what is
+    /// actually running rather than guessing from which control happens to be visible. The title
+    /// bar's `Keep All Changes` row is the one label reading the kind today; `Discard` is still
+    /// written so the other two operations serialize behind it. A single field shared across both,
+    /// not two independent
     /// guards: these are the only operations that ever mutate real git history or a worktree's
     /// own existence for this feature, so fully serializing them (a second click of either while
     /// one is in flight is a no-op, mirroring [`Self::prune_in_flight`]'s own
@@ -1408,16 +1407,6 @@ pub struct AdeApp {
     /// click, or vice versa) - the same single-flag-per-feature discipline
     /// [`Self::prune_in_flight`]/[`Self::worktree_history_op_in_flight`] already establish.
     pub(crate) update_check_in_flight: bool,
-    /// `Some(id)` after one click on agent `id`'s "Discard worktree" footer button, cleared by
-    /// most other gestures in the meantime (mirroring [`Self::prune_confirm_armed`]'s own "most
-    /// other gestures disarm it" discipline, applied everywhere that field is - see
-    /// `crate::worktree_history::flow::AdeApp::request_discard_worktree`'s own docs for why this
-    /// destructive-feeling action gets the same two-click confirmation as prune, even though it's
-    /// now genuinely undoable). Not a universal "any gesture at all clears it" guarantee, though:
-    /// arming *this* field's own sibling ([`Self::prune_confirm_armed`]'s first, arming click)
-    /// does not clear this one, and vice versa - only each field's own confirm/cancel/execute
-    /// paths, and a handful of other real navigation gestures, clear it.
-    pub(crate) discard_confirm_armed: Option<AgentId>,
     /// Whether the Settings surface is currently replacing the three-zone body - see
     /// [`Self::open_settings`]/[`Self::close_settings`], which use the same
     /// capture-and-restore shape as [`Self::palette_open`].
@@ -2194,11 +2183,11 @@ pub struct AdeApp {
     /// A real, just-armed "Remove" click on a custom theme card, by name - an adversarial audit
     /// caught the first version of this action deleting the user's file on a single click, unlike
     /// every other destructive action in this app (`Self::prune_confirm_armed`,
-    /// `Self::discard_confirm_armed`). `Self::request_remove_custom_theme`
+    /// `Self::remove_worktree_confirm_armed`). `Self::request_remove_custom_theme`
     /// is the one real place this is armed/consumed - a first click on a given name arms it, a
     /// second click on the *same* name actually deletes. Disarmed by leaving the Themes settings
     /// page or reopening Settings (`Self::select_settings_page`/`Self::open_settings`), the same
-    /// "most other gestures clear it" discipline `Self::discard_confirm_armed`'s own docs
+    /// "most other gestures clear it" discipline `Self::remove_worktree_confirm_armed`'s own docs
     /// describe, scoped to this control's own page since nothing else in the app can arm it.
     pub(crate) custom_theme_remove_armed: Option<String>,
     /// The Themes page's most recent icon-pack action result (GitHub issue #5's "custom icon
@@ -2941,10 +2930,6 @@ impl Render for AdeApp {
             .when(
                 self.menu_command_enabled(MenuCommand::KeepAllChanges),
                 |el| el.on_action(cx.listener(Self::handle_keep_all_changes_menu_command)),
-            )
-            .when(
-                self.menu_command_enabled(MenuCommand::DiscardWorktree),
-                |el| el.on_action(cx.listener(Self::handle_discard_worktree_menu_command)),
             )
             .child(self.render_title_bar(cx))
             // The Settings surface is a separate surface, not a modal: it replaces the three

--- a/crates/app/src/root/new_file.rs
+++ b/crates/app/src/root/new_file.rs
@@ -377,7 +377,6 @@ impl AdeApp {
         self.new_file_input = None;
         self.new_file_error = None;
         self.prune_confirm_armed = false;
-        self.discard_confirm_armed = None;
         // A second real "open a file" path that doesn't go through
         // `crate::code_surface::tabs::AdeApp::open_and_focus_file` - a real, adversarial-audit-
         // found gap: without this, creating a file while the graph tab was active left it

--- a/crates/app/src/root/state.rs
+++ b/crates/app/src/root/state.rs
@@ -548,7 +548,6 @@ impl AdeApp {
             worktree_history_status: None,
             update_state: updater::state::UpdateState::Idle,
             update_check_in_flight: false,
-            discard_confirm_armed: None,
             settings_open: false,
             settings_nav_scroll_handle: gpui::ScrollHandle::new(),
             settings_content_scroll_handle: gpui::ScrollHandle::new(),
@@ -1639,7 +1638,6 @@ impl AdeApp {
         cx: &mut Context<Self>,
     ) {
         self.prune_confirm_armed = false;
-        self.discard_confirm_armed = None;
         // Same reasoning for every floating menu (`crate::root::menus`): the commit composer's
         // split-button popover (Revision R12 §5) names the previously selected worktree's staged
         // set, the file tree's context menu targets a row that is about to stop existing, and the

--- a/crates/app/src/run_history/tab.rs
+++ b/crates/app/src/run_history/tab.rs
@@ -46,7 +46,6 @@ impl AdeApp {
         self.plus_menu_open = false;
         self.title_menu_open = None;
         self.prune_confirm_armed = false;
-        self.discard_confirm_armed = None;
 
         // The same "leaving Files"/"leaving the code surface" sweep `open_review_tab` performs,
         // for the identical reason: `self.open_change = None` above just unrendered the code

--- a/crates/app/src/settings/render.rs
+++ b/crates/app/src/settings/render.rs
@@ -4762,7 +4762,7 @@ impl AdeApp {
     /// every other destructive action in this app). The first click on a given `name` only arms
     /// it; a second click on the *same* name actually deletes
     /// ([`Self::execute_remove_custom_theme`]) - mirroring
-    /// `crate::worktree_history::flow::AdeApp::request_discard_worktree`'s identical shape.
+    /// `crate::worktree_history::flow::AdeApp::request_discard_worktree_path`'s identical shape.
     fn request_remove_custom_theme(&mut self, name: String, cx: &mut Context<Self>) {
         if self.custom_theme_remove_armed.as_deref() != Some(name.as_str()) {
             self.custom_theme_remove_armed = Some(name);

--- a/crates/app/src/status_bar/render.rs
+++ b/crates/app/src/status_bar/render.rs
@@ -136,7 +136,7 @@ impl AdeApp {
     }
 
     /// The transient "keeping all changes…"/"discarded …" feedback from
-    /// `AdeApp::keep_all_changes`/`AdeApp::execute_discard_worktree` (`worktree_history::flow`,
+    /// `AdeApp::keep_all_changes`/`AdeApp::execute_discard_worktree_path` (`worktree_history::flow`,
     /// Revision R10) - `None` (nothing rendered at all) whenever
     /// [`AdeApp::worktree_history_status`] is `None`.
     fn render_status_worktree_history_notice(&self) -> Option<gpui::AnyElement> {

--- a/crates/app/src/title_bar/menu.rs
+++ b/crates/app/src/title_bar/menu.rs
@@ -294,11 +294,6 @@ impl AdeApp {
                 theme::text::DIM.into(),
                 theme::surface::CHIP_NEUTRAL.into(),
             ),
-            MenuCommand::DiscardWorktree => (
-                "D",
-                theme::diff::STAT_DEL.into(),
-                theme::surface::CHIP_NEUTRAL.into(),
-            ),
             MenuCommand::Documentation => (
                 "?",
                 theme::text::DIM.into(),
@@ -354,7 +349,6 @@ impl AdeApp {
             MenuCommand::ArchiveAgent => "close the active tab".to_string(),
             MenuCommand::ReviewAgent => "what this agent changed".to_string(),
             MenuCommand::KeepAllChanges => "commit the active worktree".to_string(),
-            MenuCommand::DiscardWorktree => "force-remove uncommitted content".to_string(),
             MenuCommand::Documentation => "README on GitHub".to_string(),
             MenuCommand::ReportIssue => "GitHub issues".to_string(),
             MenuCommand::About => "Jerry".to_string(),
@@ -367,12 +361,8 @@ impl AdeApp {
     }
 
     /// This command's real display label - [`MenuCommand::label`] for every command except the
-    /// two whose real label is a live status string (GitHub issue #235 preserves both dynamic
-    /// labels exactly as the pre-issue popover had them): [`MenuCommand::KeepAllChanges`] swaps
-    /// to `"keeping…"` mid-flight, and [`MenuCommand::DiscardWorktree`] swaps to `"discarding…"`
-    /// mid-flight or `"confirm discard?"` once armed by a first click - see
-    /// [`AdeApp::perform_menu_command`]'s own `DiscardWorktree` arm for the real arm/confirm
-    /// state machine this label mirrors.
+    /// one whose real label is a live status string: [`MenuCommand::KeepAllChanges`] swaps to
+    /// `"keeping…"` mid-flight.
     fn menu_command_label(&self, cmd: MenuCommand) -> &'static str {
         match cmd {
             MenuCommand::KeepAllChanges => {
@@ -380,19 +370,6 @@ impl AdeApp {
                     == Some(worktree_history::WorktreeHistoryOpKind::Keep)
                 {
                     "keeping\u{2026}"
-                } else {
-                    cmd.label()
-                }
-            }
-            MenuCommand::DiscardWorktree => {
-                let active_id = self.agents.active_id();
-                let discard_busy = self.worktree_history_op_in_flight
-                    == Some(worktree_history::WorktreeHistoryOpKind::Discard);
-                let discard_armed = active_id.is_some() && self.discard_confirm_armed == active_id;
-                if discard_busy {
-                    "discarding\u{2026}"
-                } else if discard_armed {
-                    "confirm discard?"
                 } else {
                     cmd.label()
                 }
@@ -816,98 +793,6 @@ mod title_menu_tests {
         assert!(
             cx.debug_bounds("tree-context-menu").is_none(),
             "the context menu must really stop painting, not merely have its state cleared"
-        );
-    }
-
-    /// The title menu's own click-handling for the Discard row (not just
-    /// `request_discard_worktree` itself, already covered above): the first, arming click must
-    /// leave the menu open so the row's label can really swap to "confirm discard?" for a second
-    /// click, and the second, executing click must close it. Drives this through two real
-    /// simulated clicks on the actual rendered Discard row ([`nth_row_click_point`]), matching
-    /// this file's own established style for every other title-menu test - an earlier version of
-    /// this test hand-copied the row's `on_click` condition inline instead, which meant it could
-    /// never actually catch a bug in the real rendered row's own click wiring (e.g. a wrong
-    /// bounds computation, or the row silently missing its `on_click` entirely).
-    #[gpui::test]
-    fn agent_menu_discard_row_stays_open_while_armed_and_closes_once_confirmed(
-        cx: &mut TestAppContext,
-    ) {
-        let repo = crate::test_support::temp_repo();
-        let worktree_container = crate::test_support::temp_root();
-        let worktree_path = worktree_container.path().join("feature-wt");
-        drop(worktree_container);
-        test_support::add_worktree(repo.path(), "feature", &worktree_path);
-        test_support::write_file(&worktree_path, "dirty.txt", "uncommitted\n");
-
-        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
-        app.update(cx, |app, cx| {
-            app.set_window_controls_style(WindowControlsStyle::WindowsLinuxStyle, cx);
-        });
-        let id = app.update_in(cx, |app, window, cx| {
-            app.agents.spawn(
-                ProcessKind::Shell,
-                worktree_path.clone(),
-                app.settings.appearance.terminal_font_size,
-                app.settings.terminal.shell_override(),
-                None,
-                window,
-                cx,
-            )
-        });
-        app.update_in(cx, |app, window, cx| {
-            app.select_agent(id, window, cx);
-        });
-        cx.run_until_parked();
-        app.update(cx, |app, cx| {
-            app.title_menu_open = Some(TitleMenu::Agent);
-            cx.notify();
-        });
-        cx.run_until_parked();
-
-        // The Discard row is the 8th real row (index 7, 0-based) in the Agent menu: New
-        // Terminal, New Agent Pane, [divider], Next Agent, Previous Agent, [divider], Review
-        // Agent, Archive Agent, Keep All Changes, Discard Worktree - seven real rows and two
-        // dividers sit above it (see `MenuCommand::rows`'s own row order).
-        let bounds = app.read_with(cx, |app, _| {
-            app.title_menu_button_bounds[TitleMenu::Agent.index()]
-        });
-        let discard_row_point = nth_row_click_point(bounds, 7, 2);
-
-        cx.simulate_click(discard_row_point, gpui::Modifiers::none());
-        cx.run_until_parked();
-        assert_eq!(
-            app.read_with(cx, |app, _| app.discard_confirm_armed),
-            Some(id),
-            "a real click on the rendered Discard row should have armed confirmation"
-        );
-        assert_eq!(
-            app.read_with(cx, |app, _| app.title_menu_open),
-            Some(TitleMenu::Agent),
-            "an arming first click must leave the menu open"
-        );
-        assert!(
-            worktree_path.exists(),
-            "an armed-but-not-yet-confirmed discard must not have touched the real worktree"
-        );
-
-        // Second, confirming click at the exact same point - the row's own position doesn't
-        // change when its label swaps to "confirm discard?", only its text.
-        cx.simulate_click(discard_row_point, gpui::Modifiers::none());
-        cx.run_until_parked();
-        assert_eq!(
-            app.read_with(cx, |app, _| app.discard_confirm_armed),
-            None,
-            "the confirming second click should have run the real discard and cleared the arm \
-             flag"
-        );
-        assert_eq!(
-            app.read_with(cx, |app, _| app.title_menu_open),
-            None,
-            "the confirming second click must close the menu"
-        );
-        assert!(
-            !worktree_path.exists(),
-            "the confirming click should have actually removed the real worktree directory"
         );
     }
 

--- a/crates/app/src/title_bar/menu_model.rs
+++ b/crates/app/src/title_bar/menu_model.rs
@@ -45,7 +45,6 @@ pub(crate) enum MenuCommand {
     ArchiveAgent,
     ReviewAgent,
     KeepAllChanges,
-    DiscardWorktree,
     // Help
     Documentation,
     ReportIssue,
@@ -74,7 +73,7 @@ impl MenuCommand {
     /// ([`Self::action`], [`Self::label`], [`Self::keystroke_spec`]) are exhaustive over this
     /// same enum, so nothing here can silently end up with only some of the three - the same
     /// guarantee [`crate::root::menus::MenuSurface::ALL`] gives its own two matches.
-    pub(crate) const ALL: [MenuCommand; 31] = [
+    pub(crate) const ALL: [MenuCommand; 30] = [
         MenuCommand::OpenFile,
         MenuCommand::OpenFolder,
         MenuCommand::NewWindow,
@@ -98,7 +97,6 @@ impl MenuCommand {
         MenuCommand::ArchiveAgent,
         MenuCommand::ReviewAgent,
         MenuCommand::KeepAllChanges,
-        MenuCommand::DiscardWorktree,
         MenuCommand::Documentation,
         MenuCommand::ReportIssue,
         MenuCommand::About,
@@ -136,7 +134,6 @@ impl MenuCommand {
             MenuCommand::ArchiveAgent => Box::new(root::ArchiveAgent),
             MenuCommand::ReviewAgent => Box::new(root::ReviewAgent),
             MenuCommand::KeepAllChanges => Box::new(root::KeepAllChanges),
-            MenuCommand::DiscardWorktree => Box::new(root::DiscardWorktree),
             MenuCommand::Documentation => Box::new(root::OpenDocumentation),
             MenuCommand::ReportIssue => Box::new(root::ReportIssue),
             MenuCommand::About => Box::new(root::About),
@@ -179,7 +176,6 @@ impl MenuCommand {
             MenuCommand::ArchiveAgent => "Archive Agent",
             MenuCommand::ReviewAgent => "Review Agent",
             MenuCommand::KeepAllChanges => "Keep All Changes",
-            MenuCommand::DiscardWorktree => "Discard Worktree",
             MenuCommand::Documentation => "Documentation",
             MenuCommand::ReportIssue => "Report an Issue",
             MenuCommand::About => "About",
@@ -222,7 +218,6 @@ impl MenuCommand {
             | MenuCommand::ArchiveAgent
             | MenuCommand::ReviewAgent
             | MenuCommand::KeepAllChanges
-            | MenuCommand::DiscardWorktree
             | MenuCommand::Documentation
             | MenuCommand::ReportIssue
             | MenuCommand::About
@@ -274,7 +269,6 @@ impl MenuCommand {
                 Command(MenuCommand::ReviewAgent),
                 Command(MenuCommand::ArchiveAgent),
                 Command(MenuCommand::KeepAllChanges),
-                Command(MenuCommand::DiscardWorktree),
             ],
             TitleMenu::Help => &[
                 Command(MenuCommand::Documentation),

--- a/crates/app/src/work_surface/mod.rs
+++ b/crates/app/src/work_surface/mod.rs
@@ -12,7 +12,6 @@ use crate::sidebar::file_tree::{self};
 use crate::theme;
 use crate::work_surface::agents::{Agent, AgentId, AgentKind, ProcessKind};
 use crate::work_surface::state as work_surface;
-use crate::worktree_history::flow as worktree_history;
 use gpui::{div, font, prelude::*, px, App, ClickEvent, Context, Window};
 use std::path::{Path, PathBuf};
 

--- a/crates/app/src/work_surface/render.rs
+++ b/crates/app/src/work_surface/render.rs
@@ -161,7 +161,6 @@ impl AdeApp {
         self.close_gated_review_tab(window, cx);
         self.focus_newly_spawned_agent(window, cx);
         self.prune_confirm_armed = false;
-        self.discard_confirm_armed = None;
         cx.notify();
     }
 
@@ -296,7 +295,6 @@ impl AdeApp {
     ) {
         self.agents.set_active(id, cx);
         self.prune_confirm_armed = false;
-        self.discard_confirm_armed = None;
         // If the git graph tab was showing, this leaves it (without closing its tab) - see
         // `crate::graph_view::render::AdeApp::leave_graph_tab`'s own docs for why this must run
         // *after* `set_active` above: its `restore_focus` fallback resolves to
@@ -464,7 +462,6 @@ impl AdeApp {
     ) {
         self.close_agent(id, window, cx);
         self.prune_confirm_armed = false;
-        self.discard_confirm_armed = None;
         cx.notify();
     }
 
@@ -589,7 +586,6 @@ impl AdeApp {
         // relaunch reopens the retried agent's slot rather than the one it replaced.
         self.record_worktree_session(cx);
         self.prune_confirm_armed = false;
-        self.discard_confirm_armed = None;
         cx.notify();
     }
 
@@ -628,7 +624,6 @@ impl AdeApp {
                 // terminal that is already part of the recorded session.
                 self.record_worktree_session(cx);
                 self.prune_confirm_armed = false;
-                self.discard_confirm_armed = None;
                 cx.notify();
             }
         }
@@ -2457,43 +2452,7 @@ impl AdeApp {
             {
                 enabled = false;
             }
-            // `Discard worktree` shares the worktree-history in-flight guard
-            // (`Self::worktree_history_op_in_flight`) with the title bar's Agent menu row and the
-            // rail's own `Remove worktree…` - see `crate::worktree_history::flow`'s module docs.
-            // Disabled, not just relabelled, while busy - mirrors `Self::render_rail_footer`'s own
-            // `prune_in_flight` gating.
-            if action.kind == work_surface::ActionKind::DiscardWorktree
-                && self.worktree_history_op_in_flight.is_some()
-            {
-                enabled = false;
-            }
-            // GitHub issue #462: an agent whose cwd *is* the repository's main checkout has
-            // nothing this button can discard - `git worktree remove` refuses it, and
-            // `Self::execute_discard_worktree_path` would kill this agent and the worktree's
-            // language servers on the way to finding that out.
-            if action.kind == work_surface::ActionKind::DiscardWorktree
-                && self.is_main_worktree_path(&agent.cwd)
-            {
-                enabled = false;
-            }
-            // Busy labels are keyed off the *specific* in-flight kind, not just "something is
-            // running" - a real, live-reproduced bug an audit caught: keying this off the bare
-            // in-flight flag alone made every visible `Discard worktree` button across every
-            // agent read "discarding…" while an unrelated worktree-history op was running.
-            let label = match action.kind {
-                work_surface::ActionKind::DiscardWorktree
-                    if self.worktree_history_op_in_flight
-                        == Some(worktree_history::WorktreeHistoryOpKind::Discard) =>
-                {
-                    "discarding\u{2026}".to_string()
-                }
-                work_surface::ActionKind::DiscardWorktree
-                    if self.discard_confirm_armed == Some(id) =>
-                {
-                    "confirm discard?".to_string()
-                }
-                _ => action.label.to_string(),
-            };
+            let label = action.label.to_string();
             footer = footer.child(self.render_footer_action_button(id, action, label, enabled, cx));
         }
 
@@ -2635,9 +2594,6 @@ impl AdeApp {
                 .on_click(
                     cx.listener(move |this, _event: &ClickEvent, window, cx| match kind {
                         work_surface::ActionKind::Respawn => this.respawn_agent(id, window, cx),
-                        work_surface::ActionKind::DiscardWorktree => {
-                            this.request_discard_worktree(id, window, cx)
-                        }
                     }),
                 );
         } else {
@@ -5526,16 +5482,12 @@ mod agent_pane_readout_tests {
         });
     }
 
-    /// §4e/§4r's one surviving pair, and its two-click safety: `failed` keeps `Retry` and
-    /// `Discard worktree`, and the discard really arms before it destroys.
-    ///
-    /// Driven through the genuinely painted button (`debug_bounds` + `simulate_click`), not
-    /// through `request_discard_worktree` directly - the point is that this strip still offers
-    /// those two, and that `Open terminal` (which used to sit between them) does not paint.
-    /// `#[cfg(unix)]`: the failed run below is a real `/bin/false` child, which needs a `/bin`.
+    /// Driven through the genuinely painted strip rather than `footer_actions(Status::Fail)`,
+    /// which `work_surface::state`'s own unit test already pins - the point here is what really
+    /// renders. `#[cfg(unix)]`: the failed run below is a real `/bin/false` child.
     #[cfg(unix)]
     #[gpui::test]
-    fn a_failed_run_keeps_retry_and_a_two_click_discard_and_nothing_else(cx: &mut TestAppContext) {
+    fn a_failed_run_keeps_retry_and_offers_no_worktree_removal(cx: &mut TestAppContext) {
         let repo = crate::test_support::temp_repo();
         let worktree_container = crate::test_support::temp_root();
         let worktree_path = worktree_container.path().join("feature-wt");
@@ -5553,13 +5505,11 @@ mod agent_pane_readout_tests {
 
         let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
-        // `/bin/false` is a real child that really exits non-zero, so `Status::Fail` is derived
-        // from a genuine `ProcessSignal::Exited { success: false }` rather than being set.
+        // A real `/bin/false` child, so `Status::Fail` comes from a genuine non-zero exit.
         let id = spawn_and_select(&app, cx, worktree_path.clone(), Some("/bin/false"));
         wait_for_exit(&app, cx, id);
-        // Relabelled to a real agent kind: the strip this test measures is the *agent* pane's
-        // (`isChat` in the mock), and a `Shell` tab gets the terminal info footer instead. The
-        // failure is a genuine non-zero exit either way - only the chrome around it is gated.
+        // The strip this test measures is the *agent* pane's; a `Shell` tab gets the terminal
+        // info footer instead.
         app.update(cx, |app, cx| {
             app.agents.set_kind_for_test(id, ProcessKind::claude());
             cx.notify();
@@ -5580,73 +5530,14 @@ mod agent_pane_readout_tests {
             cx.debug_bounds("footer-action-Respawn").is_some(),
             "a failed run keeps its `Retry`"
         );
-        let discard = cx
-            .debug_bounds("footer-action-DiscardWorktree")
-            .expect("and its two-click `Discard worktree`");
-
-        cx.simulate_click(discard.center(), gpui::Modifiers::none());
-        cx.run_until_parked();
-
-        assert_eq!(
-            app.read_with(cx, |app, _| app.discard_confirm_armed),
-            Some(id),
-            "the first click must only arm - this is the one irreversible thing in the pane"
+        assert!(
+            cx.debug_bounds("footer-action-DiscardWorktree").is_none(),
+            "and offers no worktree removal - that lives on the rail's worktree row now"
         );
         assert!(
             worktree_path.exists(),
-            "and an armed-but-unconfirmed discard must not have touched the real worktree"
+            "and nothing this strip paints may have touched the real worktree"
         );
-    }
-
-    /// GitHub issue #462: the same failed run, in the repository's own main checkout. The button
-    /// still paints (its strip is the one `Status::Fail` defines), but it is inert - `git
-    /// worktree remove` refuses that checkout, and arming would only lead to a discard that kills
-    /// this agent and the worktree's language servers before git says no.
-    ///
-    /// `#[cfg(unix)]` for the same reason as the test above: a real `/bin/false` child.
-    #[cfg(unix)]
-    #[gpui::test]
-    fn a_failed_run_in_the_main_checkout_cannot_arm_its_discard(cx: &mut TestAppContext) {
-        let repo = crate::test_support::temp_repo();
-        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
-        cx.run_until_parked();
-        let id = spawn_and_select(&app, cx, repo.path().to_path_buf(), Some("/bin/false"));
-        wait_for_exit(&app, cx, id);
-        app.update(cx, |app, cx| {
-            app.agents.set_kind_for_test(id, ProcessKind::claude());
-            cx.notify();
-        });
-        cx.run_until_parked();
-
-        app.read_with(cx, |app, cx| {
-            let agent = app
-                .agents
-                .iter()
-                .find(|agent| agent.id == id)
-                .expect("the spawned agent");
-            assert_eq!(
-                app.agent_status(agent, cx),
-                Status::Fail,
-                "premise: the run really failed, so the strip really offers the button"
-            );
-            assert!(
-                app.is_main_worktree_path(&agent.cwd),
-                "premise: and it really failed in the repo's own main checkout"
-            );
-        });
-
-        let discard = cx
-            .debug_bounds("footer-action-DiscardWorktree")
-            .expect("the button still paints - disabled, not hidden");
-        cx.simulate_click(discard.center(), gpui::Modifiers::none());
-        cx.run_until_parked();
-
-        assert_eq!(
-            app.read_with(cx, |app, _| app.discard_confirm_armed),
-            None,
-            "a disabled button must not arm a discard that could never succeed"
-        );
-        assert!(repo.path().exists(), "and the main checkout is untouched");
     }
 
     #[gpui::test]

--- a/crates/app/src/work_surface/render.rs
+++ b/crates/app/src/work_surface/render.rs
@@ -2467,6 +2467,15 @@ impl AdeApp {
             {
                 enabled = false;
             }
+            // GitHub issue #462: an agent whose cwd *is* the repository's main checkout has
+            // nothing this button can discard - `git worktree remove` refuses it, and
+            // `Self::execute_discard_worktree_path` would kill this agent and the worktree's
+            // language servers on the way to finding that out.
+            if action.kind == work_surface::ActionKind::DiscardWorktree
+                && self.is_main_worktree_path(&agent.cwd)
+            {
+                enabled = false;
+            }
             // Busy labels are keyed off the *specific* in-flight kind, not just "something is
             // running" - a real, live-reproduced bug an audit caught: keying this off the bare
             // in-flight flag alone made every visible `Discard worktree` button across every
@@ -5587,6 +5596,57 @@ mod agent_pane_readout_tests {
             worktree_path.exists(),
             "and an armed-but-unconfirmed discard must not have touched the real worktree"
         );
+    }
+
+    /// GitHub issue #462: the same failed run, in the repository's own main checkout. The button
+    /// still paints (its strip is the one `Status::Fail` defines), but it is inert - `git
+    /// worktree remove` refuses that checkout, and arming would only lead to a discard that kills
+    /// this agent and the worktree's language servers before git says no.
+    ///
+    /// `#[cfg(unix)]` for the same reason as the test above: a real `/bin/false` child.
+    #[cfg(unix)]
+    #[gpui::test]
+    fn a_failed_run_in_the_main_checkout_cannot_arm_its_discard(cx: &mut TestAppContext) {
+        let repo = crate::test_support::temp_repo();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+        let id = spawn_and_select(&app, cx, repo.path().to_path_buf(), Some("/bin/false"));
+        wait_for_exit(&app, cx, id);
+        app.update(cx, |app, cx| {
+            app.agents.set_kind_for_test(id, ProcessKind::claude());
+            cx.notify();
+        });
+        cx.run_until_parked();
+
+        app.read_with(cx, |app, cx| {
+            let agent = app
+                .agents
+                .iter()
+                .find(|agent| agent.id == id)
+                .expect("the spawned agent");
+            assert_eq!(
+                app.agent_status(agent, cx),
+                Status::Fail,
+                "premise: the run really failed, so the strip really offers the button"
+            );
+            assert!(
+                app.is_main_worktree_path(&agent.cwd),
+                "premise: and it really failed in the repo's own main checkout"
+            );
+        });
+
+        let discard = cx
+            .debug_bounds("footer-action-DiscardWorktree")
+            .expect("the button still paints - disabled, not hidden");
+        cx.simulate_click(discard.center(), gpui::Modifiers::none());
+        cx.run_until_parked();
+
+        assert_eq!(
+            app.read_with(cx, |app, _| app.discard_confirm_armed),
+            None,
+            "a disabled button must not arm a discard that could never succeed"
+        );
+        assert!(repo.path().exists(), "and the main checkout is untouched");
     }
 
     #[gpui::test]

--- a/crates/app/src/work_surface/state.rs
+++ b/crates/app/src/work_surface/state.rs
@@ -474,12 +474,6 @@ pub enum ActionKind {
     /// stand-in for `Retry`/`Resume` (this app has no saved-agent resumability to actually
     /// resume *from* - see [`pty_state_label`] on the same gap).
     Respawn,
-    /// `crate::worktree_history::flow::AdeApp::request_discard_worktree` (Revision R10): a real
-    /// `wt_core::undo::discard_worktree`, behind the same two-click confirmation as the rail
-    /// footer's `prune` button (see that method's own docs for why - this is a real, destructive
-    /// action that force-removes a worktree, preserving uncommitted/untracked content in a real
-    /// git stash first).
-    DiscardWorktree,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -509,22 +503,13 @@ pub fn footer_actions(status: Status) -> Vec<FooterAction> {
         // §4e: "`Interrupt` offered on an agent that is *waiting for you* - there is nothing to
         // interrupt", and a second terminal does not answer the question the agent is asking.
         Status::Ask => Vec::new(),
-        Status::Fail => vec![
-            FooterAction {
-                kind: ActionKind::Respawn,
-                label: "Retry",
-                keycap: Some("mod+R"),
-                style: ActionStyle::Outline,
-                implemented: true,
-            },
-            FooterAction {
-                kind: ActionKind::DiscardWorktree,
-                label: "Discard worktree",
-                keycap: None,
-                style: ActionStyle::Ghost,
-                implemented: true,
-            },
-        ],
+        Status::Fail => vec![FooterAction {
+            kind: ActionKind::Respawn,
+            label: "Retry",
+            keycap: Some("mod+R"),
+            style: ActionStyle::Outline,
+            implemented: true,
+        }],
         // §4t: "`Interrupt` was the last button on it, and the pane is a terminal: `⌃C` already
         // interrupts and `mod+R` already retries, so a button duplicating a keystroke that works
         // in the focused surface is the same unearned space as §4r."
@@ -712,13 +697,12 @@ mod tests {
     }
 
     #[test]
-    fn fail_actions_are_exactly_a_real_retry_then_a_real_discard() {
+    fn fail_actions_are_exactly_a_real_retry() {
         let actions = footer_actions(Status::Fail);
         let labels: Vec<&str> = actions.iter().map(|action| action.label).collect();
-        assert_eq!(labels, vec!["Retry", "Discard worktree"]);
+        assert_eq!(labels, vec!["Retry"]);
         assert_eq!(actions[0].kind, ActionKind::Respawn);
-        assert_eq!(actions[1].kind, ActionKind::DiscardWorktree);
-        assert!(actions.iter().all(|action| action.implemented));
+        assert!(actions[0].implemented);
     }
 
     #[test]
@@ -745,6 +729,7 @@ mod tests {
                             | "Open in editor"
                             | "Merge"
                             | "Archive"
+                            | "Discard worktree"
                     ),
                     "{status:?} still offers {:?}, which GitHub issue #295 moved out of the \
                      agent pane's bottom strip",
@@ -758,7 +743,6 @@ mod tests {
     fn surviving_buttons_advertise_only_keycaps_that_really_exist() {
         let fail = footer_actions(Status::Fail);
         assert_eq!(fail[0].keycap, Some("mod+R"));
-        assert_eq!(fail[1].keycap, None);
         assert_eq!(footer_actions(Status::Idle)[0].keycap, Some("mod+enter"));
     }
 

--- a/crates/app/src/worktree_history/flow.rs
+++ b/crates/app/src/worktree_history/flow.rs
@@ -28,15 +28,12 @@ impl AdeApp {
             .unwrap_or_else(|| path.display().to_string())
     }
 
-    /// Whether `path` is a repository's own main checkout - the one worktree `git worktree remove`
-    /// refuses outright, and so the one [`Self::execute_discard_worktree_path`] can never succeed
-    /// on (`wt_core::undo::discard_worktree`'s `DiscardSourceIsMainWorktree`). Every removal
-    /// affordance consults this, so the refusal lands before that method's agent/language-server
-    /// teardown rather than after it. Reads the focused repo's list first and then every other
-    /// added repo's, because a rail row menu can be opened on a worktree belonging to a repo that
-    /// isn't focused. An unknown path is not main: a worktree list that hasn't loaded yet must not
-    /// disable a real action.
+    /// Whether `path` is a repository's own main checkout - the one worktree
+    /// [`Self::execute_discard_worktree_path`] can never succeed on.
     pub(crate) fn is_main_worktree_path(&self, path: &Path) -> bool {
+        // Every added repo, not just the focused one: a rail row menu can be opened on a worktree
+        // belonging to a repo `Self::worktrees` says nothing about. An unknown path is not main,
+        // so a list that has not loaded yet cannot disable a real action.
         self.worktrees
             .iter()
             .chain(self.repos.iter().flat_map(|repo| repo.worktrees.iter()))
@@ -54,7 +51,7 @@ impl AdeApp {
 
     /// The Review footer's `Keep all` action - a real `wt_core::undo::commit_all_changes` on
     /// agent `id`'s worktree. Not gated by any confirmation (unlike
-    /// [`Self::request_discard_worktree`]): it's non-destructive.
+    /// [`Self::request_discard_worktree_path`]): it's non-destructive.
     pub(crate) fn keep_all_changes(&mut self, id: AgentId, cx: &mut Context<Self>) {
         if self.worktree_history_op_in_flight.is_some() {
             return;
@@ -65,7 +62,6 @@ impl AdeApp {
         let worktree_path = agent.cwd.clone();
         let branch_display = self.branch_display_for(&worktree_path);
         self.prune_confirm_armed = false;
-        self.discard_confirm_armed = None;
         self.worktree_history_op_in_flight = Some(WorktreeHistoryOpKind::Keep);
         self.worktree_history_status =
             Some(format!("keeping all changes in {branch_display}\u{2026}"));
@@ -96,52 +92,8 @@ impl AdeApp {
         self._worktree_history_task = Some(task);
     }
 
-    /// The Review/Fail footer's `Discard worktree` action - two-click confirmation (mirroring
-    /// [`Self::request_prune`]'s own reasoning: this is a real, destructive action - it
-    /// force-removes a worktree directory, preserving uncommitted/untracked content in a real git
-    /// stash first (see [`wt_core::undo::discard_worktree`]'s own docs), but not undoable from
-    /// within this app). The first click only arms [`AdeApp::discard_confirm_armed`] for `id`; a
-    /// second click on the *same* agent's button while armed actually runs it.
-    pub(crate) fn request_discard_worktree(
-        &mut self,
-        id: AgentId,
-        window: &mut Window,
-        cx: &mut Context<Self>,
-    ) {
-        if self.worktree_history_op_in_flight.is_some() {
-            return;
-        }
-        if self.discard_confirm_armed != Some(id) {
-            self.discard_confirm_armed = Some(id);
-            cx.notify();
-            return;
-        }
-        self.prune_confirm_armed = false;
-        self.discard_confirm_armed = None;
-        self.execute_discard_worktree(id, window, cx);
-    }
-
-    /// Runs the real, already-confirmed discard - only ever reached through
-    /// [`Self::request_discard_worktree`]'s second click. `_window` is accepted (not read
-    /// directly) purely to match every other footer-button click handler's signature - the real
-    /// `Window` [`Self::close_agent`] needs on success is obtained fresh, asynchronously, via
-    /// `update_in` in the completion handler below (see this module's own docs).
-    pub(in crate::worktree_history) fn execute_discard_worktree(
-        &mut self,
-        id: AgentId,
-        _window: &mut Window,
-        cx: &mut Context<Self>,
-    ) {
-        let Some(agent) = self.agents.iter().find(|agent| agent.id == id) else {
-            return;
-        };
-        let worktree_path = agent.cwd.clone();
-        self.execute_discard_worktree_path(worktree_path, cx);
-    }
-
-    /// The rail's `Remove worktree…` row (GitHub issue #290), keyed by worktree path - two
-    /// clicks, exactly like [`Self::request_discard_worktree`]'s button, and running the same
-    /// real [`Self::execute_discard_worktree_path`] underneath.
+    /// The rail's `Remove worktree…` row, keyed by worktree path - two clicks, and the only door
+    /// onto [`Self::execute_discard_worktree_path`]. `true` once it really ran.
     pub(crate) fn request_discard_worktree_path(
         &mut self,
         worktree_path: PathBuf,
@@ -160,7 +112,6 @@ impl AdeApp {
             return false;
         }
         self.prune_confirm_armed = false;
-        self.discard_confirm_armed = None;
         self.remove_worktree_confirm_armed = None;
         self.execute_discard_worktree_path(worktree_path, cx);
         true
@@ -419,17 +370,17 @@ mod worktree_history_regression_tests {
         let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
         let id = spawn_agent(&app, cx, feature.clone());
 
-        app.update_in(cx, |app, window, cx| {
-            app.request_discard_worktree(id, window, cx)
+        app.update(cx, |app, cx| {
+            app.request_discard_worktree_path(feature.clone(), cx)
         });
         assert_eq!(
-            app.read_with(cx, |app, _| app.discard_confirm_armed),
-            Some(id)
+            app.read_with(cx, |app, _| app.remove_worktree_confirm_armed.clone()),
+            Some(feature.clone())
         );
         assert!(feature.exists(), "the first click must not touch anything");
 
-        app.update_in(cx, |app, window, cx| {
-            app.request_discard_worktree(id, window, cx)
+        app.update(cx, |app, cx| {
+            app.request_discard_worktree_path(feature.clone(), cx)
         });
         assert!(app.read_with(cx, |app, _| app.worktree_history_op_in_flight.is_some()));
         cx.run_until_parked();
@@ -464,12 +415,12 @@ mod worktree_history_regression_tests {
         .expect("write ignored file");
 
         let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
-        let id = spawn_agent(&app, cx, feature.clone());
-        app.update_in(cx, |app, window, cx| {
-            app.request_discard_worktree(id, window, cx)
+        let _id = spawn_agent(&app, cx, feature.clone());
+        app.update(cx, |app, cx| {
+            app.request_discard_worktree_path(feature.clone(), cx)
         });
-        app.update_in(cx, |app, window, cx| {
-            app.request_discard_worktree(id, window, cx)
+        app.update(cx, |app, cx| {
+            app.request_discard_worktree_path(feature.clone(), cx)
         });
         cx.run_until_parked();
 

--- a/crates/app/src/worktree_history/flow.rs
+++ b/crates/app/src/worktree_history/flow.rs
@@ -28,6 +28,21 @@ impl AdeApp {
             .unwrap_or_else(|| path.display().to_string())
     }
 
+    /// Whether `path` is a repository's own main checkout - the one worktree `git worktree remove`
+    /// refuses outright, and so the one [`Self::execute_discard_worktree_path`] can never succeed
+    /// on (`wt_core::undo::discard_worktree`'s `DiscardSourceIsMainWorktree`). Every removal
+    /// affordance consults this, so the refusal lands before that method's agent/language-server
+    /// teardown rather than after it. Reads the focused repo's list first and then every other
+    /// added repo's, because a rail row menu can be opened on a worktree belonging to a repo that
+    /// isn't focused. An unknown path is not main: a worktree list that hasn't loaded yet must not
+    /// disable a real action.
+    pub(crate) fn is_main_worktree_path(&self, path: &Path) -> bool {
+        self.worktrees
+            .iter()
+            .chain(self.repos.iter().flat_map(|repo| repo.worktrees.iter()))
+            .any(|item| item.path == path && item.is_main)
+    }
+
     /// Refreshes worktree/diff state after a real git mutation (keep/discard both change what's
     /// on disk) - the same `load_worktrees` + `load_diff` pair `Self::complete_merge_flow`'s own
     /// success arm already uses for the identical reason.

--- a/crates/app/src/worktree_history/mod.rs
+++ b/crates/app/src/worktree_history/mod.rs
@@ -10,7 +10,7 @@ use crate::root::*;
 use crate::work_surface::agents::AgentId;
 #[cfg(test)]
 use crate::work_surface::agents::ProcessKind;
-use gpui::{Context, Window};
+use gpui::Context;
 use std::path::Path;
 use std::path::PathBuf;
 

--- a/docs/design/decisions.md
+++ b/docs/design/decisions.md
@@ -220,6 +220,10 @@ all, review diff, open in editor, discard, retry, interrupt, open terminal.
 
 **Decision:** It is a readout. `work_surface::state::ActionKind` went from seven variants to two
 (`Respawn`, `DiscardWorktree`); the other five were **deleted**, not hidden behind a condition.
+GitHub issue #462 then took `DiscardWorktree` too, leaving one (`Respawn`): worktree removal has a
+single home, the rail's own worktree row, and a removal offered under one agent of a two-agent
+worktree threw away the other agent's work from a pane that never mentioned them - the same reason
+§4r had already given for taking it off `Review`.
 
 **Consequences:** The pane reports what the agent is doing rather than competing with it for the
 bottom of the screen, and the actions that survive are the ones the CLI genuinely cannot perform for

--- a/docs/design/rail.md
+++ b/docs/design/rail.md
@@ -112,6 +112,12 @@ as a fact rather than an inference.
   loaded and genuinely-empty are different states and get different copy.
 - **Worktree inventory and its prune action belong here**, not in the status bar — one fact, one
   home.
+- **No removal affordance is offered on a repo's main checkout.** `git worktree remove` refuses it,
+  and the discard behind `Remove worktree…` kills that checkout's agents and language servers
+  *before* git gets to say no. The row still paints, disabled and carrying its reason
+  (`menu::REMOVE_MAIN_WORKTREE_REASON`) — a menu that changes shape per row costs more than one
+  greyed line. The pane footer's `Discard worktree` and the title bar's `Discard Worktree` read the
+  same predicate (`AdeApp::is_main_worktree_path`), so the three doors cannot drift.
 
 ## Not built yet
 

--- a/docs/design/rail.md
+++ b/docs/design/rail.md
@@ -112,12 +112,17 @@ as a fact rather than an inference.
   loaded and genuinely-empty are different states and get different copy.
 - **Worktree inventory and its prune action belong here**, not in the status bar — one fact, one
   home.
-- **No removal affordance is offered on a repo's main checkout.** `git worktree remove` refuses it,
-  and the discard behind `Remove worktree…` kills that checkout's agents and language servers
-  *before* git gets to say no. The row still paints, disabled and carrying its reason
-  (`menu::REMOVE_MAIN_WORKTREE_REASON`) — a menu that changes shape per row costs more than one
-  greyed line. The pane footer's `Discard worktree` and the title bar's `Discard Worktree` read the
-  same predicate (`AdeApp::is_main_worktree_path`), so the three doors cannot drift.
+- **Worktree removal has exactly one door, and it is here.** `Remove worktree…` on the worktree row
+  is the only way to remove a worktree in this app. The pane footer's `Discard worktree` and the
+  title bar's **Agent ▸ Discard Worktree** were deleted in issue #462 — both acted on the *active
+  agent's* checkout from a surface that never names the worktree, and under one agent of a
+  two-agent worktree that throws away the other agent's work. Removal belongs where the worktree
+  itself is named. (Prune is a different verb and keeps its own homes — see the footer above.)
+- **That one row is disabled on a repo's main checkout.** `git worktree remove` refuses it, and the
+  discard behind the row kills that checkout's agents and language servers *before* git gets to say
+  no. The row still paints, disabled and carrying its reason (`menu::REMOVE_MAIN_WORKTREE_REASON`)
+  — a menu that changes shape per row costs more than one greyed line. The predicate is
+  `AdeApp::is_main_worktree_path`.
 
 ## Not built yet
 

--- a/docs/design/work-surface.md
+++ b/docs/design/work-surface.md
@@ -72,7 +72,9 @@ the real invocation, the real pid and the real pty state (`attached · waiting o
 
 Its footer band is a **readout, not an action bar** — the strip below an agent pane reports; it does
 not offer git operations the CLI could have done itself. `work_surface::state::ActionKind` is down
-to two variants (`Respawn`, `DiscardWorktree`) and the five it lost were deleted rather than hidden.
+to one variant (`Respawn`) and the six it lost were deleted rather than hidden - `DiscardWorktree`
+last, in GitHub issue #462, which left worktree removal with a single home on the rail's worktree
+row.
 Anything still listed renders honestly disabled when it has no backing logic
 (`FooterAction::implemented`).
 


### PR DESCRIPTION
<!-- Closes #462 -->

## What

Worktree removal now has **exactly one entry point**: `Remove worktree…` on the rail's worktree
row. And that row is disabled on a repository's own main checkout, which is the one worktree
`git worktree remove` refuses.

Two commits:

1. **Gate the removal doors on the main checkout.** All three read one predicate,
   `AdeApp::is_main_worktree_path`, which looks the path up in the focused repo's worktree list and
   then in every other added repo's — a rail menu can be opened on a row belonging to a repo that
   isn't focused, where `AdeApp::worktrees` has nothing to say. The menu row is **disabled, not
   hidden**: it keeps its place and carries its reason as its tooltip through the existing
   `MenuEntry::gated`, so the worktree menu is the same shape on every row.

2. **Delete two of the three doors.** The pane footer's `Discard worktree` and the title bar's
   **Agent ▸ Discard Worktree** are gone. Both acted on the *active agent's* checkout from a
   surface that never names the worktree, and under one agent of a two-agent worktree that throws
   away the other agent's work — the reason §4r already gave when it took the same row off
   `Review`. `work_surface::state::ActionKind` is down to one variant (`Respawn`), so a failed
   run's strip is `Retry` alone.

   `AdeApp::discard_confirm_armed` goes with them: the agent-keyed
   `request_discard_worktree`/`execute_discard_worktree` pair was its only writer, so the ~20
   "most other gestures disarm it" resets scattered across the app were dead the moment it was.
   Net −426 lines.

Prune is a different verb and keeps its own homes (rail footer, palette, status bar, Settings).
`wt-core` is unchanged — its `DiscardSourceIsMainWorktree` refusal stays as the last line of
defence; this only stops the UI walking into it.

## Why

The failure was not inert. `execute_discard_worktree_path` shuts down every agent PTY session and
every language server rooted in the worktree **before** calling git (issue #470's ordering). So
arming and confirming a removal on the main checkout killed live agents, left their panes dead, and
*then* reported `discard failed: …` for an operation that could never have succeeded.

The rest of the app already gated on this — `WorktreeNote::is_prunable` starts `!self.is_main`, and
the Settings worktrees page returns `WorktreeRowAction::None` for the main checkout with the comment
"`git worktree remove` refuses it outright". These doors were the ones that were missed.

The full reasoning is on #462.

## Testing

- [x] `/check` — conventions at baseline (300/170/0), `cargo fmt --check` clean, `cargo clippy
      --workspace --all-targets -- -D warnings` clean. Tests: see the note below.
- [ ] `verify` capture — **not run**: the `verify` skill's capture path is macOS-only
      (`screencapture`/`osascript`), and the Windows substitute could not reliably target Jerry's
      window — synthetic input was routed to other applications on the desktop rather than to the
      app, so no honest capture of the disabled row exists. The app was launched and confirmed to
      start and render its rail with this change; the row itself is covered by the `#[gpui::test]`
      below, which clicks the genuinely painted popover row.
- [x] New behaviour has a real test, in the right tier:
  - `rail::menu::tests::remove_worktree_is_disabled_on_the_main_checkout` (`unit`) — the row is
    present, `!enabled`, and carries `REMOVE_MAIN_WORKTREE_REASON`.
  - `rail::menu_render::rail_menu_tests::remove_worktree_is_disabled_on_the_main_checkout` (`ui`) —
    against a real repo with a real linked worktree: clicking the painted row on the main checkout
    neither arms the confirmation nor tears down the agent living there, while the same row on the
    linked worktree still arms.
  - `work_surface::state::…::fail_actions_are_exactly_a_real_retry` (`unit`) and
    `…::a_failed_run_keeps_retry_and_offers_no_worktree_removal` (`ui`, `#[cfg(unix)]` — needs a
    real `/bin/false` child) — the strip offers `Retry` and paints no removal button.
  - Three tests covering the deleted surfaces were removed with them; the two
    `worktree_history::flow` discard regressions were repointed at the surviving
    `request_discard_worktree_path`.

  Each new assertion was confirmed to fail with its gate removed, then pass with it restored.
- [ ] `external` tier — not touched by this change.

**Note on `cargo nextest run --workspace` locally:** this was run on Windows, where the suite is
known-broken (#468/#440). Rather than report a red run without a baseline, the full suite was run
on both this branch and its base and the failure sets diffed: **identical** — 65 failed + 2 timed
out on each, same test names, zero difference (3171 tests here vs 3173, the two being deleted
tests). For the modules this PR touches, 178 of 184 pass and the 6 failures are the pre-existing
`right_click_worktree_row` family — the rail's worktree rows do not paint under `TestAppContext` on
Windows. That is also why the new `ui` test opens the row menu through `open_rail_row_menu` rather
than a real right-click: the popover itself paints on every platform, so the test still clicks a
real painted menu row and runs green on Windows instead of joining the red family. Linux CI is the
authority on the rest.

## Architecture notes

No crate-boundary or Command/Query change. `AdeApp::is_main_worktree_path` is a plain in-memory
read of the already-cached worktree model — no I/O, so nothing to offload off the UI thread.

Design history for the removal lives in `docs/design/decisions.md` and
`docs/design/{rail,work-surface}.md` rather than in source comments, per CLAUDE.md's comment rule.

## Screenshot

Not included — see the `verify` note under Testing.
