### PR TITLE
fix(app): stop spawned agents outliving a force-killed Jerry on Windows

### DIFF
--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -385,10 +385,16 @@ libc = "0.2"
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.61.2", features = [
     "Win32_Foundation",
+    # `SECURITY_ATTRIBUTES`: named by `CreateJobObjectW`'s signature, which is feature-gated on
+    # it - the call itself passes null (default security, non-inheritable handle).
+    "Win32_Security",
     # For `SYNCHRONIZE`, which is a *standard* access right shared by every securable object
     # (`WaitForSingleObject` needs it on the process handle) and not a filesystem thing at all -
     # this is just the module the generated bindings put it in.
     "Win32_Storage_FileSystem",
+    # The kill-on-close job object `crate::job_object` puts this whole process in, so spawned
+    # agents cannot outlive a force-killed Jerry (GitHub issue #482).
+    "Win32_System_JobObjects",
     # PSAPI: `GetProcessMemoryInfo`/`PROCESS_MEMORY_COUNTERS`, the working-set reading behind the
     # status bar's `Y GB` field on Windows.
     "Win32_System_ProcessStatus",

--- a/crates/app/src/job_object.rs
+++ b/crates/app/src/job_object.rs
@@ -1,0 +1,183 @@
+//! The Windows kill-on-close job object that stops spawned children outliving Jerry
+//! (GitHub issue #482). `PtySession`'s tree kills only run while this process is alive to run
+//! them; a force-killed or crashed Jerry runs no destructors, and a Windows child is otherwise
+//! unaffected by its parent dying. Owns exactly one process-wide job; per-session kills stay
+//! in `pty-core`.
+
+// This module exists entirely to call Win32 FFI (`CreateJobObjectW`, `SetInformationJobObject`,
+// `AssignProcessToJobObject`) - every call site below carries its own `SAFETY` comment; see
+// CLAUDE.md's Rust standards for the project-wide "unsafe only for justified FFI" rule.
+#![allow(unsafe_code)]
+
+use std::io;
+
+use windows_sys::Win32::Foundation::{CloseHandle, HANDLE};
+use windows_sys::Win32::System::JobObjects::{
+    AssignProcessToJobObject, CreateJobObjectW, JobObjectExtendedLimitInformation,
+    SetInformationJobObject, JOBOBJECT_BASIC_LIMIT_INFORMATION,
+    JOBOBJECT_EXTENDED_LIMIT_INFORMATION, JOB_OBJECT_LIMIT_BREAKAWAY_OK,
+    JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+};
+use windows_sys::Win32::System::Threading::GetCurrentProcess;
+
+/// Puts this process in a fresh kill-on-close job so every child it ever spawns dies with it,
+/// however it dies. Call once, before anything can spawn.
+///
+/// Failure is logged and non-fatal: without the job, cleanup degrades to the `Drop`-time tree
+/// kills that already exist, which is exactly the pre-#482 behavior.
+pub fn adopt_this_process() {
+    match adopt_this_process_returning_job() {
+        Ok(_job) => {
+            // The handle is deliberately never closed. This process is a member of a
+            // kill-on-close job, so closing the last handle would terminate Jerry itself; the
+            // kernel closes it when this process dies, which is the trigger doing its job.
+            log::info!("child processes are adopted by a kill-on-close job object");
+        }
+        Err(err) => {
+            log::warn!(
+                "could not set up the kill-on-close job object ({err}) - children of a \
+                 force-killed Jerry will outlive it"
+            );
+        }
+    }
+}
+
+/// [`adopt_this_process`]'s fallible core, returning the job handle so a test can query
+/// membership against it. The caller must keep the handle open for the life of the process.
+fn adopt_this_process_returning_job() -> io::Result<HANDLE> {
+    let job = create_kill_on_close_job()?;
+    // SAFETY: `GetCurrentProcess` takes nothing and returns the process's own pseudo-handle,
+    // which is valid for the whole call and needs no closing.
+    let this_process = unsafe { GetCurrentProcess() };
+    if let Err(err) = assign_process(job, this_process) {
+        // SAFETY: `job` came from a successful `CreateJobObjectW` and is closed exactly once
+        // here; the assignment failed, so this process is not a member and the close kills
+        // nothing.
+        unsafe { CloseHandle(job) };
+        return Err(err);
+    }
+    Ok(job)
+}
+
+/// A fresh, unnamed job object whose members are terminated when its last handle closes
+/// (`JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`), with breakaway permitted
+/// (`JOB_OBJECT_LIMIT_BREAKAWAY_OK`) so the updater's relaunch can escape it deliberately.
+fn create_kill_on_close_job() -> io::Result<HANDLE> {
+    // SAFETY: both parameters are null by contract - default security, which also makes the
+    // handle non-inheritable (load-bearing: an inherited copy in a child would keep the job
+    // alive past this process's death), and no name. Reads nothing from this process; returns
+    // a handle, null on failure.
+    let job = unsafe { CreateJobObjectW(std::ptr::null(), std::ptr::null()) };
+    if job.is_null() {
+        return Err(io::Error::last_os_error());
+    }
+
+    let limits = JOBOBJECT_EXTENDED_LIMIT_INFORMATION {
+        BasicLimitInformation: JOBOBJECT_BASIC_LIMIT_INFORMATION {
+            LimitFlags: JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE | JOB_OBJECT_LIMIT_BREAKAWAY_OK,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    // SAFETY: `job` is the live handle just created above. The information pointer addresses a
+    // live, uniquely borrowed stack `JOBOBJECT_EXTENDED_LIMIT_INFORMATION` whose length is the
+    // struct's real size taken from the type itself, the pair this call's contract requires
+    // for `JobObjectExtendedLimitInformation`; the callee only reads it and does not retain
+    // the pointer.
+    let ok = unsafe {
+        SetInformationJobObject(
+            job,
+            JobObjectExtendedLimitInformation,
+            std::ptr::from_ref(&limits).cast(),
+            std::mem::size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
+        )
+    };
+    if ok == 0 {
+        let err = io::Error::last_os_error();
+        // SAFETY: `job` came from a successful `CreateJobObjectW`, nothing was assigned to it,
+        // and it is closed exactly once here.
+        unsafe { CloseHandle(job) };
+        return Err(err);
+    }
+    Ok(job)
+}
+
+/// Assigns `process` to `job`. Members it spawns afterwards join automatically.
+fn assign_process(job: HANDLE, process: HANDLE) -> io::Result<()> {
+    // SAFETY: takes two handles the caller owns for the whole call and borrows no memory from
+    // this process, so there is nothing for it to invalidate.
+    let ok = unsafe { AssignProcessToJobObject(job, process) };
+    if ok == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod kill_on_close_job_tests {
+    use super::{adopt_this_process_returning_job, assign_process, create_kill_on_close_job};
+    use std::os::windows::io::AsRawHandle;
+    use std::process::Stdio;
+    use std::time::Duration;
+    use test_support::{wait_until, ChildGuard};
+    use windows_sys::core::BOOL;
+    use windows_sys::Win32::Foundation::{CloseHandle, HANDLE};
+    use windows_sys::Win32::System::JobObjects::IsProcessInJob;
+
+    /// A real child that blocks until killed: `pause` reads from a stdin pipe whose write end
+    /// this test holds open, so nothing ever arrives.
+    fn blocked_child() -> ChildGuard {
+        let mut command = pty_core::new_std_command("cmd.exe");
+        command
+            .args(["/d", "/c", "pause"])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        ChildGuard::spawn(&mut command).expect("cmd.exe must spawn")
+    }
+
+    /// The kernel property the whole fix rests on: no destructor, no `taskkill`, just the last
+    /// handle closing - which is what the OS does to every handle of a dead process.
+    #[test]
+    fn closing_the_last_job_handle_kills_a_process_assigned_to_it() {
+        let job = create_kill_on_close_job().expect("job creation must succeed on real Windows");
+        let mut child = blocked_child();
+        assert!(child.is_running(), "the fixture child must start out alive");
+        assign_process(job, child.as_raw_handle() as HANDLE)
+            .expect("assigning a live child to a fresh job must succeed");
+
+        // SAFETY: `job` came from a successful `create_kill_on_close_job` and is closed exactly
+        // once here. This test process was never assigned to it, so the close terminates only
+        // the child - which is the behavior under test.
+        unsafe { CloseHandle(job) };
+
+        assert!(
+            wait_until(Duration::from_secs(5), || !child.is_running()),
+            "closing the last handle of a kill-on-close job must terminate its members"
+        );
+    }
+
+    /// Children join the job at spawn because *this process* is a member - proving no
+    /// per-spawn-site plumbing is needed for coverage.
+    #[test]
+    fn a_child_spawned_after_adoption_is_born_inside_the_job() {
+        let job = adopt_this_process_returning_job()
+            .expect("adopting the test process must succeed on real Windows");
+        // This test's process is now inside a kill-on-close job, so `job` must stay open until
+        // the process exits - leaked here exactly as production leaks it. nextest gives the
+        // test its own process, so nothing else inherits that state.
+        let mut child = blocked_child();
+
+        let mut inside: BOOL = 0;
+        // SAFETY: both handles are live for the whole call (`job` is never closed, the child
+        // outlives the call under its guard), and the out-pointer addresses a live, uniquely
+        // borrowed stack `BOOL` the callee writes exactly once.
+        let ok = unsafe { IsProcessInJob(child.as_raw_handle() as HANDLE, job, &mut inside) };
+        assert!(ok != 0, "IsProcessInJob must succeed for a live child");
+        assert!(
+            inside != 0,
+            "a child spawned after adoption must be inside the job automatically"
+        );
+        child.kill_and_wait().expect("test child teardown");
+    }
+}

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -24,6 +24,8 @@ pub mod graph_view;
 pub mod hooks;
 pub mod icon_pack;
 pub mod icons;
+#[cfg(windows)]
+pub mod job_object;
 pub mod keymap;
 pub mod keymap_overrides;
 pub mod language;

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -13,6 +13,11 @@ use std::process::ExitCode;
 fn main() -> ExitCode {
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
 
+    // Before anything can spawn: children join the job at creation, so a child spawned earlier
+    // than this would be exactly the orphan issue #482 exists to prevent.
+    #[cfg(windows)]
+    app::job_object::adopt_this_process();
+
     #[cfg(any(target_os = "linux", target_os = "freebsd"))]
     apply_display_scale_override();
 

--- a/crates/app/src/updater/flow.rs
+++ b/crates/app/src/updater/flow.rs
@@ -8,6 +8,8 @@
 use super::*;
 use std::ffi::OsString;
 use std::path::Path;
+#[cfg(windows)]
+use windows_sys::Win32::System::Threading::{CREATE_BREAKAWAY_FROM_JOB, CREATE_NO_WINDOW};
 
 const REPO_OWNER: &str = "ColinEspinas";
 const REPO_NAME: &str = "jerry";
@@ -104,6 +106,22 @@ fn build_relaunch_command(exe: &Path, args: &[OsString]) -> std::process::Comman
     let mut command = pty_core::new_std_command(exe);
     command.args(args);
     command
+}
+
+/// What the Windows relaunch spawns with: `CREATE_BREAKAWAY_FROM_JOB` so the fresh instance
+/// escapes the old one's kill-on-close job (`crate::job_object`, GitHub issue #482) - without
+/// it the new Jerry is terminated the moment the old one exits and that job's last handle
+/// closes - and `CREATE_NO_WINDOW` again, because `creation_flags` *replaces* what
+/// `pty_core::new_std_command` set rather than ORing into it (GitHub issue #465).
+#[cfg(windows)]
+const RELAUNCH_CREATION_FLAGS: u32 = CREATE_NO_WINDOW | CREATE_BREAKAWAY_FROM_JOB;
+
+/// Applies [`RELAUNCH_CREATION_FLAGS`] - separate from [`build_relaunch_command`] so the
+/// no-breakaway retry in [`AdeApp::relaunch_and_exit`] can reuse the plain builder.
+#[cfg(windows)]
+fn add_breakaway_flags(command: &mut std::process::Command) {
+    use std::os::windows::process::CommandExt as _;
+    command.creation_flags(RELAUNCH_CREATION_FLAGS);
 }
 
 impl AdeApp {
@@ -251,7 +269,26 @@ impl AdeApp {
             }
         };
         let args: Vec<OsString> = std::env::args_os().skip(1).collect();
-        match build_relaunch_command(&exe, &args).spawn() {
+        #[cfg(windows)]
+        let spawned = {
+            let mut command = build_relaunch_command(&exe, &args);
+            add_breakaway_flags(&mut command);
+            command.spawn().or_else(|err| {
+                // Only reachable when a job this process sits in forbids breakaway - ours
+                // permits it, so that means an outer one. The retry can't escape
+                // `crate::job_object`'s kill-on-close job, so if that adoption succeeded the
+                // relaunched instance still dies with this one; what the retry rescues is the
+                // adoption-failed case, where the same outer job is exactly what blocked it.
+                log::warn!(
+                    "relaunching with CREATE_BREAKAWAY_FROM_JOB failed ({err}); retrying without \
+                     breakaway"
+                );
+                build_relaunch_command(&exe, &args).spawn()
+            })
+        };
+        #[cfg(not(windows))]
+        let spawned = build_relaunch_command(&exe, &args).spawn();
+        match spawned {
             Ok(_child) => {
                 cx.quit();
             }
@@ -292,6 +329,23 @@ mod relaunch_command_tests {
         let exe = Path::new("/usr/local/bin/jerry");
         let command = build_relaunch_command(exe, &[]);
         assert_eq!(command.get_args().count(), 0);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn the_relaunch_flags_break_away_from_the_job_without_unhiding_the_console() {
+        assert_eq!(
+            RELAUNCH_CREATION_FLAGS & CREATE_BREAKAWAY_FROM_JOB,
+            CREATE_BREAKAWAY_FROM_JOB,
+            "without breakaway the relaunched instance dies with this one's kill-on-close job \
+             (GitHub issue #482)"
+        );
+        assert_eq!(
+            RELAUNCH_CREATION_FLAGS & CREATE_NO_WINDOW,
+            CREATE_NO_WINDOW,
+            "creation_flags replaces what new_std_command set, so dropping CREATE_NO_WINDOW here \
+             would regress the console flash (GitHub issue #465)"
+        );
     }
 }
 

--- a/crates/pty-core/src/lib.rs
+++ b/crates/pty-core/src/lib.rs
@@ -761,7 +761,9 @@ impl PtySession {
 
 /// Terminates `pid` and every descendant, synchronously: `taskkill /T` walks the parent-pid
 /// chain, the closest Windows equivalent of the unix process-group signal plus descendant walk,
-/// without the job-object `unsafe` FFI this project rules out. Best-effort by nature (a
+/// without job-object `unsafe` FFI in this crate (the process-wide kill-on-close job object
+/// backstopping a Jerry that dies without running `Drop` lives in `crates/app`'s `job_object`
+/// module - GitHub issue #482; this walk covers the in-session kill paths). Best-effort by nature (a
 /// descendant that re-parented is missed; one that exited already is fine) - but without it a
 /// bare `TerminateProcess` on the direct child orphans every grandchild, which is how an npm
 /// `.cmd`-shim agent's real `node.exe` survived kills (GitHub issue #468) and how a discarded

--- a/docs/architecture/decisions.md
+++ b/docs/architecture/decisions.md
@@ -310,3 +310,38 @@ already attaches them to a headless pseudo console via `PROC_THREAD_ATTRIBUTE_PS
 `CREATE_NO_WINDOW` is neither needed nor passable there. Anything that spawns without
 `std::process::Command` (direct `CreateProcessW` FFI, a future async runtime's command type)
 must apply the same flag at its own call site; none exists today.
+
+## 11. A process-wide kill-on-close job object backstops child cleanup on Windows
+
+**Status:** Accepted.
+
+**Context:** Every cleanup path for spawned children — `PtySession::drop`/`kill`/`shutdown`'s
+`taskkill /T` tree kills, `HookFiles::drop`'s temp-dir removal — is code running *inside* the
+Jerry process. A force-killed (Task Manager "End task", `taskkill /F` without `/T`), crashed, or
+aborted Jerry runs none of it, and unlike a unix process group, a Windows child is simply not
+affected by its parent dying. In practice that leaked ~180 orphaned `claude.exe` agents per day,
+which the user's own settings hooks amplified into ~10,000 processes (#482). `portable-pty`
+creates no job object of its own.
+
+**Decision:** At the top of `main()`, before anything can spawn, `crates/app`'s `job_object`
+module creates one unnamed job object with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE |
+JOB_OBJECT_LIMIT_BREAKAWAY_OK` and assigns *this process* to it. Children join a member's job
+automatically at `CreateProcess` time, so every spawn — agent PTYs through ConPTY, every
+`new_std_command` child, LSP servers, future call sites — is covered with no per-site plumbing.
+The job handle is deliberately never closed: the kernel closes it when the process terminates,
+by any means, and then kills every remaining member. Setup failure is logged and non-fatal
+(behavior degrades to exactly the destructor-only world this replaces).
+
+It lives in `crates/app`, not `pty-core`, for two reasons: the job is app-lifecycle policy, not
+per-session PTY mechanics, and CLAUDE.md pins the core crates as `unsafe`-free — `crates/app`
+already carries the sanctioned Win32 FFI sites (`hooks/settings_file.rs`,
+`status_bar/process_stats/windows.rs`) and the `windows-sys` dependency.
+
+**Consequences:** The in-session kill paths (`taskkill /T` and friends) stay: the job only fires
+when the whole process dies, while sessions are killed and discarded continuously during normal
+use. A child that must *outlive* Jerry has to break away explicitly — the updater's relaunch is
+the one such child, spawned with `CREATE_BREAKAWAY_FROM_JOB` (permitted by `BREAKAWAY_OK`), with
+a logged no-breakaway retry for the corner where an outer job forbids it. If job creation or
+self-assignment fails, orphans are again possible; the startup sweep of `jerry-hooks-*`
+directories (`hooks/settings_file.rs`) remains the independent cleanup for what a dead instance
+leaves on disk.


### PR DESCRIPTION
Closes #482

## What

On Windows, every child Jerry spawns now dies with it — however it dies. At the top of `main()`, before anything can spawn, the new `crates/app/src/job_object.rs` puts the Jerry process itself into a kill-on-close job object (`JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE | JOB_OBJECT_LIMIT_BREAKAWAY_OK`). Children join a member's job automatically at `CreateProcess` time, so agent PTY children, every `new_std_command` child, and LSP servers are all covered with no per-spawn-site plumbing; when the process terminates — force-kill, crash, or clean exit — the kernel closes the job's last handle and kills every remaining member. Before this, cleanup was entirely destructor-dependent (`PtySession::drop`'s `taskkill /T`), so a force-killed Jerry orphaned every live `claude.exe` (~180/day on the reporting machine, amplified by settings hooks into ~10,000 processes).

The one child that must *outlive* Jerry — the updater's relaunch — now spawns with `CREATE_BREAKAWAY_FROM_JOB` (re-including `CREATE_NO_WINDOW`, since `creation_flags` replaces rather than ORs — issue #465), with a logged no-breakaway retry for the corner where an outer job forbids breakaway.

Of the issue's other asks: the `jerry-hooks-*` temp-dir startup sweep already exists (`hooks/settings_file.rs::sweep_stale_directories`, liveness-keyed, tested) — the observed stale dirs are downstream of the orphaned processes this PR stops creating. Job setup failure is logged and non-fatal: behavior degrades to exactly the pre-PR destructor-only world. The full analysis is in the plan comment on #482.

## Testing

- [x] `/check` (conventions + fmt + clippy `-D warnings` + `cargo nextest run --workspace`) — fmt and clippy pass; conventions ran with the ratchet's jq-dependent baseline comparison skipped locally (`jq` not installed; CI runs it in full, and this change adds no `use super::*` globs or render-layer adapter calls). The workspace test run on this Windows machine: 3159/3173 pass; the 14 failures are not this change's — 7 pass in isolation (parallel-load flakiness) and the other 7 (`terminal::pane` real-PTY `sh`-under-ConPTY tests) fail identically on clean `master` here, part of the known "full suite does not pass on Windows yet" gap that `ci.yml`'s Windows job documents (#440). The Linux/macOS CI suite is the arbiter.
- [x] New/changed behavior has a real test, in the right tier (docs/testing.md):
  - `job_object::kill_on_close_job_tests::closing_the_last_job_handle_kills_a_process_assigned_to_it` — the kernel property the fix rests on, against a real child process (unit tier, Windows-only)
  - `job_object::kill_on_close_job_tests::a_child_spawned_after_adoption_is_born_inside_the_job` — proves auto-join via `IsProcessInJob`, i.e. that no per-spawn plumbing is needed (unit tier, Windows-only)
  - `updater::flow::relaunch_command_tests::the_relaunch_flags_break_away_from_the_job_without_unhiding_the_console`
- `verify` capture: not applicable — no UI surface.
- `external` tier: not touched.

## Architecture notes

New entry: `docs/architecture/decisions.md` §11 — the process-wide job object lives in `crates/app` (app-lifecycle policy; the core crates stay `unsafe`-free per CLAUDE.md), not `pty-core`; the in-session `taskkill /T` kill paths stay. Adds `Win32_System_JobObjects` + `Win32_Security` features to the already-direct `windows-sys` dependency; the new `unsafe` FFI sites follow the sanctioned pattern of `hooks/settings_file.rs` and `status_bar/process_stats/windows.rs`, each with its own `SAFETY` comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
