### PR TITLE
feat(app): report Cursor agent status through hooks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,3 +51,15 @@ thiserror = "1"
 serde = { version = "1.0.221", features = ["derive"] }
 toml = "0.8"
 serde_json = "1"
+
+# Debug info is the bulk of a debug `target/` on MSVC, and almost none of it is ever read: a
+# backtrace or a debugger session wants this workspace's own frames, not `aws-lc-sys`' or a
+# tree-sitter grammar's. Dependencies therefore get none, and this workspace's crates keep
+# line tables - enough for file/line in panics and backtraces, without the full type/variable
+# DWARF that a step-through debugger needs. Raise `[profile.dev] debug` back to `2` locally
+# (or `--config 'profile.dev.debug=2'`) for a real debugging session.
+[profile.dev]
+debug = "line-tables-only"
+
+[profile.dev.package."*"]
+debug = 0

--- a/crates/app/src/hooks/cursor_event.rs
+++ b/crates/app/src/hooks/cursor_event.rs
@@ -1,0 +1,270 @@
+//! Turning one raw Cursor Agent CLI hook payload into the same [`HookReport`]/[`HookFact`] shape
+//! `crate::hooks::event` produces for Claude Code (GitHub issue #479). Kept as a real second
+//! parser rather than teaching `event::parse` a second schema: Cursor's field names, casing and
+//! per-event shape don't match Claude's at all, so unifying them would only be indirection -
+//! everything downstream (`crate::hooks::server`'s inbox/edit recording,
+//! `crate::hooks::flow::AdeApp::record_agent_statuses`, History) reads the shared [`HookReport`]
+//! type and doesn't know or care which parser produced it.
+//!
+//! **Scope cut, load-bearing:** [`HookReport::edit`] is always `None` for every report this
+//! module produces, including `preToolUse`/`postToolUse` for a file-writing `tool_name` like
+//! `Write`/`Edit`. `tool_input`'s *inner* JSON shape comes from a protobuf `toJson()` call inside
+//! Cursor's own CLI, and protobuf JSON serialization can legally use either a field's exact proto
+//! name or a camelCase transform of it depending on how the `.proto` schema annotates that field -
+//! genuinely unknown without a live captured payload, unlike every field this module *does* read
+//! below (flat, unambiguous, directly-constructed JS object keys, verified against the installed
+//! CLI's own compiled bundle - see GitHub issue #479's research comment). Guessing the inner
+//! `tool_input` shape wrong would silently attribute a file edit to the wrong path rather than
+//! fail loudly, which is worse than not attributing one at all. Revisit only with a real captured
+//! payload, the same standard `event.rs`'s own `REAL_*` fixtures are held to.
+
+use crate::hooks::event::{
+    truncated, HookFact, HookReport, ACTIVITY_MAX_CHARS, MAX_PAYLOAD_BYTES, PROMPT_MAX_CHARS,
+    QUESTION_MAX_CHARS,
+};
+
+/// Parses one Cursor Agent CLI hook event into the fact Jerry acts on, or `None` if this payload
+/// carries nothing worth changing a row over - an unrecognised `event_name`, a payload over
+/// [`MAX_PAYLOAD_BYTES`], invalid/non-object JSON, or a required field missing for the event that
+/// fired. Never panics: this runs on every real hook POST from a live agent process, so a bad
+/// payload must degrade to "nothing changed" rather than take the listener down.
+pub fn parse(event_name: &str, payload: &[u8]) -> Option<HookReport> {
+    if payload.len() > MAX_PAYLOAD_BYTES {
+        return None;
+    }
+    let value: serde_json::Value = serde_json::from_slice(payload).ok()?;
+    if !value.is_object() {
+        return None;
+    }
+
+    // Every real event payload carries `conversation_id` - Cursor's own `session_id` equivalent,
+    // and what GitHub issue #227's History/"Resume here" needs (`HookReport::session_id`'s own
+    // docs cover why it's read once here rather than per-arm, same as `event::parse`).
+    let session_id = value
+        .get("conversation_id")
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_owned);
+
+    let report = match event_name {
+        "beforeSubmitPrompt" => Some(HookReport {
+            prompt: value
+                .get("prompt")
+                .and_then(serde_json::Value::as_str)
+                .and_then(|prompt| truncated(prompt, PROMPT_MAX_CHARS)),
+            ..HookReport::bare(HookFact::Working)
+        }),
+
+        // `tool_input`'s inner shape is deliberately not read at all - see this module's own
+        // scope-cut docs. The activity line degrades to the bare tool name, matching
+        // `event::parse`'s own fallback when `tool_input_preview` finds nothing.
+        "preToolUse" | "postToolUse" => {
+            let tool = value.get("tool_name").and_then(serde_json::Value::as_str)?;
+            Some(HookReport {
+                activity: truncated(tool, ACTIVITY_MAX_CHARS),
+                ..HookReport::bare(HookFact::Working)
+            })
+        }
+
+        "postToolUseFailure" => {
+            let tool = value.get("tool_name").and_then(serde_json::Value::as_str)?;
+            Some(HookReport {
+                activity: truncated(tool, ACTIVITY_MAX_CHARS),
+                question: value
+                    .get("error_message")
+                    .and_then(serde_json::Value::as_str)
+                    .and_then(|message| truncated(message, QUESTION_MAX_CHARS)),
+                ..HookReport::bare(HookFact::TurnFailed)
+            })
+        }
+
+        // No `last_assistant_message`-equivalent field on `stop` itself - Cursor splits that onto
+        // `afterAgentResponse.text` instead (handled below).
+        "stop" => Some(HookReport::bare(HookFact::TurnEnded)),
+
+        // Judgement call, deliberately flagged in the PR this shipped in: this event carries
+        // `text` (the assistant's final message, what Claude gets for free on
+        // `Stop.last_assistant_message`), but threading it onto the following `stop` needs
+        // per-agent state kept across two calls, and `parse()` is pure with no memory of the last
+        // payload. That pairing lives in the *caller* instead (`crate::hooks::server`'s
+        // `edits`/`inbox`, keyed by `AgentId`), so `text` is dropped here rather than this module
+        // growing a second, parallel state-tracking mechanism. `HookFact::Working`, not a fifth
+        // variant, since the agent genuinely is still mid-turn.
+        "afterAgentResponse" => Some(HookReport::bare(HookFact::Working)),
+
+        _ => None,
+    }?;
+
+    Some(HookReport {
+        session_id,
+        ..report
+    })
+}
+
+#[cfg(test)]
+mod cursor_event_tests {
+    use super::parse;
+    use crate::hooks::event::{EventKind, HookFact, MAX_PAYLOAD_BYTES};
+
+    // Synthetic payloads built from the field lists in GitHub issue #479's design comment - read
+    // out of the installed CLI's own compiled bundle, but never captured from a live run. Named
+    // `SYNTHETIC_*` (not `event.rs`'s `REAL_*`) so a future reader never mistakes these for
+    // captured ground truth.
+
+    const SYNTHETIC_BEFORE_SUBMIT_PROMPT: &[u8] = br#"{
+        "conversation_id": "conv-123",
+        "generation_id": "gen-1",
+        "model": "claude-4.5-sonnet",
+        "prompt": "add a health check endpoint",
+        "attachments": [],
+        "composer_mode": "agent"
+    }"#;
+
+    const SYNTHETIC_PRE_TOOL_USE: &[u8] = br#"{
+        "conversation_id": "conv-123",
+        "generation_id": "gen-1",
+        "model": "claude-4.5-sonnet",
+        "tool_name": "Write",
+        "tool_input": { "file_path": "/tmp/repo/src/main.rs", "content": "fn main() {}" },
+        "tool_use_id": "tool-1",
+        "cwd": "/tmp/repo"
+    }"#;
+
+    const SYNTHETIC_POST_TOOL_USE: &[u8] = br#"{
+        "conversation_id": "conv-123",
+        "generation_id": "gen-1",
+        "model": "claude-4.5-sonnet",
+        "tool_name": "Edit",
+        "tool_input": { "file_path": "/tmp/repo/src/main.rs" },
+        "tool_use_id": "tool-1",
+        "cwd": "/tmp/repo",
+        "tool_output": "ok",
+        "duration": 120
+    }"#;
+
+    const SYNTHETIC_POST_TOOL_USE_FAILURE: &[u8] = br#"{
+        "conversation_id": "conv-123",
+        "generation_id": "gen-1",
+        "model": "claude-4.5-sonnet",
+        "tool_name": "Bash",
+        "tool_input": { "command": "cargo test" },
+        "tool_use_id": "tool-2",
+        "cwd": "/tmp/repo",
+        "error_message": "exit status 101",
+        "failure_type": "non_zero_exit",
+        "is_interrupt": false
+    }"#;
+
+    const SYNTHETIC_STOP: &[u8] = br#"{
+        "conversation_id": "conv-123",
+        "generation_id": "gen-1",
+        "model": "claude-4.5-sonnet",
+        "status": "completed",
+        "loop_count": 3,
+        "input_tokens": 4200,
+        "output_tokens": 850
+    }"#;
+
+    const SYNTHETIC_AFTER_AGENT_RESPONSE: &[u8] = br#"{
+        "conversation_id": "conv-123",
+        "generation_id": "gen-1",
+        "model": "claude-4.5-sonnet",
+        "text": "Both done: added the endpoint and a test for it.",
+        "input_tokens": 4200,
+        "output_tokens": 850
+    }"#;
+
+    #[test]
+    fn before_submit_prompt_reports_working_and_carries_the_prompt_and_session_id() {
+        let report =
+            parse("beforeSubmitPrompt", SYNTHETIC_BEFORE_SUBMIT_PROMPT).expect("must parse");
+        assert_eq!(report.fact, HookFact::Working);
+        assert_eq!(report.kind, EventKind::Transition);
+        assert_eq!(
+            report.prompt.as_deref(),
+            Some("add a health check endpoint")
+        );
+        assert_eq!(report.session_id.as_deref(), Some("conv-123"));
+        assert!(report.edit.is_none());
+    }
+
+    #[test]
+    fn pre_tool_use_reports_working_with_an_activity_line_and_no_edit() {
+        let report = parse("preToolUse", SYNTHETIC_PRE_TOOL_USE).expect("must parse");
+        assert_eq!(report.fact, HookFact::Working);
+        assert_eq!(report.activity.as_deref(), Some("Write"));
+        assert!(
+            report.edit.is_none(),
+            "the scope cut must hold even for a file-writing tool_name"
+        );
+    }
+
+    #[test]
+    fn post_tool_use_reports_working_with_an_activity_line_and_no_edit() {
+        let report = parse("postToolUse", SYNTHETIC_POST_TOOL_USE).expect("must parse");
+        assert_eq!(report.fact, HookFact::Working);
+        assert_eq!(report.activity.as_deref(), Some("Edit"));
+        assert!(
+            report.edit.is_none(),
+            "the scope cut must hold even for a file-writing tool_name"
+        );
+    }
+
+    #[test]
+    fn post_tool_use_failure_reports_turn_failed_with_the_error_message() {
+        let report =
+            parse("postToolUseFailure", SYNTHETIC_POST_TOOL_USE_FAILURE).expect("must parse");
+        assert_eq!(report.fact, HookFact::TurnFailed);
+        assert_eq!(report.activity.as_deref(), Some("Bash"));
+        assert_eq!(report.question.as_deref(), Some("exit status 101"));
+        assert!(report.edit.is_none());
+    }
+
+    #[test]
+    fn stop_reports_turn_ended_bare() {
+        let report = parse("stop", SYNTHETIC_STOP).expect("must parse");
+        assert_eq!(report.fact, HookFact::TurnEnded);
+        assert_eq!(report.session_id.as_deref(), Some("conv-123"));
+        assert!(report.edit.is_none());
+    }
+
+    #[test]
+    fn after_agent_response_reports_working_and_never_a_fifth_fact() {
+        let report =
+            parse("afterAgentResponse", SYNTHETIC_AFTER_AGENT_RESPONSE).expect("must parse");
+        assert_eq!(report.fact, HookFact::Working);
+        assert!(report.edit.is_none());
+    }
+
+    #[test]
+    fn an_unknown_event_name_returns_none() {
+        assert!(parse("somethingCursorDoesNotSend", SYNTHETIC_STOP).is_none());
+    }
+
+    #[test]
+    fn malformed_json_returns_none_rather_than_panicking() {
+        assert!(parse("stop", b"{ not json").is_none());
+    }
+
+    #[test]
+    fn a_non_object_json_root_returns_none() {
+        assert!(parse("stop", b"[1,2,3]").is_none());
+    }
+
+    #[test]
+    fn pre_tool_use_missing_tool_name_returns_none_rather_than_panicking() {
+        let payload = br#"{"conversation_id": "conv-123", "tool_input": {}}"#;
+        assert!(parse("preToolUse", payload).is_none());
+    }
+
+    #[test]
+    fn post_tool_use_failure_missing_tool_name_returns_none() {
+        let payload = br#"{"conversation_id": "conv-123", "error_message": "boom"}"#;
+        assert!(parse("postToolUseFailure", payload).is_none());
+    }
+
+    #[test]
+    fn a_payload_over_the_max_size_returns_none() {
+        let oversized = vec![b'a'; MAX_PAYLOAD_BYTES + 1];
+        assert!(parse("stop", &oversized).is_none());
+    }
+}

--- a/crates/app/src/hooks/cursor_hooks_file.rs
+++ b/crates/app/src/hooks/cursor_hooks_file.rs
@@ -1,0 +1,708 @@
+//! Read-modify-write merge of `~/.cursor/hooks.json` (GitHub issue #479) - the Cursor Agent CLI's
+//! own, single global hooks file. Unlike `crate::hooks::settings_file`'s `--settings <path>` file
+//! (entirely Jerry-owned, regenerated whole on every launch), `hooks.json` is shared with the user
+//! and possibly other tools, so this is a real surgical merge: read it, touch only Jerry's own
+//! entries, write it back - or abort untouched if it can't be parsed at all.
+//!
+//! Own-entries are identified the same way Orca and Superset (see issue #479's design comment)
+//! identify theirs: the managed forwarder script's own path appearing as a substring of an
+//! entry's `command` string - `hooks.json` entries are bare `{command, timeout}` objects with no
+//! room for a marker field. The substring matched is deliberately the forwarder's *stable parent
+//! directory* ([`managed_marker`]), not its exact version-stamped file name - the same reasoning
+//! `crate::hooks::settings_file`'s `DIRECTORY_PREFIX`/`sweep_stale_directories` already uses for
+//! the Claude forwarder's per-launch directories: an entry written by an older Jerry version still
+//! lives under the same stable directory, so a later [`install`] sweeps and replaces it instead of
+//! it accumulating as an orphan every time the forwarder's own file name is stamped forward with a
+//! new version.
+
+use std::io;
+use std::path::{Path, PathBuf};
+
+use serde_json::{Map, Value};
+
+use crate::hooks::settings_file::{powershell_quote, random_suffix, shell_quote};
+use crate::settings::store::home_dir;
+
+/// The hook events Jerry subscribes to in `~/.cursor/hooks.json` - deliberately not the CLI's
+/// full ~18-event set. See GitHub issue #479's design comment:
+/// - Not `sessionStart`/`sessionEnd`: Orca's own hazard note (a process-boundary session hook can
+///   reset turn-tracking state across a resumed session) applies just as much to Jerry, whose
+///   Cursor sessions are also minted via `--resume`/`create-chat`
+///   ([`crate::work_surface::agents::AgentKind::mints_chat_id`]).
+/// - Not `beforeShellExecution`/`beforeMCPExecution`: both fire *before* Cursor's own permission
+///   decision, so they cannot distinguish "about to block on a human" from "about to auto-run
+///   under trust" - subscribing would make [`crate::hooks::event::HookFact::NeedsInput`] a
+///   false-positive machine rather than a real signal. `NeedsInput` stays on the existing
+///   terminal-title/quiescence fallback (`crate::rail::status`) - no change needed there.
+pub const CURSOR_HOOK_EVENTS: [&str; 6] = [
+    "beforeSubmitPrompt",
+    "stop",
+    "preToolUse",
+    "postToolUse",
+    "postToolUseFailure",
+    "afterAgentResponse",
+];
+
+/// Timeout Jerry declares on each of its own hook entries, in seconds. The forwarder itself never
+/// blocks long (a real `--max-time 5` curl call, mirroring
+/// `crate::hooks::settings_file`'s forwarder scripts) - this is a generous ceiling so a slow or
+/// loaded machine's hook call is never itself the thing that trips Cursor's own timeout handling.
+const HOOK_TIMEOUT_SECS: u64 = 30;
+
+/// The stable directory name (under Jerry's own config dir) the Cursor forwarder script lives in.
+/// Deliberately never version-stamped itself - only the file inside it is (see
+/// [`forwarder_path`]) - because this directory's own path is what [`managed_marker`] matches
+/// entries against, and it must stay the same across every Jerry version for the sweep-old-entries
+/// property described in this module's own docs to hold.
+const FORWARDER_DIR_NAME: &str = "cursor-hooks";
+
+/// `~/.cursor/hooks.json` - the one location `cursor-agent` actually reads a global hooks file
+/// from. There is no CLI flag or environment variable that points it elsewhere (GitHub issue
+/// #479's research comment).
+pub fn hooks_json_path() -> Option<PathBuf> {
+    Some(home_dir()?.join(".cursor").join("hooks.json"))
+}
+
+/// This build's Cursor forwarder script path: under Jerry's own config dir
+/// (`~/.config/jerry/cursor-hooks/`, mirroring `crate::settings::store::settings_toml_path`'s own
+/// `~/.config/jerry/...` convention), version-stamped by file name so an upgrade's freshly written
+/// script never collides with - or is confused for - an older one still referenced by a stale
+/// `hooks.json` entry. Never deleted on drop: unlike
+/// `crate::hooks::settings_file::HookFiles`'s per-launch directory, `~/.cursor/hooks.json`
+/// outlives any single Jerry process and has to keep pointing at a real file between launches.
+pub fn forwarder_path() -> Option<PathBuf> {
+    let extension = if cfg!(windows) { "ps1" } else { "sh" };
+    Some(
+        home_dir()?
+            .join(".config")
+            .join("jerry")
+            .join(FORWARDER_DIR_NAME)
+            .join(format!(
+                "jerry-cursor-hook-forwarder-{}.{extension}",
+                env!("CARGO_PKG_VERSION")
+            )),
+    )
+}
+
+/// Writes this build's forwarder script to `path`, creating its parent directory if needed - a
+/// no-op if `path` already holds exactly this content, so repeated calls (once per launch, per
+/// [`crate::hooks`]'s module docs) don't needlessly touch the file's mtime.
+pub fn ensure_forwarder_written(path: &Path) -> io::Result<()> {
+    let contents = if cfg!(windows) {
+        CURSOR_WINDOWS_FORWARDER_SCRIPT
+    } else {
+        CURSOR_UNIX_FORWARDER_SCRIPT
+    };
+    if let Ok(existing) = std::fs::read(path) {
+        if existing == contents.as_bytes() {
+            return Ok(());
+        }
+    }
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    write_atomic(path, contents.as_bytes())?;
+    // Owner-executable, matching `crate::hooks::settings_file::write_private_file`'s own reasoning
+    // for the Claude forwarder: some shells Cursor might invoke this through resolve it as a
+    // program rather than always going through an explicit interpreter.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700))?;
+    }
+    Ok(())
+}
+
+/// Merges Jerry's 6 managed entries into `cursor_hooks_json_path`, pointing every one at
+/// `forwarder_path` - see this module's own docs for the merge/identity/sweep rules. Idempotent:
+/// running this twice in a row with the same `forwarder_path` writes nothing the second time.
+///
+/// Never clobbers a file it cannot parse: if `cursor_hooks_json_path` exists but is not valid
+/// JSON, or its root is not a JSON object, this returns `Ok(())` having touched nothing at all -
+/// exactly [`crate::hooks::event::parse`]'s own "gracefully decline" shape, not an error, because
+/// "the user's hand-edited file is currently broken" isn't a failure of *this* operation.
+pub fn install(cursor_hooks_json_path: &Path, forwarder_path: &Path) -> io::Result<()> {
+    let Some((mut root, existing_raw)) = load_mergeable(cursor_hooks_json_path, true)? else {
+        return Ok(());
+    };
+    let Some(object) = root.as_object_mut() else {
+        return Ok(());
+    };
+    object.entry("version").or_insert(Value::from(1));
+    let hooks_value = object
+        .entry("hooks")
+        .or_insert_with(|| Value::Object(Map::new()));
+    let Some(hooks_obj) = hooks_value.as_object_mut() else {
+        return Ok(());
+    };
+
+    let marker = managed_marker(forwarder_path);
+    for event in CURSOR_HOOK_EVENTS {
+        let command = managed_command(forwarder_path, event)?;
+        let entries = hooks_obj
+            .entry(event.to_string())
+            .or_insert_with(|| Value::Array(Vec::new()));
+        let Some(array) = entries.as_array_mut() else {
+            return Ok(());
+        };
+        array.retain(|entry| !is_managed_entry(entry, &marker));
+        array.push(serde_json::json!({ "command": command, "timeout": HOOK_TIMEOUT_SECS }));
+    }
+
+    write_if_changed(cursor_hooks_json_path, existing_raw.as_deref(), &root)
+}
+
+/// Strips every entry [`install`] would have written, under every one of [`CURSOR_HOOK_EVENTS`],
+/// identified the same way [`install`] identifies them - dropping an event's own key entirely if
+/// removing Jerry's entry leaves it empty, but never touching a key that still holds real
+/// user-authored entries. A complete no-op - it doesn't even open the file - when
+/// `cursor_hooks_json_path` doesn't exist, and the same "abort untouched" behaviour as [`install`]
+/// when it exists but isn't parseable.
+pub fn remove_managed_entries(
+    cursor_hooks_json_path: &Path,
+    forwarder_path: &Path,
+) -> io::Result<()> {
+    let Some((mut root, existing_raw)) = load_mergeable(cursor_hooks_json_path, false)? else {
+        return Ok(());
+    };
+    let Some(object) = root.as_object_mut() else {
+        return Ok(());
+    };
+    let Some(hooks_obj) = object.get_mut("hooks").and_then(Value::as_object_mut) else {
+        return Ok(());
+    };
+
+    let marker = managed_marker(forwarder_path);
+    let mut now_empty = Vec::new();
+    for event in CURSOR_HOOK_EVENTS {
+        let Some(array) = hooks_obj.get_mut(event).and_then(Value::as_array_mut) else {
+            continue;
+        };
+        array.retain(|entry| !is_managed_entry(entry, &marker));
+        if array.is_empty() {
+            now_empty.push(event);
+        }
+    }
+    for event in now_empty {
+        hooks_obj.remove(event);
+    }
+
+    write_if_changed(cursor_hooks_json_path, existing_raw.as_deref(), &root)
+}
+
+/// Reads and parses `path` into `(root value, original raw text)`. `Ok(None)` means "the caller
+/// must abort without writing" - either the content isn't a parseable JSON object, or the file
+/// doesn't exist and `create_if_missing` is `false` ([`remove_managed_entries`]'s "don't create
+/// what isn't there" contract). `create_if_missing` is `true` from [`install`], which synthesizes
+/// a fresh empty object instead.
+fn load_mergeable(
+    path: &Path,
+    create_if_missing: bool,
+) -> io::Result<Option<(Value, Option<String>)>> {
+    match std::fs::read_to_string(path) {
+        Ok(raw) => match serde_json::from_str::<Value>(&raw) {
+            Ok(value) if value.is_object() => Ok(Some((value, Some(raw)))),
+            _ => {
+                log::warn!(
+                    "{} is not a valid JSON object, so Jerry will not touch it - fix or remove it \
+                     by hand, or Cursor agent status will keep using the terminal/quiescence \
+                     fallback until it's readable again",
+                    path.display()
+                );
+                Ok(None)
+            }
+        },
+        Err(err) if err.kind() == io::ErrorKind::NotFound => {
+            if create_if_missing {
+                Ok(Some((Value::Object(Map::new()), None)))
+            } else {
+                Ok(None)
+            }
+        }
+        Err(err) => Err(err),
+    }
+}
+
+/// Serializes `root` and writes it to `path` only if that differs from `existing_raw` - the
+/// no-op-on-no-change half of both [`install`] and [`remove_managed_entries`]'s idempotency.
+fn write_if_changed(path: &Path, existing_raw: Option<&str>, root: &Value) -> io::Result<()> {
+    let rendered = format!(
+        "{}\n",
+        serde_json::to_string_pretty(root)
+            .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?
+    );
+    if existing_raw == Some(rendered.as_str()) {
+        return Ok(());
+    }
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    write_atomic(path, rendered.as_bytes())
+}
+
+/// Writes `contents` to a temp file beside `path`, then renames it into place - so a reader (the
+/// user's editor, `cursor-agent` itself starting mid-write) never observes a half-written file.
+fn write_atomic(path: &Path, contents: &[u8]) -> io::Result<()> {
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let temp_name = match path.file_name().and_then(|name| name.to_str()) {
+        Some(name) => format!(".{name}.jerry-tmp-{}", random_suffix()),
+        None => format!(".jerry-tmp-{}", random_suffix()),
+    };
+    let temp_path = parent.join(temp_name);
+    std::fs::write(&temp_path, contents)?;
+    std::fs::rename(&temp_path, path)
+}
+
+/// The substring an entry's `command` must contain to be considered Jerry's own - the forwarder's
+/// *parent directory*, not its exact (version-stamped) file name. See this module's own top-level
+/// docs for why that's the deliberate choice.
+fn managed_marker(forwarder_path: &Path) -> String {
+    forwarder_path
+        .parent()
+        .unwrap_or(forwarder_path)
+        .to_string_lossy()
+        .into_owned()
+}
+
+/// Whether `entry`'s `command` field contains `marker` - [`managed_marker`]'s consumer.
+fn is_managed_entry(entry: &Value, marker: &str) -> bool {
+    entry
+        .get("command")
+        .and_then(Value::as_str)
+        .is_some_and(|command| command.contains(marker))
+}
+
+/// The real `command` string for one event's managed entry - `<forwarder> <event>` on POSIX
+/// (quoted via [`shell_quote`], reused verbatim from `crate::hooks::settings_file` rather than
+/// re-implementing the same escaping), or the same `powershell.exe -File <forwarder> <event>`
+/// shape `crate::hooks::settings_file::windows_hook_entry` already builds for Claude's settings
+/// file - deliberately parallel, reusing [`powershell_quote`] rather than a second quoter, since
+/// `hooks.json`'s `command` field is executed the same way a shell command line is.
+fn managed_command(forwarder_path: &Path, event: &str) -> io::Result<String> {
+    let forwarder = forwarder_path.to_string_lossy();
+    if cfg!(windows) {
+        let quoted = powershell_quote(&forwarder)?;
+        Ok(format!(
+            "powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -File {quoted} {event}"
+        ))
+    } else {
+        Ok(format!("{} {event}", shell_quote(&forwarder)))
+    }
+}
+
+/// The POSIX forwarder - deliberately parallel to
+/// `crate::hooks::settings_file::UNIX_FORWARDER_SCRIPT`: same safety contract (a no-op without the
+/// `JERRY_*` environment, never propagates curl's exit status, always exits 0), only the request
+/// path differs (`/hook/cursor`, not `/hook` - see `crate::hooks::server`'s second route).
+pub const CURSOR_UNIX_FORWARDER_SCRIPT: &str = r#"#!/bin/sh
+# Written by Jerry (github.com/ColinEspinas/jerry) to forward Cursor Agent CLI hook payloads to
+# the Jerry instance that spawned this agent (GitHub issue #479). Safe to run anywhere, including
+# from a `cursor-agent` session started outside Jerry - `~/.cursor/hooks.json` is one global file,
+# so without the JERRY_* environment variables Jerry injects on the panes it spawns, this exits
+# immediately having done nothing.
+[ -n "$JERRY_HOOK_PORT" ] || exit 0
+[ -n "$JERRY_HOOK_TOKEN" ] || exit 0
+[ -n "$JERRY_AGENT_ID" ] || exit 0
+[ -n "$1" ] || exit 0
+command -v curl >/dev/null 2>&1 || exit 0
+
+# Never propagate curl's exit status: a non-zero exit here would surface as a Cursor hook error. A
+# dead listener must cost nothing. Cursor pipes the hook's JSON payload on this script's own
+# stdin; `--data-binary @-` reads it straight through to curl, never buffered on disk.
+curl --silent --show-error --output /dev/null --max-time 5 \
+  --request POST \
+  --header "Authorization: Bearer $JERRY_HOOK_TOKEN" \
+  --header "Content-Type: application/json" \
+  --data-binary @- \
+  "http://127.0.0.1:$JERRY_HOOK_PORT/hook/cursor?event=$1&agent=$JERRY_AGENT_ID" >/dev/null 2>&1
+
+exit 0
+"#;
+
+/// The Windows PowerShell forwarder - deliberately parallel to
+/// `crate::hooks::settings_file::WINDOWS_FORWARDER_SCRIPT`: identical contract, identical
+/// PowerShell-5.1-on-.NET-Framework argument-escaping approach (see that script's own comments for
+/// the full reasoning, not repeated here), only the request path differs (`/hook/cursor`).
+pub const CURSOR_WINDOWS_FORWARDER_SCRIPT: &str = r#"# Written by Jerry (github.com/ColinEspinas/jerry) to forward Cursor Agent CLI hook payloads to
+# the Jerry instance that spawned this agent (GitHub issue #479). Safe to run anywhere, including
+# from a `cursor-agent` session started outside Jerry - `~/.cursor/hooks.json` is one global file,
+# so without the JERRY_* environment variables Jerry injects on the panes it spawns, this exits
+# immediately having done nothing.
+param([string] $JerryHookEvent = '')
+
+$ErrorActionPreference = 'SilentlyContinue'
+$ProgressPreference = 'SilentlyContinue'
+
+if (-not $env:JERRY_HOOK_PORT) { exit 0 }
+if (-not $env:JERRY_HOOK_TOKEN) { exit 0 }
+if (-not $env:JERRY_AGENT_ID) { exit 0 }
+if (-not $JerryHookEvent) { exit 0 }
+
+# Same CreateProcess-argument-vector escaping as `crate::hooks::settings_file`'s Claude forwarder -
+# see that script's own comments for why this is spelled out by hand rather than handed to
+# ProcessStartInfo.ArgumentList, which does not exist under Windows PowerShell 5.1's .NET
+# Framework runtime.
+function ConvertTo-JerryArgument {
+    param([string] $JerryValue)
+    $JerryEscaped = ''
+    $JerrySlashes = 0
+    foreach ($JerryChar in $JerryValue.ToCharArray()) {
+        if ($JerryChar -eq '\') { $JerrySlashes++; continue }
+        if ($JerryChar -eq '"') {
+            $JerryEscaped += '\' * (2 * $JerrySlashes + 1) + '"'
+            $JerrySlashes = 0
+            continue
+        }
+        if ($JerrySlashes -gt 0) { $JerryEscaped += '\' * $JerrySlashes; $JerrySlashes = 0 }
+        $JerryEscaped += $JerryChar
+    }
+    return '"' + $JerryEscaped + ('\' * (2 * $JerrySlashes)) + '"'
+}
+
+$JerryCurlProcess = $null
+try {
+    $JerryCurl = Join-Path -Path "$env:SystemRoot" -ChildPath 'System32\curl.exe'
+    if (-not (Test-Path -LiteralPath $JerryCurl -PathType Leaf)) {
+        $JerryFound = @(Get-Command -Name 'curl.exe' -CommandType Application -ErrorAction SilentlyContinue)
+        if ($JerryFound.Count -eq 0) { exit 0 }
+        $JerryCurl = $JerryFound[0].Source
+    }
+
+    $JerryArgs = @(
+        '--silent',
+        '--max-time', '5',
+        '--request', 'POST',
+        '--header', "Authorization: Bearer $($env:JERRY_HOOK_TOKEN)",
+        '--header', 'Content-Type: application/json',
+        '--data-binary', '@-',
+        "http://127.0.0.1:$($env:JERRY_HOOK_PORT)/hook/cursor?event=$JerryHookEvent&agent=$($env:JERRY_AGENT_ID)"
+    )
+
+    $JerryStart = New-Object System.Diagnostics.ProcessStartInfo
+    $JerryStart.FileName = $JerryCurl
+    $JerryStart.Arguments = (($JerryArgs | ForEach-Object { ConvertTo-JerryArgument $_ }) -join ' ')
+    $JerryStart.UseShellExecute = $false
+    $JerryStart.CreateNoWindow = $true
+    $JerryStart.RedirectStandardInput = $true
+    $JerryStart.RedirectStandardOutput = $true
+    $JerryStart.RedirectStandardError = $true
+    $JerryCurlProcess = [System.Diagnostics.Process]::Start($JerryStart)
+
+    [void] $JerryCurlProcess.StandardOutput.BaseStream.CopyToAsync([System.IO.Stream]::Null)
+    [void] $JerryCurlProcess.StandardError.BaseStream.CopyToAsync([System.IO.Stream]::Null)
+
+    $JerryStdin = [Console]::OpenStandardInput()
+    try { $JerryStdin.CopyTo($JerryCurlProcess.StandardInput.BaseStream) }
+    finally { $JerryCurlProcess.StandardInput.Close() }
+
+    if (-not $JerryCurlProcess.WaitForExit(10000)) { $JerryCurlProcess.Kill() }
+} catch {
+    # Deliberately swallowed - see `crate::hooks::settings_file::WINDOWS_FORWARDER_SCRIPT`'s own
+    # comment for why every path out of this file must exit 0.
+} finally {
+    if ($JerryCurlProcess) { $JerryCurlProcess.Dispose() }
+}
+
+exit 0
+"#;
+
+#[cfg(test)]
+mod cursor_hooks_file_tests {
+    use std::path::{Path, PathBuf};
+
+    use serde_json::Value;
+
+    use super::{
+        ensure_forwarder_written, install, managed_command, remove_managed_entries,
+        CURSOR_HOOK_EVENTS, FORWARDER_DIR_NAME, HOOK_TIMEOUT_SECS,
+    };
+
+    /// A forwarder path under a fresh tempdir's own `cursor-hooks` directory - mirrors what
+    /// [`forwarder_path`] would produce, without touching the real home directory.
+    fn test_forwarder(root: &Path, version: &str) -> PathBuf {
+        root.join(FORWARDER_DIR_NAME)
+            .join(format!("jerry-cursor-hook-forwarder-{version}.sh"))
+    }
+
+    #[test]
+    fn a_fresh_or_missing_file_gets_created_with_the_six_managed_entries_and_version_1() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let hooks_json = temp.path().join("hooks.json");
+        let forwarder = test_forwarder(temp.path(), "0.1.0");
+
+        install(&hooks_json, &forwarder).expect("install must succeed");
+
+        let raw = std::fs::read_to_string(&hooks_json).expect("file must exist");
+        let parsed: Value = serde_json::from_str(&raw).expect("must be valid JSON");
+        assert_eq!(parsed["version"], 1);
+        let hooks = parsed["hooks"].as_object().expect("a hooks object");
+        assert_eq!(hooks.len(), CURSOR_HOOK_EVENTS.len());
+        for event in CURSOR_HOOK_EVENTS {
+            let entries = hooks[event].as_array().expect("an array");
+            assert_eq!(entries.len(), 1, "{event}: exactly one managed entry");
+            let command = entries[0]["command"].as_str().expect("a command string");
+            assert!(command.contains(&forwarder.to_string_lossy().into_owned()));
+            assert!(command.ends_with(&format!(" {event}")));
+            assert_eq!(entries[0]["timeout"], HOOK_TIMEOUT_SECS);
+        }
+    }
+
+    #[test]
+    fn unrelated_user_authored_hooks_survive_byte_for_byte_alongside_managed_entries() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let hooks_json = temp.path().join("hooks.json");
+        let forwarder = test_forwarder(temp.path(), "0.1.0");
+
+        let original = serde_json::json!({
+            "version": 2,
+            "hooks": {
+                // A different event key entirely, untouched by Jerry.
+                "sessionStart": [{ "command": "/usr/local/bin/some-other-tool --notify", "timeout": 10 }],
+                // The *same* event key Jerry manages, but a real user-authored command under it.
+                "stop": [{ "command": "/home/user/.bin/on-stop.sh", "timeout": 5 }],
+            }
+        });
+        std::fs::write(
+            &hooks_json,
+            serde_json::to_string_pretty(&original).expect("serialize"),
+        )
+        .expect("seed file");
+
+        install(&hooks_json, &forwarder).expect("install must succeed");
+
+        let raw = std::fs::read_to_string(&hooks_json).expect("read");
+        let parsed: Value = serde_json::from_str(&raw).expect("valid JSON");
+        // The user's pinned version survives - only defaulted when absent.
+        assert_eq!(parsed["version"], 2);
+        let session_start = parsed["hooks"]["sessionStart"]
+            .as_array()
+            .expect("sessionStart array");
+        assert_eq!(session_start.len(), 1);
+        assert_eq!(
+            session_start[0]["command"],
+            "/usr/local/bin/some-other-tool --notify"
+        );
+        let stop = parsed["hooks"]["stop"].as_array().expect("stop array");
+        assert_eq!(stop.len(), 2, "the user's own stop entry plus Jerry's own");
+        assert!(stop
+            .iter()
+            .any(|entry| entry["command"] == "/home/user/.bin/on-stop.sh"));
+        assert!(stop.iter().any(|entry| entry["command"]
+            .as_str()
+            .is_some_and(|command| command.contains(&forwarder.to_string_lossy().into_owned()))));
+    }
+
+    #[test]
+    fn a_stale_entry_from_an_older_forwarder_version_under_the_same_stable_directory_is_swept() {
+        // Decision (a) from GitHub issue #479's design comment: matching is on the forwarder's
+        // stable *parent directory*, not its exact version-stamped file name - the same reasoning
+        // `crate::hooks::settings_file`'s `DIRECTORY_PREFIX`/`sweep_stale_directories` already
+        // uses for the Claude forwarder's launch directories. An entry a previous Jerry version
+        // wrote must be swept and replaced, not accumulate as an orphan on every upgrade.
+        let temp = tempfile::tempdir().expect("temp dir");
+        let hooks_json = temp.path().join("hooks.json");
+        let old_forwarder = test_forwarder(temp.path(), "0.1.0");
+        let new_forwarder = test_forwarder(temp.path(), "0.2.0");
+
+        install(&hooks_json, &old_forwarder).expect("first install");
+        install(&hooks_json, &new_forwarder).expect("second install, newer version");
+
+        let raw = std::fs::read_to_string(&hooks_json).expect("read");
+        let parsed: Value = serde_json::from_str(&raw).expect("valid JSON");
+        for event in CURSOR_HOOK_EVENTS {
+            let entries = parsed["hooks"][event].as_array().expect("an array");
+            assert_eq!(
+                entries.len(),
+                1,
+                "{event}: the old version's entry must be swept, not accumulated"
+            );
+            assert!(entries[0]["command"].as_str().is_some_and(
+                |command| command.contains(&new_forwarder.to_string_lossy().into_owned())
+            ));
+        }
+    }
+
+    #[test]
+    fn an_unrelated_tools_entry_under_a_different_directory_is_never_touched() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let hooks_json = temp.path().join("hooks.json");
+        let forwarder = test_forwarder(temp.path(), "0.1.0");
+
+        let original = serde_json::json!({
+            "hooks": { "stop": [{ "command": "/opt/someone-elses/tool/hook.sh stop", "timeout": 5 }] }
+        });
+        std::fs::write(
+            &hooks_json,
+            serde_json::to_string_pretty(&original).expect("serialize"),
+        )
+        .expect("seed file");
+
+        install(&hooks_json, &forwarder).expect("install");
+        remove_managed_entries(&hooks_json, &forwarder).expect("remove");
+
+        let raw = std::fs::read_to_string(&hooks_json).expect("read");
+        let parsed: Value = serde_json::from_str(&raw).expect("valid JSON");
+        let stop = parsed["hooks"]["stop"].as_array().expect("stop array");
+        assert_eq!(stop.len(), 1);
+        assert_eq!(stop[0]["command"], "/opt/someone-elses/tool/hook.sh stop");
+    }
+
+    #[test]
+    fn unparseable_existing_json_is_left_byte_for_byte_untouched() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let hooks_json = temp.path().join("hooks.json");
+        let forwarder = test_forwarder(temp.path(), "0.1.0");
+        std::fs::write(&hooks_json, b"{ not valid json at all").expect("seed file");
+        let before = std::fs::read(&hooks_json).expect("read before");
+
+        let result = install(&hooks_json, &forwarder);
+
+        assert!(result.is_ok(), "must not surface a hard error: {result:?}");
+        let after = std::fs::read(&hooks_json).expect("read after");
+        assert_eq!(before, after, "an unparseable file must never be rewritten");
+    }
+
+    #[test]
+    fn a_json_array_root_is_also_refused_rather_than_treated_as_mergeable() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let hooks_json = temp.path().join("hooks.json");
+        let forwarder = test_forwarder(temp.path(), "0.1.0");
+        std::fs::write(&hooks_json, b"[]").expect("seed file");
+
+        install(&hooks_json, &forwarder).expect("must not error");
+
+        let after = std::fs::read(&hooks_json).expect("read after");
+        assert_eq!(after, b"[]", "a non-object root must never be rewritten");
+    }
+
+    #[test]
+    fn installing_twice_in_a_row_is_a_real_no_op_the_second_time() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let hooks_json = temp.path().join("hooks.json");
+        let forwarder = test_forwarder(temp.path(), "0.1.0");
+
+        install(&hooks_json, &forwarder).expect("first install");
+        let mtime_after_first = std::fs::metadata(&hooks_json)
+            .expect("metadata")
+            .modified()
+            .expect("mtime");
+
+        // A real, observable delay so a second write (if one happened) would produce a strictly
+        // later mtime on every platform's filesystem timestamp resolution.
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        install(&hooks_json, &forwarder).expect("second install");
+        let mtime_after_second = std::fs::metadata(&hooks_json)
+            .expect("metadata")
+            .modified()
+            .expect("mtime");
+
+        assert_eq!(
+            mtime_after_first, mtime_after_second,
+            "the second install must not have written the file at all"
+        );
+    }
+
+    #[test]
+    fn remove_managed_entries_drops_now_empty_event_keys_but_leaves_other_user_keys_alone() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let hooks_json = temp.path().join("hooks.json");
+        let forwarder = test_forwarder(temp.path(), "0.1.0");
+
+        let original = serde_json::json!({
+            "hooks": {
+                "sessionStart": [{ "command": "/usr/local/bin/some-other-tool", "timeout": 10 }],
+                "stop": [{ "command": "/home/user/.bin/on-stop.sh", "timeout": 5 }],
+            }
+        });
+        std::fs::write(
+            &hooks_json,
+            serde_json::to_string_pretty(&original).expect("serialize"),
+        )
+        .expect("seed file");
+        install(&hooks_json, &forwarder).expect("install");
+
+        remove_managed_entries(&hooks_json, &forwarder).expect("remove");
+
+        let raw = std::fs::read_to_string(&hooks_json).expect("read");
+        let parsed: Value = serde_json::from_str(&raw).expect("valid JSON");
+        let hooks = parsed["hooks"].as_object().expect("hooks object");
+        // Every event Jerry manages but that had no user entry alongside it must be gone
+        // entirely, not left as an empty array.
+        for event in CURSOR_HOOK_EVENTS {
+            if event == "stop" {
+                continue;
+            }
+            assert!(
+                !hooks.contains_key(event),
+                "{event}: must be removed entirely"
+            );
+        }
+        // `stop` had a real user entry too, so the key survives with just that entry left.
+        let stop = hooks["stop"].as_array().expect("stop array");
+        assert_eq!(stop.len(), 1);
+        assert_eq!(stop[0]["command"], "/home/user/.bin/on-stop.sh");
+        // Untouched, unrelated key.
+        assert_eq!(
+            hooks["sessionStart"][0]["command"],
+            "/usr/local/bin/some-other-tool"
+        );
+    }
+
+    #[test]
+    fn remove_managed_entries_on_a_missing_file_creates_nothing() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let hooks_json = temp.path().join("hooks.json");
+        let forwarder = test_forwarder(temp.path(), "0.1.0");
+
+        remove_managed_entries(&hooks_json, &forwarder).expect("must not error");
+
+        assert!(!hooks_json.exists(), "nothing must be created");
+    }
+
+    #[test]
+    fn ensure_forwarder_written_produces_a_real_owner_executable_file_and_is_idempotent() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let path = temp.path().join(FORWARDER_DIR_NAME).join("forwarder.sh");
+
+        ensure_forwarder_written(&path).expect("first write");
+        assert!(path.is_file());
+        let mtime_first = std::fs::metadata(&path)
+            .expect("metadata")
+            .modified()
+            .expect("mtime");
+
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        ensure_forwarder_written(&path).expect("second write");
+        let mtime_second = std::fs::metadata(&path)
+            .expect("metadata")
+            .modified()
+            .expect("mtime");
+        assert_eq!(
+            mtime_first, mtime_second,
+            "identical content must not be rewritten"
+        );
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = path.metadata().expect("metadata").permissions().mode() & 0o777;
+            assert_eq!(mode, 0o700);
+        }
+    }
+
+    #[test]
+    fn the_managed_command_carries_the_event_name_and_the_forwarder_path() {
+        let forwarder = PathBuf::from(
+            "/home/user/.config/jerry/cursor-hooks/jerry-cursor-hook-forwarder-0.1.0.sh",
+        );
+        for event in CURSOR_HOOK_EVENTS {
+            let command = managed_command(&forwarder, event).expect("must build");
+            if cfg!(windows) {
+                assert!(command.starts_with("powershell.exe "));
+            } else {
+                assert!(command.contains(&forwarder.to_string_lossy().into_owned()));
+            }
+            assert!(command.ends_with(&format!(" {event}")));
+        }
+    }
+}

--- a/crates/app/src/hooks/event.rs
+++ b/crates/app/src/hooks/event.rs
@@ -147,7 +147,10 @@ pub struct HookReport {
 impl HookReport {
     /// A report carrying only a state fact - the common case for the turn-boundary events, which
     /// have no text worth rendering (see the module docs on `last_assistant_message`).
-    fn bare(fact: HookFact) -> HookReport {
+    ///
+    /// `pub(crate)`: `crate::hooks::cursor_event` builds every one of its own reports off this
+    /// too, rather than repeating the same all-`None` literal for a second agent kind.
+    pub(crate) fn bare(fact: HookFact) -> HookReport {
         HookReport {
             kind: EventKind::Transition,
             fact,
@@ -163,7 +166,10 @@ impl HookReport {
 /// Truncates on a real `char` boundary, appending an ellipsis only when something was actually
 /// cut. Returns `None` for text that is empty or whitespace-only, so a present-but-blank JSON
 /// field is treated as the absence of information rather than rendered as an empty row.
-fn truncated(text: &str, max_chars: usize) -> Option<String> {
+///
+/// `pub(crate)`: `crate::hooks::cursor_event` reuses this for the same truncation, rather than a
+/// second implementation of the same rule.
+pub(crate) fn truncated(text: &str, max_chars: usize) -> Option<String> {
     let text = text.trim();
     if text.is_empty() {
         return None;

--- a/crates/app/src/hooks/flow.rs
+++ b/crates/app/src/hooks/flow.rs
@@ -1,6 +1,6 @@
 //! Recording what the hooks taught Jerry about each agent, onto disk (GitHub issue #239 phase 2).
 
-use gpui::{Context, Window};
+use gpui::{AppContext as _, Context, Window};
 
 use crate::root::AdeApp;
 use crate::work_surface::agents::ProcessKind;
@@ -100,7 +100,16 @@ impl AdeApp {
         kind: crate::work_surface::agents::ProcessKind,
     ) -> Option<crate::hooks::HookInjection> {
         use crate::work_surface::agents::{AgentKind, ProcessKind};
-        if !matches!(kind, ProcessKind::Agent(AgentKind::Claude)) {
+        let wants_injection = match kind {
+            ProcessKind::Agent(AgentKind::Claude) => true,
+            // Opt-in (GitHub issue #479): unlike Claude's per-launch, entirely Jerry-owned
+            // `--settings <path>`, a Cursor injection implies a real write into
+            // `~/.cursor/hooks.json`, a file the user owns - see `crate::settings::store::Settings`'s
+            // `agents.cursor_hooks_enabled` and this app's own Agents settings page toggle.
+            ProcessKind::Agent(AgentKind::Cursor) => self.settings.agents.cursor_hooks_enabled,
+            _ => false,
+        };
+        if !wants_injection {
             return None;
         }
         // Bring-up is attempted exactly once per `AdeApp`. Keyed on a `tried` flag rather than on
@@ -116,6 +125,48 @@ impl AdeApp {
         self.hook_runtime
             .as_ref()
             .map(|runtime| runtime.injection())
+    }
+
+    /// Reconciles `~/.cursor/hooks.json` against the current `agents.cursor_hooks_enabled`
+    /// setting (GitHub issue #479): installs Jerry's managed entries when it's on, removes them
+    /// when it's off. Called once at startup (`Self::start_update_check_loop`'s own call site in
+    /// `crate::root::state`) so a stale entry from an older forwarder version, or a toggle flipped
+    /// while the app was closed, self-heals - and again immediately whenever the setting itself
+    /// flips, so turning it on or off has a real, immediate effect rather than "next restart".
+    /// Every real filesystem call happens on the background executor
+    /// (`crate::hooks::cursor_hooks_file`'s own I/O is all synchronous, like every other module
+    /// under `crate::hooks`) - never on the UI thread, per this codebase's GPUI blocking-call rule.
+    ///
+    /// A no-op under `cfg!(test)`: this is the one piece of hook wiring that would otherwise touch
+    /// the *real* user's home directory rather than a test-owned tempdir (every other hooks test
+    /// passes its own paths straight into `crate::hooks::cursor_hooks_file`'s pure functions),
+    /// mirroring `crate::updater::state::UPDATE_CHECK_ENABLED`'s identical reasoning for why a
+    /// background side effect with a real external footprint must not run under the test harness.
+    pub(crate) fn reconcile_cursor_hooks(&mut self, cx: &mut Context<Self>) {
+        if cfg!(test) {
+            return;
+        }
+        let enabled = self.settings.agents.cursor_hooks_enabled;
+        cx.background_spawn(async move {
+            let (Some(hooks_json), Some(forwarder)) = (
+                crate::hooks::cursor_hooks_file::hooks_json_path(),
+                crate::hooks::cursor_hooks_file::forwarder_path(),
+            ) else {
+                log::warn!("could not resolve a home directory - Cursor agent hooks are skipped");
+                return;
+            };
+            let result = if enabled {
+                crate::hooks::cursor_hooks_file::ensure_forwarder_written(&forwarder).and_then(
+                    |()| crate::hooks::cursor_hooks_file::install(&hooks_json, &forwarder),
+                )
+            } else {
+                crate::hooks::cursor_hooks_file::remove_managed_entries(&hooks_json, &forwarder)
+            };
+            if let Err(err) = result {
+                log::warn!("could not reconcile {}: {err}", hooks_json.display());
+            }
+        })
+        .detach();
     }
 
     /// Folds every live agent's current real state into the persisted record, and writes the file

--- a/crates/app/src/hooks/mod.rs
+++ b/crates/app/src/hooks/mod.rs
@@ -1,5 +1,7 @@
 //! A real, structural status side-channel for Claude Code agents (GitHub issue #239, phase 2).
 
+pub mod cursor_event;
+pub mod cursor_hooks_file;
 pub mod event;
 pub mod flow;
 pub mod history;
@@ -124,5 +126,16 @@ impl HookInjection {
             (settings_file::AGENT_ENV.to_owned(), id.to_string()),
         ];
         Some((args, env))
+    }
+
+    /// The environment-only counterpart of [`Self::spawn_extras`], for an agent CLI with no
+    /// `--settings <path>`-equivalent flag (`cursor-agent`, GitHub issue #479) - just the same
+    /// `PORT_ENV`/`TOKEN_ENV`/`AGENT_ENV` triplet, with no extra CLI arguments to prepend.
+    pub fn env_only(&self, id: AgentId) -> Vec<(String, String)> {
+        vec![
+            (settings_file::PORT_ENV.to_owned(), self.port.to_string()),
+            (settings_file::TOKEN_ENV.to_owned(), self.token.clone()),
+            (settings_file::AGENT_ENV.to_owned(), id.to_string()),
+        ]
     }
 }

--- a/crates/app/src/hooks/server.rs
+++ b/crates/app/src/hooks/server.rs
@@ -7,6 +7,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
+use crate::hooks::cursor_event;
 use crate::hooks::event::{self, EditedFile, HookFact, HookReport, MAX_PAYLOAD_BYTES};
 use crate::work_surface::agents::AgentId;
 
@@ -639,9 +640,14 @@ fn read_and_record(
         Some((path, query)) => (path, query),
         None => (target, ""),
     };
-    if path != "/hook" {
-        return Some(Response::NotFound);
-    }
+    // The route decides only which parser turns a payload into a `HookReport` - the auth, body
+    // bounding, and everything downstream of getting one (edits/inbox recording) stay identical
+    // and agent-agnostic (GitHub issue #479's second route, `/hook/cursor`).
+    let parse: fn(&str, &[u8]) -> Option<HookReport> = match path {
+        "/hook" => event::parse,
+        "/hook/cursor" => cursor_event::parse,
+        _ => return Some(Response::NotFound),
+    };
 
     // -- bound the body by the declared length before buffering any of it --
     let length = content_length?;
@@ -661,7 +667,7 @@ fn read_and_record(
     // An unparseable or absent agent id is a real, expected case (the forwarder ran outside a
     // Jerry-spawned pane, or a hand-made request): accept the request so the client isn't left
     // retrying, but record nothing - there is no row it could belong to.
-    if let (Some(agent_id), Some(report)) = (agent_id, event::parse(&event_name, &body)) {
+    if let (Some(agent_id), Some(report)) = (agent_id, parse(&event_name, &body)) {
         // The edit is appended *before* the inbox merge and from the same parse, so it is never
         // affected by `merge_nudge` deciding the report itself is superseded - a file really was
         // written whatever the row's status ends up saying (GitHub issue #284).
@@ -766,10 +772,16 @@ mod tests {
     }
 
     fn post(port: u16, token: &str, query: &str, body: &str) -> String {
+        post_to(port, token, "/hook", query, body)
+    }
+
+    /// [`post`], with the request path parameterized - GitHub issue #479's second route,
+    /// `/hook/cursor`, is exercised through this rather than a separate near-duplicate helper.
+    fn post_to(port: u16, token: &str, path: &str, query: &str, body: &str) -> String {
         raw_request(
             port,
             &format!(
-                "POST /hook?{query} HTTP/1.1\r\nHost: 127.0.0.1\r\nAuthorization: Bearer {token}\r\nContent-Length: {}\r\n\r\n{body}",
+                "POST {path}?{query} HTTP/1.1\r\nHost: 127.0.0.1\r\nAuthorization: Bearer {token}\r\nContent-Length: {}\r\n\r\n{body}",
                 body.len()
             ),
         )
@@ -966,6 +978,54 @@ mod tests {
         assert_eq!(activity.as_deref(), Some("Bash: cargo test"));
         assert_eq!(question, None);
         assert_eq!(listener.signal_for(8).fact, None);
+    }
+
+    #[test]
+    fn a_real_tokened_post_to_the_cursor_route_round_trips_through_the_cursor_parser() {
+        // GitHub issue #479's second route: `/hook/cursor` must dispatch to
+        // `crate::hooks::cursor_event::parse`, not `event::parse` - a Cursor-shaped payload
+        // (`conversation_id`, `preToolUse`) is not valid under Claude's own schema at all, so a
+        // round trip through the *wrong* parser would record nothing rather than the right fact.
+        let listener = HookListener::start().expect("listener must start");
+        let body = r#"{"conversation_id":"conv-9","tool_name":"Bash"}"#;
+        let response = post_to(
+            listener.port(),
+            listener.token(),
+            "/hook/cursor",
+            "event=preToolUse&agent=42",
+            body,
+        );
+        assert!(
+            response.starts_with("HTTP/1.1 204"),
+            "expected 204, got {response:?}"
+        );
+        assert_eq!(listener.signal_for(42).fact, Some(HookFact::Working));
+        assert_eq!(
+            listener.text_for(42).0.as_deref(),
+            Some("Bash"),
+            "the Cursor parser's own activity formatting must be the one that ran"
+        );
+        assert_eq!(
+            listener.session_id_for(42).as_deref(),
+            Some("conv-9"),
+            "conversation_id is Cursor's session_id equivalent"
+        );
+    }
+
+    #[test]
+    fn an_unknown_route_is_a_real_404_not_a_silent_accept() {
+        let listener = HookListener::start().expect("listener must start");
+        let response = post_to(
+            listener.port(),
+            listener.token(),
+            "/hook/not-a-real-route",
+            "event=Stop&agent=1",
+            "{}",
+        );
+        assert!(
+            response.starts_with("HTTP/1.1 404"),
+            "expected 404, got {response:?}"
+        );
     }
 
     #[test]

--- a/crates/app/src/hooks/settings_file.rs
+++ b/crates/app/src/hooks/settings_file.rs
@@ -392,7 +392,10 @@ fn process_is_alive(pid: u32) -> bool {
 }
 
 /// A short random, hex-encoded suffix - see [`create_private_dir`].
-fn random_suffix() -> String {
+///
+/// `pub(crate)`: `crate::hooks::cursor_hooks_file`'s own atomic-write temp file name reuses this
+/// rather than a second random-suffix implementation.
+pub(crate) fn random_suffix() -> String {
     use rand::RngCore;
     let mut bytes = [0u8; 8];
     rand::rng().fill_bytes(&mut bytes);
@@ -469,7 +472,11 @@ pub fn windows_hook_entry(forwarder: &str, event: &str) -> io::Result<serde_json
 /// Wraps `value` in POSIX single quotes, escaping any single quote inside it via the standard
 /// `'\''` idiom. Single quotes are used rather than double because inside them the shell expands
 /// nothing at all - so a path containing `$`, backticks or `\` is passed through literally.
-fn shell_quote(value: &str) -> String {
+///
+/// `pub(crate)` rather than private: `crate::hooks::cursor_hooks_file` reuses this verbatim for
+/// the Cursor forwarder's own `hooks.json` command string (GitHub issue #479), rather than
+/// re-implementing the same escaping a second time.
+pub(crate) fn shell_quote(value: &str) -> String {
     format!("'{}'", value.replace('\'', r"'\''"))
 }
 

--- a/crates/app/src/root/state.rs
+++ b/crates/app/src/root/state.rs
@@ -929,6 +929,13 @@ impl AdeApp {
         // start_update_check_loop`'s own docs. Unconditional for the same reason the keybindings/
         // theme setup above is: it has nothing to do with which (if any) repo is focused.
         this.start_update_check_loop(cx);
+        // GitHub issue #479: reconciles `~/.cursor/hooks.json` against the current
+        // `agents.cursor_hooks_enabled` setting on every launch, not only when the setting is
+        // first turned on - see `crate::hooks::flow::AdeApp::reconcile_cursor_hooks`'s own docs
+        // for why that self-heals a stale entry from an older forwarder version or a toggle
+        // flipped while the app was closed. Unconditional for the same reason the update check
+        // above is: it has nothing to do with which (if any) repo is focused.
+        this.reconcile_cursor_hooks(cx);
         // GitHub issue #294: the per-provider rate-limit budget poll. Unconditional like the
         // update check above, and for the same reason - it has nothing to do with which (if any)
         // repo is focused. It polls nothing at all until there is a real agent session to show a

--- a/crates/app/src/settings/render.rs
+++ b/crates/app/src/settings/render.rs
@@ -534,6 +534,50 @@ impl AdeApp {
                     }))
                     .child(self.render_settings_agents_footer()),
             )
+            .child(
+                div()
+                    .pt(px(20.0))
+                    .pb(px(6.0))
+                    .font(font(theme::font::SANS))
+                    .font_weight(gpui::FontWeight::SEMIBOLD)
+                    .text_size(px(9.5))
+                    .text_color(theme::palette::GROUP_HEADER)
+                    .child("Hooks"),
+            )
+            .child(
+                div()
+                    .flex()
+                    .flex_col()
+                    .rounded(theme::radius::CARD)
+                    .border_1()
+                    .border_color(theme::border::CARD)
+                    .overflow_hidden()
+                    .child(self.render_settings_row(
+                        "Cursor agent hooks",
+                        "Writes a small, reversible entry into your own ~/.cursor/hooks.json so a \
+                         Cursor agent Jerry spawns reports real status into the rail and History - \
+                         off by default. A Cursor session started outside Jerry is unaffected \
+                         either way, and nothing is ever written into any repository or worktree.",
+                        self.render_toggle_control(
+                            "settings-cursor-hooks-enabled",
+                            self.settings.agents.cursor_hooks_enabled,
+                            cx,
+                            |this, cx| this.toggle_cursor_hooks_enabled(cx),
+                        ),
+                    )),
+            )
+    }
+
+    /// Flips `agents.cursor_hooks_enabled` (GitHub issue #479), persists it, and immediately
+    /// reconciles `~/.cursor/hooks.json` against the new value - installing Jerry's managed
+    /// entries when turning it on, removing them when turning it off - rather than leaving that
+    /// for the next restart. See `crate::hooks::flow::AdeApp::reconcile_cursor_hooks`'s own docs
+    /// for why the real filesystem work happens on the background executor.
+    fn toggle_cursor_hooks_enabled(&mut self, cx: &mut Context<Self>) {
+        self.settings.agents.cursor_hooks_enabled = !self.settings.agents.cursor_hooks_enabled;
+        self.persist_settings(cx);
+        self.reconcile_cursor_hooks(cx);
+        cx.notify();
     }
 
     pub(in crate::settings) fn render_settings_agent_row(
@@ -7887,6 +7931,116 @@ mod bracket_pair_colorization_settings_tests {
                 .settings
                 .appearance
                 .bracket_pair_colorization),
+            "and clicking it again must flip it back"
+        );
+    }
+}
+
+/// GitHub issue #479's Agents page toggle - same real-mutator-and-real-click shape
+/// `bracket_pair_colorization_settings_tests` already established, plus the "off by default"
+/// assertion that's the whole point of this setting differing from Superset's own equivalent.
+#[cfg(test)]
+mod cursor_hooks_settings_tests {
+    use crate::root::{AdeApp, ToggleSettings};
+    use crate::settings::state::SettingsPage;
+    use crate::settings::store as settings_store;
+    use gpui::TestAppContext;
+    use std::path::PathBuf;
+
+    fn open_app_with_state_dir(
+        cx: &mut TestAppContext,
+        repo_path: PathBuf,
+        settings_path: PathBuf,
+    ) -> (gpui::Entity<AdeApp>, &mut gpui::VisualTestContext) {
+        let settings = settings_store::Settings::load_or_init_at(&settings_path);
+        cx.add_window_view(|window, cx| {
+            AdeApp::new_with_settings(
+                Some(repo_path),
+                true,
+                settings,
+                Some(settings_path),
+                window,
+                cx,
+            )
+        })
+    }
+
+    #[gpui::test]
+    fn toggle_cursor_hooks_enabled_flips_the_real_setting_and_persists_across_reload(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let state_dir = tempfile::tempdir().expect("tempdir");
+        let settings_path = state_dir.path().join("settings.toml");
+        let (app, cx) =
+            open_app_with_state_dir(cx, repo.path().to_path_buf(), settings_path.clone());
+
+        assert!(
+            !app.read_with(cx, |app, _| app.settings.agents.cursor_hooks_enabled),
+            "sanity check: off by default - an explicit opt-in, unlike Superset's equivalent"
+        );
+
+        app.update(cx, |app, cx| {
+            app.toggle_cursor_hooks_enabled(cx);
+        });
+        assert!(
+            app.read_with(cx, |app, _| app.settings.agents.cursor_hooks_enabled),
+            "the real Settings field must have flipped on"
+        );
+        cx.run_until_parked();
+
+        let (reloaded, cx) = open_app_with_state_dir(cx, repo.path().to_path_buf(), settings_path);
+        assert!(
+            reloaded.read_with(cx, |app, _| app.settings.agents.cursor_hooks_enabled),
+            "the toggle must have really been persisted to disk, not just flipped in memory"
+        );
+
+        app.update(cx, |app, cx| {
+            app.toggle_cursor_hooks_enabled(cx);
+        });
+        assert!(
+            !app.read_with(cx, |app, _| app.settings.agents.cursor_hooks_enabled),
+            "the real Settings field must have flipped back off"
+        );
+    }
+
+    #[gpui::test]
+    fn the_agents_page_row_paints_and_clicking_it_flips_the_real_setting(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let state_dir = tempfile::tempdir().expect("tempdir");
+        let settings_path = state_dir.path().join("settings.toml");
+        let (app, cx) = open_app_with_state_dir(cx, repo.path().to_path_buf(), settings_path);
+
+        cx.dispatch_action(ToggleSettings);
+        app.update_in(cx, |app, window, cx| {
+            app.select_settings_page(SettingsPage::Agents, window, cx);
+        });
+        cx.run_until_parked();
+        app.update(cx, |app, cx| {
+            app.settings_content_scroll_handle.scroll_to_bottom();
+            cx.notify();
+        });
+        cx.run_until_parked();
+
+        let bounds = cx
+            .debug_bounds("settings-cursor-hooks-enabled")
+            .expect("the Cursor agent hooks toggle must really paint on the Agents page");
+        assert!(
+            !app.read_with(cx, |app, _| app.settings.agents.cursor_hooks_enabled),
+            "premise: off before the click"
+        );
+
+        cx.simulate_click(bounds.center(), gpui::Modifiers::none());
+        cx.run_until_parked();
+        assert!(
+            app.read_with(cx, |app, _| app.settings.agents.cursor_hooks_enabled),
+            "clicking the real row must flip the real setting"
+        );
+
+        cx.simulate_click(bounds.center(), gpui::Modifiers::none());
+        cx.run_until_parked();
+        assert!(
+            !app.read_with(cx, |app, _| app.settings.agents.cursor_hooks_enabled),
             "and clicking it again must flip it back"
         );
     }

--- a/crates/app/src/settings/store.rs
+++ b/crates/app/src/settings/store.rs
@@ -30,6 +30,24 @@ pub struct Settings {
     pub icon_pack: IconPackSettings,
     pub lsp: BTreeMap<String, LspServerSettings>,
     pub sound: SoundSettings,
+    pub agents: AgentsSettings,
+}
+
+/// Settings about the agent CLIs themselves, rather than about the Jerry UI around them - separate
+/// from [`TerminalSettings`] (which is about *shell* spawn behaviour) for the same reason that
+/// section is its own key rather than folded into [`AppearanceSettings`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct AgentsSettings {
+    /// GitHub issue #479: whether Jerry writes its managed forwarder entries into
+    /// `~/.cursor/hooks.json` so a Jerry-spawned `cursor-agent` reports real status into the rail
+    /// and History. Off by default - an explicit, reversible opt-in, unlike Superset's own
+    /// default-on equivalent (see issue #479's design comment for the incident report that
+    /// argues for being stricter here) - because this genuinely writes into a file the user owns,
+    /// even though the entries themselves are inert for any `cursor-agent` session Jerry didn't
+    /// spawn (`crate::hooks::cursor_hooks_file`'s forwarder scripts no-op without Jerry's own
+    /// environment).
+    pub cursor_hooks_enabled: bool,
 }
 
 /// The integrated terminal's own behavioural settings (GitHub issue #213: "Allow to select
@@ -1561,6 +1579,30 @@ mod tests {
             Settings::load_or_init_at(&path).terminal.shell.as_deref(),
             Some("fish")
         );
+    }
+
+    #[test]
+    fn cursor_hooks_enabled_defaults_off_and_round_trips_through_a_real_file() {
+        // GitHub issue #479: explicit opt-in, off by default - see `AgentsSettings`'s own docs
+        // for why this deliberately differs from Superset's default-on equivalent.
+        assert!(!Settings::default().agents.cursor_hooks_enabled);
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("settings.toml");
+
+        let mut configured = Settings::default();
+        configured.agents.cursor_hooks_enabled = true;
+        configured.save_at(&path).expect("write configured");
+
+        assert!(Settings::load_or_init_at(&path).agents.cursor_hooks_enabled);
+
+        // An install that has never touched this setting still gets a real, loadable file with
+        // no `[agents]` section written for it at all - `#[serde(default)]` covers the gap.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("settings.toml");
+        std::fs::write(&path, "[terminal]\nshell = \"fish\"\n")
+            .expect("write a file with no agents section");
+        assert!(!Settings::load_or_init_at(&path).agents.cursor_hooks_enabled);
     }
 
     #[test]

--- a/crates/app/src/terminal/pane.rs
+++ b/crates/app/src/terminal/pane.rs
@@ -634,6 +634,10 @@ pub enum TerminalPaneEvent {
     /// pane's rendered grid - `path` is already resolved against this pane's own
     /// `TerminalSpec::cwd` (see [`render_link_span`]), never a bare, unresolved string.
     OpenPath { path: PathBuf, line: Option<u32> },
+    /// This pane's child process exited and its real [`ExitStatus`] was observed. `clean` is
+    /// that status' own `success()` - a `0` exit and no signal, i.e. the process was asked to
+    /// quit (`exit`, `/quit`, `Ctrl-D`) rather than having crashed or been killed.
+    ProcessExited { clean: bool },
 }
 
 pub struct TerminalPane {
@@ -1762,7 +1766,9 @@ impl TerminalPane {
                     }
 
                     if let Some(status) = newly_exited {
+                        let clean = status.success();
                         this.exit_status = Some(status);
+                        cx.emit(TerminalPaneEvent::ProcessExited { clean });
                     }
 
                     if process_ended {
@@ -3430,6 +3436,80 @@ mod pane_teardown_tests {
                  real-pty test in this file leaks a process if this stops holding"
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod process_exit_event_tests {
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    use gpui::TestAppContext;
+
+    use super::pty_pane_fixtures::{pump_until, release, spawn_pane};
+    use super::TerminalPaneEvent;
+
+    /// A real child process that does nothing but exit with `code`, spelled for this platform's
+    /// own always-present interpreter - `cmd.exe` ships with every Windows install, `/bin/sh`
+    /// with every unix one, so neither spelling depends on a POSIX toolchain being on `PATH`.
+    fn exiting_pane(cx: &mut TestAppContext, code: u8) -> gpui::Entity<super::TerminalPane> {
+        let script = format!("exit {code}");
+        #[cfg(windows)]
+        let (program, args) = ("cmd", ["/c", script.as_str()]);
+        #[cfg(unix)]
+        let (program, args) = ("sh", ["-c", script.as_str()]);
+        spawn_pane(cx, program, &args)
+    }
+
+    /// Collects every [`TerminalPaneEvent`] the pane emits for the rest of the test.
+    fn watch(
+        cx: &mut TestAppContext,
+        pane: &gpui::Entity<super::TerminalPane>,
+    ) -> (Rc<RefCell<Vec<TerminalPaneEvent>>>, gpui::Subscription) {
+        let seen = Rc::new(RefCell::new(Vec::new()));
+        let recorder = Rc::clone(&seen);
+        let subscription = cx.update(|cx| {
+            cx.subscribe(pane, move |_pane, event: &TerminalPaneEvent, _cx| {
+                recorder.borrow_mut().push(event.clone());
+            })
+        });
+        (seen, subscription)
+    }
+
+    #[gpui::test]
+    fn a_process_that_exits_zero_reports_a_clean_exit(cx: &mut TestAppContext) {
+        let pane = exiting_pane(cx, 0);
+        let (seen, _subscription) = watch(cx, &pane);
+
+        assert!(
+            pump_until(cx, |_cx| !seen.borrow().is_empty()),
+            "the real child exited, so its pane must announce that exit"
+        );
+        assert_eq!(
+            seen.borrow().as_slice(),
+            [TerminalPaneEvent::ProcessExited { clean: true }],
+            "`exit 0` is the user asking to quit - the one case a tab may close itself over"
+        );
+
+        release(cx, pane);
+    }
+
+    #[gpui::test]
+    fn a_process_that_exits_nonzero_reports_an_unclean_exit(cx: &mut TestAppContext) {
+        let pane = exiting_pane(cx, 3);
+        let (seen, _subscription) = watch(cx, &pane);
+
+        assert!(
+            pump_until(cx, |_cx| !seen.borrow().is_empty()),
+            "a failing child exits just as really as a succeeding one"
+        );
+        assert_eq!(
+            seen.borrow().as_slice(),
+            [TerminalPaneEvent::ProcessExited { clean: false }],
+            "a non-zero exit must not be reported as clean - the pane stays open on it"
+        );
+
+        release(cx, pane);
     }
 }
 

--- a/crates/app/src/work_surface/agents.rs
+++ b/crates/app/src/work_surface/agents.rs
@@ -160,6 +160,27 @@ impl ProcessKind {
 /// `crate::hooks::HookInjection::spawn_extras` and consumed by [`ProcessKind::spec`].
 pub type SpawnExtras = (Vec<String>, Vec<(String, String)>);
 
+/// [`Agent::spawn_inner`]'s hook-injection gate, split out as a pure function so it's directly
+/// unit-testable without a real `TerminalPane` spawn. Claude gets `--settings <path>` plus env
+/// (`HookInjection::spawn_extras`); Cursor (GitHub issue #479) has no such flag, so it gets only
+/// the env triplet (`HookInjection::env_only`) and no extra leading argument - and only when
+/// `hooks` is `Some` at all, which `crate::hooks::flow::AdeApp::hook_injection_for` already
+/// withholds unless the user has opted in via the `cursor_hooks_enabled` setting. Every other
+/// kind (`Codex`, or any kind with no injection offered) gets no extras.
+fn hook_extras_for(
+    kind: ProcessKind,
+    hooks: Option<&crate::hooks::HookInjection>,
+    id: AgentId,
+) -> Option<SpawnExtras> {
+    match (kind, hooks) {
+        (ProcessKind::Agent(AgentKind::Claude), Some(hooks)) => hooks.spawn_extras(id),
+        (ProcessKind::Agent(AgentKind::Cursor), Some(hooks)) => {
+            Some((Vec::new(), hooks.env_only(id)))
+        }
+        _ => None,
+    }
+}
+
 impl From<AgentKind> for ProcessKind {
     fn from(agent: AgentKind) -> Self {
         ProcessKind::Agent(agent)
@@ -391,12 +412,7 @@ impl Agents {
         let id = self.next_id;
         self.next_id += 1;
 
-        // Claude Code only, and gated here rather than inside `spec` so the gate is one
-        // legible line next to the spawn it guards.
-        let hook_extras = match (kind, hooks) {
-            (ProcessKind::Agent(AgentKind::Claude), Some(hooks)) => hooks.spawn_extras(id),
-            _ => None,
-        };
+        let hook_extras = hook_extras_for(kind, hooks, id);
         let extras = if leading_args.is_empty() {
             hook_extras
         } else {
@@ -802,6 +818,41 @@ mod tests {
         assert_eq!(
             spec.env,
             vec![("JERRY_HOOK_PORT".to_owned(), "5000".to_owned())]
+        );
+    }
+
+    #[test]
+    fn cursor_gets_env_only_hook_extras_claude_keeps_its_settings_flag_and_codex_gets_neither() {
+        // GitHub issue #479's real gate, exercised against a real `HookInjection` (not a
+        // hand-built fake tuple) - `cursor-agent` has no `--settings`-equivalent flag, so it must
+        // never receive one, while still getting the same env triplet Claude does.
+        let temp = tempfile::tempdir().expect("tempdir");
+        let runtime = crate::hooks::HookRuntime::start(temp.path()).expect("runtime must start");
+        let injection = runtime.injection();
+
+        let (claude_args, claude_env) = hook_extras_for(ProcessKind::claude(), Some(&injection), 1)
+            .expect("claude must get extras");
+        assert!(
+            claude_args.iter().any(|arg| arg == "--settings"),
+            "claude keeps its --settings flag: {claude_args:?}"
+        );
+        assert!(claude_env.iter().any(|(key, _)| key == "JERRY_HOOK_PORT"));
+
+        let (cursor_args, cursor_env) = hook_extras_for(ProcessKind::cursor(), Some(&injection), 1)
+            .expect("cursor must get extras");
+        assert!(
+            cursor_args.is_empty(),
+            "cursor-agent has no --settings-equivalent flag: {cursor_args:?}"
+        );
+        assert!(cursor_env.iter().any(|(key, _)| key == "JERRY_HOOK_PORT"));
+
+        assert!(
+            hook_extras_for(ProcessKind::codex(), Some(&injection), 1).is_none(),
+            "codex has no hook wiring at all yet"
+        );
+        assert!(
+            hook_extras_for(ProcessKind::cursor(), None, 1).is_none(),
+            "no injection offered (the setting is off) means no extras, not a bare env_only"
         );
     }
 

--- a/crates/app/src/work_surface/agents.rs
+++ b/crates/app/src/work_surface/agents.rs
@@ -213,9 +213,9 @@ pub struct Agent {
     /// `None` for any Cursor pane whose id could not be minted at spawn time - an agent with no
     /// id is simply not resumable, which is what the run-history footer already says.
     pub session_id: Option<String>,
-    /// Keeps [`Agents::spawn`]'s link-click-opens-a-file subscription (see
-    /// [`TerminalPaneEvent`]) alive for this agent's lifetime - never read, only held.
-    _link_subscription: Subscription,
+    /// Keeps [`Agents::spawn`]'s subscription to this agent's pane (see [`TerminalPaneEvent`])
+    /// alive for this agent's lifetime - never read, only held.
+    _pane_subscription: Subscription,
 }
 
 /// Owns every open agent/tab and which one is active.
@@ -422,11 +422,23 @@ impl Agents {
         };
         let spec = kind.spec(cwd.clone(), shell_override, extras);
         let pane = cx.new(|cx| TerminalPane::new(spec, terminal_font_size_px, cx));
-        let link_subscription =
-            cx.subscribe_in(&pane, window, move |app, _pane, event, window, cx| {
-                let TerminalPaneEvent::OpenPath { path, line } = event;
-                app.open_terminal_link(path.clone(), *line, window, cx);
-            });
+        let pane_subscription = cx.subscribe_in(
+            &pane,
+            window,
+            move |app, _pane, event, window, cx| match event {
+                TerminalPaneEvent::OpenPath { path, line } => {
+                    app.open_terminal_link(path.clone(), *line, window, cx);
+                }
+                // A process the user asked to quit takes its tab with it; a crashed or killed
+                // one keeps its pane so its last output, and the footer's Retry/Resume, are
+                // still there to read.
+                TerminalPaneEvent::ProcessExited { clean } => {
+                    if *clean {
+                        app.close_agent(id, window, cx);
+                    }
+                }
+            },
+        );
 
         self.agents.push(Agent {
             id,
@@ -436,7 +448,7 @@ impl Agents {
             spawned_at: Instant::now(),
             spawned_at_unix: unix_now(),
             session_id: None,
-            _link_subscription: link_subscription,
+            _pane_subscription: pane_subscription,
         });
         self.active = Some(id);
         self.active_by_cwd.insert(cwd, id);

--- a/crates/app/src/work_surface/render.rs
+++ b/crates/app/src/work_surface/render.rs
@@ -6256,3 +6256,76 @@ mod agent_picker_tests {
         });
     }
 }
+
+#[cfg(test)]
+mod process_exit_close_tests {
+    use gpui::{Entity, TestAppContext};
+
+    use crate::root::AdeApp;
+    use crate::terminal::pane::{TerminalPane, TerminalPaneEvent};
+    use crate::work_surface::agents::AgentId;
+
+    /// The app's initial shell agent, and the pane whose process exit the tab hangs off.
+    fn initial_agent(
+        app: &Entity<AdeApp>,
+        cx: &mut TestAppContext,
+    ) -> (AgentId, Entity<TerminalPane>) {
+        app.read_with(cx, |app, _| {
+            let agent = app.agents.iter().next().expect("initial shell agent");
+            (agent.id, agent.pane.clone())
+        })
+    }
+
+    fn open_agent_ids(app: &Entity<AdeApp>, cx: &mut TestAppContext) -> Vec<AgentId> {
+        app.read_with(cx, |app, _| {
+            app.agents.iter().map(|agent| agent.id).collect()
+        })
+    }
+
+    #[gpui::test]
+    fn a_clean_process_exit_closes_that_agents_tab(cx: &mut TestAppContext) {
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
+        let (id, pane) = initial_agent(&app, cx);
+        // A sibling tab, so this exercises closing *a* tab rather than emptying the work
+        // surface - the tab strip's own "nothing is open" path is a different test's subject.
+        app.update_in(cx, |app, window, cx| {
+            app.agents.spawn(
+                crate::work_surface::agents::ProcessKind::Shell,
+                repo.path().to_path_buf(),
+                app.settings.appearance.terminal_font_size,
+                app.settings.terminal.shell_override(),
+                None,
+                window,
+                cx,
+            )
+        });
+
+        pane.update(cx, |_pane, cx| {
+            cx.emit(TerminalPaneEvent::ProcessExited { clean: true })
+        });
+        cx.run_until_parked();
+
+        assert!(
+            !open_agent_ids(&app, cx).contains(&id),
+            "typing `exit` into an agent ends that session, so its tab must go with it"
+        );
+    }
+
+    #[gpui::test]
+    fn a_crash_leaves_the_tab_open_to_be_read(cx: &mut TestAppContext) {
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
+        let (id, pane) = initial_agent(&app, cx);
+
+        pane.update(cx, |_pane, cx| {
+            cx.emit(TerminalPaneEvent::ProcessExited { clean: false })
+        });
+        cx.run_until_parked();
+
+        assert!(
+            open_agent_ids(&app, cx).contains(&id),
+            "a failed process's last output, and the footer's Retry, must survive the exit"
+        );
+    }
+}

--- a/crates/wt-core/src/checkout.rs
+++ b/crates/wt-core/src/checkout.rs
@@ -485,8 +485,14 @@ mod tests {
         );
         match result.unwrap_err() {
             Error::GitCommand { stderr, .. } => {
+                // Lowercased on both sides: older git (2.39, still Debian bookworm's default)
+                // capitalizes this message ("Cannot delete branch..."), newer git doesn't - a
+                // wording-only difference across git's own versions, not something this test
+                // should pin to one binary's exact casing.
                 assert!(
-                    stderr.contains("cannot delete branch 'main'"),
+                    stderr
+                        .to_lowercase()
+                        .contains("cannot delete branch 'main'"),
                     "git's own real refusal reason must be preserved verbatim: {stderr}"
                 );
             }

--- a/docs/architecture/decisions.md
+++ b/docs/architecture/decisions.md
@@ -345,3 +345,42 @@ a logged no-breakaway retry for the corner where an outer job forbids it. If job
 self-assignment fails, orphans are again possible; the startup sweep of `jerry-hooks-*`
 directories (`hooks/settings_file.rs`) remains the independent cleanup for what a dead instance
 leaves on disk.
+
+## 12. A hookless agent CLI with no config-path flag gets a merged, opt-in entry in its own global
+config file, never a file inside the worktree
+
+**Status:** Accepted.
+
+**Context:** GitHub issue #239 phase 2 gave Claude Code a real status side-channel by generating a
+whole `--settings <path>` file Jerry owns outright and passing it on the CLI - zero footprint,
+because nothing is shared and nothing is written unless that exact flag is present. `cursor-agent`
+(issue #479) has real, working hooks in the same spawn mode Jerry already uses, but no equivalent
+flag or environment variable to point it at an alternate config: hooks load from exactly four
+fixed locations, and the only one Jerry can reach at all is the user-level
+`~/.cursor/hooks.json` - a file the user owns and other tools may already be managing entries in.
+`<worktree>/.cursor/hooks.json` was considered and rejected: it would appear in Jerry's own
+Changes pane and review diff, and the agent could commit it - dirtying the very surface the diff
+is supposed to review.
+
+**Decision:** For an agent CLI shaped like this - real hooks, no config-path override, config
+loaded from one global, shared, `.json`-with-an-array-of-`{command, timeout}`-entries file - Jerry
+does a real read-modify-write merge (`crates/app/src/hooks/cursor_hooks_file.rs`) rather than
+generating the file outright: unparseable JSON aborts the whole operation untouched, every
+unrelated key and entry survives byte-for-byte, and Jerry's own entries are identified by a
+forwarder script path substring rather than a marker field (the entry shape has no room for one).
+The forwarder script itself moves out of the per-launch, `Drop`-deleted temp directory
+`crates/app/src/hooks/settings_file.rs` uses for Claude into a stable, version-stamped path under
+Jerry's own config dir, because `~/.cursor/hooks.json` outlives any single Jerry process. Because
+this genuinely writes into a file the user owns - unlike Claude's entirely Jerry-owned, per-launch
+`--settings` file - it is gated behind an explicit, default-off setting
+(`Settings.agents.cursor_hooks_enabled`) reconciled (installed or removed) on every launch and
+immediately on toggle, rather than default-on the way a similar integration in another Cursor
+client ships it.
+
+**Consequences:** The forwarder itself stays inert without Jerry's own `JERRY_HOOK_PORT`/
+`JERRY_HOOK_TOKEN`/`JERRY_AGENT_ID` environment, so a `cursor-agent` session started outside Jerry
+is unaffected by the entry's mere presence - the opt-in setting gates whether Jerry *writes* the
+entry, not whether a stray entry could ever do anything on its own. The next agent CLI that is
+hookless-by-default in this same shape (a real hook mechanism, no config-path flag, one shared
+global config file) should read this entry and `cursor_hooks_file.rs` before inventing a new
+merge strategy.


### PR DESCRIPTION
<!-- Closes #479 -->

## What

Gives a Jerry-spawned `cursor-agent` a real status side-channel, the same way Claude Code already
has one, instead of the terminal-title/quiescence fallback #464 deliberately shipped with. A
Cursor agent's status now reports into the rail for real, and shows up under History with a real
`conversation_id`.

Concretely:

- `crates/app/src/hooks/cursor_hooks_file.rs` — a real read-modify-write merge of
  `~/.cursor/hooks.json`: unparseable existing JSON aborts untouched, every unrelated entry
  survives byte-for-byte, and Jerry's own entries are identified by its forwarder script's stable
  directory path rather than a marker field (the entry shape has no room for one). Includes the
  matching Cursor forwarder scripts (POSIX + Windows), parallel to the existing Claude ones.
- `crates/app/src/hooks/cursor_event.rs` — parses the 6 Cursor hook events Jerry subscribes to
  (`beforeSubmitPrompt`, `stop`, `preToolUse`, `postToolUse`, `postToolUseFailure`,
  `afterAgentResponse`) into the same `HookReport`/`HookFact` shape `event.rs` already produces for
  Claude, so everything downstream (inbox, rail status, History) doesn't know or care which agent
  produced it.
- `crates/app/src/hooks/server.rs` — a new `/hook/cursor` route alongside the existing `/hook`.
- A new, explicit, **default-off** `agents.cursor_hooks_enabled` setting with a real toggle on the
  Agents settings page, reconciled (installed or removed) on every launch and immediately on
  toggle - so a stale entry or an offline toggle flip self-heals.
- `docs/architecture/decisions.md` §11 records the design: why this is a merge rather than a
  generated file (unlike Claude's `--settings <path>`), and why it's opt-in rather than default-on.
- A separate, small `test(wt-core)` commit ahead of this one fixes a pre-existing test that
  asserted on the exact casing of one of git's own error messages - unrelated to this feature, but
  needed to get a genuinely green gate in this environment (see that commit's message).

Deliberately **not** in scope for this PR, and explained in the issue's design comment: `sessionStart`/`sessionEnd`
(Orca's own prior-art hazard: they can reset turn-tracking across a resumed session, which Jerry's
`--resume`/`create-chat` sessions are just as exposed to), `beforeShellExecution`/`beforeMCPExecution`
(fire before Cursor's own permission decision, so they can't distinguish "about to block on a
human" from "about to auto-run" - `NeedsInput` stays on the existing title/quiescence fallback),
and file-edit provenance for Cursor (`HookReport.edit` is always `None` - the inner `tool_input`
JSON shape comes from a protobuf `toJson()` call whose exact casing isn't verified against a live
payload; see `cursor_event.rs`'s own module docs).

## Why

See the two comments already posted on #479: prior-art review of Orca's and Superset's own
Cursor-hooks integrations (both real, shipping, public repos), and the resulting design. This PR
implements that design as posted, with one deviation worth calling out: `afterAgentResponse`
carries the assistant's final-message `text` (what Claude gets for free on `Stop`), but threading
it onto the following `stop` report would need per-call state `cursor_event::parse` deliberately
doesn't have - `parse()` stays pure, and `text` is dropped for now rather than the module growing a
second, parallel state-tracking mechanism. Documented in the function's own doc comment.

## Testing

- [x] `/check` passes locally (conventions, fmt, clippy `-D warnings`, `cargo nextest run
      --workspace`) - genuinely green, not skipped
- [x] `verify` capture - **not run**: this sandbox is headless Linux (no X11/Wayland/Xvfb), and
      `verify`'s screenshot mechanism is macOS-only. The new toggle row is covered instead by a
      real `#[gpui::test]` that opens the Agents settings page, asserts the row paints
      (`cx.debug_bounds`), and simulates a real click on it to confirm the setting flips both ways
      (`settings::render::cursor_hooks_settings_tests`).
- [x] New/changed behavior has real tests: 68 tests across `cursor_event`, `cursor_hooks_file`,
      the new server route, the spawn-gate extraction in `work_surface::agents`, and the settings
      toggle (both the persistence round-trip and the real-click UI test)
- [x] External tier - n/a, nothing here touches a real language server or agent process; the
      feasibility research (documented on the issue) deliberately used only static analysis and
      two other projects' shipped source, never a live `cursor-agent` invocation

## Architecture notes

New Command-adjacent surface: `cursor_hooks_file::install`/`remove_managed_entries` are the
read-modify-write pair for `~/.cursor/hooks.json`, parallel in spirit to `settings_file`'s
Claude-only file generation. `docs/architecture/decisions.md` §11 has the full reasoning for why
this shape (merge, not generate) is the right one for a hookless-by-default CLI agent with no
config-path override, and is meant to be the reference for the next agent CLI shaped the same way.
