### PR TITLE
fix(app): paint a revisited worktree's last-known content the instant it is selected

### DIFF
--- a/crates/app/src/code_surface/mod.rs
+++ b/crates/app/src/code_surface/mod.rs
@@ -1,8 +1,8 @@
 //! Surface C, the code surface: everything about one feature, in one folder.
 
 use crate::code_surface::state::{
-    BlameCacheEntry, BlameLoadState, CommitMessageState, DiffLoadState, FileLoadState, HoverAnchor,
-    HoverEntry, HoverStatus,
+    BlameCacheEntry, BlameLoadState, ChangesSnapshot, CommitMessageState, DiffLoadState,
+    FileLoadState, HoverAnchor, HoverEntry, HoverStatus,
 };
 use crate::language;
 use crate::lsp::client::LspClientState;

--- a/crates/app/src/code_surface/state.rs
+++ b/crates/app/src/code_surface/state.rs
@@ -12,6 +12,20 @@ pub(crate) enum DiffLoadState {
     Error(String),
 }
 
+/// One worktree's last-known Changes content - every field [`AdeApp::load_diff`] blanks -
+/// stashed on switch-away and painted straight back on the next visit while the fresh reload
+/// runs behind it (GitHub issue #454). Never holds a `Loading` `diff_state`: the stash refuses
+/// to record one, so a restore always paints landed content.
+pub(crate) struct ChangesSnapshot {
+    pub(crate) diff_state: DiffLoadState,
+    pub(crate) diff_totals: Option<(u32, u32)>,
+    pub(crate) change_set: crate::provenance::change_set::ChangeSet,
+    pub(crate) uncommitted_diff: crate::sidebar::sections::ScopeLoad<WorktreeDiff>,
+    pub(crate) uncommitted_change_set: crate::provenance::change_set::ChangeSet,
+    pub(crate) branch_commits: crate::sidebar::sections::ScopeLoad<wt_core::diff::BranchCommits>,
+    pub(crate) dirty_files: Option<std::collections::HashSet<PathBuf>>,
+}
+
 /// The outcome of the most recent (or in-flight) `code_view::load_file` call for whichever path
 /// [`AdeApp::render_file_view`] most recently asked to load. Mirrors [`DiffLoadState`]'s shape:
 /// `load_file` does the same class of blocking I/O (`std::fs::read`, plus a `tree-sitter` parse

--- a/crates/app/src/code_surface/tabs.rs
+++ b/crates/app/src/code_surface/tabs.rs
@@ -32,6 +32,52 @@ impl AdeApp {
         self._load_diff_task = Some(self.spawn_diff_reload(root, cx));
     }
 
+    /// Stashes [`Self::diff_root`]'s landed Changes content under its root, for
+    /// [`Self::load_diff_for_switch`] to paint straight back on the next visit (GitHub issue
+    /// #454). Refuses to record an in-flight `Loading` (nothing worth restoring) or a root that
+    /// no longer exists on disk (a discarded worktree's content must not be resurrected by the
+    /// switch away from it).
+    pub(crate) fn stash_changes_snapshot(&mut self) {
+        if matches!(self.diff_state, DiffLoadState::Loading) {
+            return;
+        }
+        if !self.diff_root.is_dir() {
+            return;
+        }
+        let snapshot = ChangesSnapshot {
+            diff_state: std::mem::replace(&mut self.diff_state, DiffLoadState::Loading),
+            diff_totals: self.diff_totals.take(),
+            change_set: std::mem::take(&mut self.change_set),
+            uncommitted_diff: std::mem::take(&mut self.uncommitted_diff),
+            uncommitted_change_set: std::mem::take(&mut self.uncommitted_change_set),
+            branch_commits: std::mem::take(&mut self.branch_commits),
+            dirty_files: self.dirty_files.take(),
+        };
+        self.changes_by_worktree
+            .insert(self.diff_root.clone(), snapshot);
+    }
+
+    /// [`Self::load_diff`] for a worktree switch (GitHub issue #454): when `root` has stashed
+    /// last-known content, restore it and reload without blanking - [`Self::refresh_diff`]'s own
+    /// no-blank shape - so the switch paints instantly. A first-ever visit falls back to the
+    /// honest blanking load.
+    pub(crate) fn load_diff_for_switch(&mut self, root: PathBuf, cx: &mut Context<Self>) {
+        let Some(snapshot) = self.changes_by_worktree.remove(&root) else {
+            self.load_diff(root, cx);
+            return;
+        };
+        self.diff_root = root.clone();
+        self.diff_state = snapshot.diff_state;
+        self.diff_totals = snapshot.diff_totals;
+        self.change_set = snapshot.change_set;
+        self.uncommitted_diff = snapshot.uncommitted_diff;
+        self.uncommitted_change_set = snapshot.uncommitted_change_set;
+        self.branch_commits = snapshot.branch_commits;
+        self.dirty_files = snapshot.dirty_files;
+        cx.notify();
+        self._load_diff_task = Some(self.spawn_diff_reload(root, cx));
+    }
+
     /// Re-runs exactly the same real git reload [`Self::load_diff`] does, for the *same* worktree
     /// [`Self::diff_root`] already names - GitHub issue #399. The one difference is what it does
     /// **not** do: unlike `load_diff`, this never blanks [`Self::diff_state`]/

--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -48,8 +48,8 @@ use crate::work_surface::state as work_surface;
 use crate::worktree_history::flow as worktree_history;
 
 use crate::code_surface::state::{
-    BlameCacheEntry, BlameLoadState, CommitMessageState, DiffLoadState, FileLoadState, HoverAnchor,
-    HoverEntry,
+    BlameCacheEntry, BlameLoadState, ChangesSnapshot, CommitMessageState, DiffLoadState,
+    FileLoadState, HoverAnchor, HoverEntry,
 };
 use crate::lsp::client::LspClientState;
 use crate::lsp::completion_popup::CompletionsEntry;
@@ -782,6 +782,16 @@ pub struct AdeApp {
     /// *current* worktree's entry, creating it empty on first access rather than requiring a
     /// separate "new worktree" seeding step.
     pub(crate) open_files_by_worktree: HashMap<PathBuf, Vec<PathBuf>>,
+    /// Each visited worktree's last successfully loaded file tree, stashed on switch-away
+    /// ([`Self::reset_repo_scoped_state`]) and painted straight back on the next visit while the
+    /// fresh walk runs behind it - so a revisit never renders a blank sidebar (GitHub issue
+    /// #454). Keyed by worktree root like [`Self::open_files_by_worktree`]; entries move out on
+    /// restore and back in on the next switch-away, and a discarded worktree's entry is evicted
+    /// with it (`crate::worktree_history::flow`).
+    pub(crate) file_tree_by_worktree: HashMap<PathBuf, file_tree::FileTreeListing>,
+    /// [`Self::file_tree_by_worktree`]'s Changes-panel twin - see
+    /// [`crate::code_surface::state::ChangesSnapshot`]'s own docs.
+    pub(crate) changes_by_worktree: HashMap<PathBuf, ChangesSnapshot>,
     /// Which file tab (if any) the centre pane is showing instead of an agent -
     /// `Some(path)` iff `path` is also in [`Self::open_files`]. Set by a Changes row
     /// (`Self::open_change_diff`), a Files-tree row (`Self::open_file_view`), or an already-open

--- a/crates/app/src/root/state.rs
+++ b/crates/app/src/root/state.rs
@@ -2749,9 +2749,10 @@ mod file_tree_watch_integration_tests {
 /// reload lands behind it - while a first-ever visit keeps the honest empty/`Loading` states.
 #[cfg(test)]
 mod instant_worktree_switch_tests {
-    use super::*;
+    use crate::code_surface::state::DiffLoadState;
+    use crate::root::AdeApp;
     use gpui::TestAppContext;
-    use std::path::Path;
+    use std::path::{Path, PathBuf};
 
     fn add_worktree(repo_path: &Path, branch: &str, name: &str) -> PathBuf {
         let container = crate::test_support::temp_root();

--- a/crates/app/src/root/state.rs
+++ b/crates/app/src/root/state.rs
@@ -322,6 +322,8 @@ impl AdeApp {
             selected: None,
             agents: Agents::new(),
             file_tree: file_tree::FileTree::default(),
+            file_tree_by_worktree: HashMap::new(),
+            changes_by_worktree: HashMap::new(),
             file_tree_error: None,
             right_sidebar_view: RightSidebarView::Files,
             file_tree_scroll_handle: UniformListScrollHandle::new(),
@@ -1332,6 +1334,26 @@ impl AdeApp {
     /// Loads [`Self::file_tree_root`]'s listing and applies the result, off the foreground
     /// thread — from git's own content answer, walking the filesystem only for a non-git root
     /// (see `file_tree::build_worktree_file_tree`, GitHub issue #472).
+    /// `stash_changes_snapshot`'s file-tree twin (GitHub issue #454): stashes the current
+    /// [`Self::file_tree_root`]'s loaded tree under its root, for
+    /// [`Self::reset_repo_scoped_state`] to paint straight back on the next visit. Refuses an
+    /// empty tree (nothing worth restoring) and a root that no longer exists on disk (a
+    /// discarded worktree's rows must not be resurrected by the switch away from it).
+    fn stash_file_tree_listing(&mut self) {
+        if self.file_tree.is_empty() {
+            return;
+        }
+        if !self.file_tree_root.is_dir() {
+            return;
+        }
+        let listing = file_tree::FileTreeListing {
+            tree: std::mem::take(&mut self.file_tree),
+            partial: !self.file_tree_complete,
+        };
+        self.file_tree_by_worktree
+            .insert(self.file_tree_root.clone(), listing);
+    }
+
     pub(crate) fn load_file_tree(&mut self, root: PathBuf, cx: &mut Context<Self>) {
         self.set_file_tree_root(root.clone(), cx);
         let task = cx.spawn(async move |this, cx| {
@@ -1638,6 +1660,11 @@ impl AdeApp {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        // GitHub issue #454: before any reset below blanks them, stash the outgoing worktree's
+        // landed file tree and Changes content so its next visit paints instantly instead of
+        // showing an empty sidebar and Loading spinners until the async reloads land.
+        self.stash_changes_snapshot();
+        self.stash_file_tree_listing();
         self.prune_confirm_armed = false;
         self.discard_confirm_armed = None;
         // Same reasoning for every floating menu (`crate::root::menus`): the commit composer's
@@ -1689,10 +1716,22 @@ impl AdeApp {
         // below sets the root too, but its walk is asynchronous, so without this the frames
         // between here and the walk landing would render whatever was left's rows against the
         // new root's expanded set - and a click on one of those stale rows would reach
-        // `set_dir_expanded` with a path from an entirely different worktree/repo. Clearing
-        // `file_tree` makes that window render an honestly empty tree instead.
+        // `set_dir_expanded` with a path from an entirely different worktree/repo. What fills
+        // that window is `new_root`'s *own* stashed last-known tree when it has one (GitHub
+        // issue #454) - its rows are this worktree's real paths, so a click on one is valid,
+        // merely possibly stale until the walk lands - and an honestly empty tree on a first
+        // visit, exactly as before.
         self.set_file_tree_root(new_root.clone(), cx);
-        self.file_tree = file_tree::FileTree::default();
+        match self.file_tree_by_worktree.remove(&new_root) {
+            Some(listing) => {
+                self.file_tree_complete = listing.is_complete();
+                self.file_tree = listing.tree;
+            }
+            None => {
+                self.file_tree_complete = false;
+                self.file_tree = file_tree::FileTree::default();
+            }
+        }
         self.reload_expanded_dirs_from_fold_state();
         // Every one of these holds an absolute path in whatever was just left (GitHub issue #19):
         // a half-typed name for a folder in the old tree, a cut/copied entry a paste here would
@@ -1710,7 +1749,6 @@ impl AdeApp {
         // delete backups this leaves unreachable.
         self.clear_tree_undo_history();
         self.tree_op_error = None;
-        self.file_tree_complete = false;
         // `focus_newly_spawned_agent` (despite its name - its body has no "newly spawned" logic
         // in it, just the shared "move focus unless a file tab/Settings is showing" guard) closes
         // the dangling-focus risk this switch creates: the previously-active agent's pane may
@@ -1825,15 +1863,15 @@ impl AdeApp {
         // `load_file_tree` above already set `self.file_tree_root = new_root` synchronously, so
         // `new_root` is the active root by the time eviction runs.
         self.evict_stale_lsp_clients(&new_root, cx);
-        self.load_diff(new_root, cx);
+        self.load_diff_for_switch(new_root, cx);
         // The graph tab is repo-scoped, not worktree-scoped (design spec §1: "the graph is
         // repo-scoped"), but the toolbar's `HEAD` chip/upstream counts and the Worktrees scope
         // (`wt_core::graph::GraphScope::Worktrees`, driven by real worktree HEADs) are real facts
         // about whatever is genuinely current now - without this, switching while the graph tab
         // is open silently left it showing stale data (a real, adversarial-audit-found gap), and
         // the Commit panel's cached "Files changed" could even fail against the wrong repo path.
-        // `load_diff` above already updated `Self::diff_root` synchronously, so `load_graph`
-        // (which reads it) picks up the new root correctly.
+        // `load_diff_for_switch` above already updated `Self::diff_root` synchronously (both of
+        // its arms do), so `load_graph` (which reads it) picks up the new root correctly.
         if self.graph_tab_open {
             self.load_graph(cx);
         }
@@ -2703,5 +2741,169 @@ mod file_tree_watch_integration_tests {
             "switching worktrees must re-arm a real watcher on the newly selected root, not \
              leave the previous worktree's watcher (or none at all) in place"
         );
+    }
+}
+
+/// GitHub issue #454's contract: switching back to an already-visited worktree paints that
+/// worktree's own last-known file tree and Changes content in the very same frame - the fresh
+/// reload lands behind it - while a first-ever visit keeps the honest empty/`Loading` states.
+#[cfg(test)]
+mod instant_worktree_switch_tests {
+    use super::*;
+    use gpui::TestAppContext;
+    use std::path::Path;
+
+    fn add_worktree(repo_path: &Path, branch: &str, name: &str) -> PathBuf {
+        let container = crate::test_support::temp_root();
+        let path = container.path().join(name);
+        drop(container);
+        test_support::add_worktree(repo_path, branch, &path);
+        path
+    }
+
+    fn index_of(app: &AdeApp, path: &Path) -> usize {
+        app.worktrees
+            .iter()
+            .position(|item| item.path == path)
+            .unwrap_or_else(|| {
+                panic!(
+                    "{} must be a real worktree row - the list is {:?}",
+                    path.display(),
+                    app.worktrees
+                        .iter()
+                        .map(|item| item.path.clone())
+                        .collect::<Vec<_>>()
+                )
+            })
+    }
+
+    #[gpui::test]
+    fn switching_back_to_a_visited_worktree_paints_its_last_known_content_immediately(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = crate::test_support::temp_repo();
+        let repo_path = repo.path().to_path_buf();
+        let feature = add_worktree(&repo_path, "feature", "instant-wt");
+        // A real uncommitted file, so the main worktree's Changes content is non-trivially real.
+        std::fs::write(repo_path.join("uncommitted.txt"), "wip\n").expect("write");
+
+        let (app, cx) = crate::test_support::open_test_app(cx, repo_path.clone());
+        cx.run_until_parked();
+        app.update(cx, |app, cx| app.load_worktrees(cx));
+        cx.run_until_parked();
+        app.read_with(cx, |app, _| {
+            assert!(
+                !app.file_tree.is_empty(),
+                "premise: the main worktree's tree really loaded"
+            );
+            assert!(
+                app.uncommitted_diff.loaded().is_some(),
+                "premise: the main worktree's Changes scopes really loaded"
+            );
+            assert!(
+                !matches!(app.diff_state, DiffLoadState::Loading),
+                "premise: the against-base diff really landed"
+            );
+        });
+
+        app.update_in(cx, |app, window, cx| {
+            let index = index_of(app, &feature);
+            app.select_worktree(index, window, cx);
+        });
+        cx.run_until_parked();
+
+        // The switch back. Every assertion runs inside the same update the click handler runs
+        // in - nothing asynchronous has had a chance to land yet, so what these see is exactly
+        // the frame the user sees at click time.
+        app.update_in(cx, |app, window, cx| {
+            let index = index_of(app, &repo_path);
+            app.select_worktree(index, window, cx);
+            assert!(
+                !app.file_tree.is_empty(),
+                "a revisited worktree must paint its last-known file tree immediately, not a \
+                 blank sidebar until the fresh walk lands (GitHub issue #454)"
+            );
+            assert!(
+                app.uncommitted_diff.loaded().is_some(),
+                "a revisited worktree must paint its last-known uncommitted changes immediately, \
+                 not a Loading spinner"
+            );
+            assert!(
+                !matches!(app.diff_state, DiffLoadState::Loading),
+                "and its last-known against-base diff, for the same reason"
+            );
+        });
+
+        // The background refresh still runs and lands on top of the restored content.
+        cx.run_until_parked();
+        app.read_with(cx, |app, _| {
+            assert!(
+                !app.file_tree.is_empty(),
+                "the fresh walk must land on top of the restored tree, never blank it"
+            );
+            let uncommitted = app
+                .uncommitted_diff
+                .loaded()
+                .expect("the fresh uncommitted scope must have landed");
+            assert!(
+                uncommitted
+                    .files
+                    .iter()
+                    .any(|file| file.path.ends_with("uncommitted.txt")),
+                "and it must be the real reloaded answer, not just the stale snapshot left in \
+                 place - got {:?}",
+                uncommitted
+                    .files
+                    .iter()
+                    .map(|f| f.path.clone())
+                    .collect::<Vec<_>>()
+            );
+        });
+    }
+
+    #[gpui::test]
+    fn a_never_visited_worktree_still_starts_from_honest_loading_states(cx: &mut TestAppContext) {
+        let repo = crate::test_support::temp_repo();
+        let repo_path = repo.path().to_path_buf();
+        let feature = add_worktree(&repo_path, "feature", "honest-wt");
+
+        let (app, cx) = crate::test_support::open_test_app(cx, repo_path.clone());
+        cx.run_until_parked();
+        app.update(cx, |app, cx| app.load_worktrees(cx));
+        cx.run_until_parked();
+        app.read_with(cx, |app, _| {
+            assert!(
+                !app.file_tree.is_empty(),
+                "premise: the main worktree's tree really loaded first"
+            );
+        });
+
+        // First-ever visit: there is no last-known content for this worktree, and the previous
+        // worktree's must never stand in for it - same-frame assertions, as above.
+        app.update_in(cx, |app, window, cx| {
+            let index = index_of(app, &feature);
+            app.select_worktree(index, window, cx);
+            assert!(
+                app.file_tree.is_empty(),
+                "a first visit has nothing honest to paint yet - and the previous worktree's \
+                 tree must never bleed across"
+            );
+            assert!(
+                app.uncommitted_diff.loaded().is_none(),
+                "same for the Changes scopes - Loading, never the previous worktree's answer"
+            );
+            assert!(
+                matches!(app.diff_state, DiffLoadState::Loading),
+                "and the against-base diff"
+            );
+        });
+
+        cx.run_until_parked();
+        app.read_with(cx, |app, _| {
+            assert!(
+                !app.file_tree.is_empty(),
+                "and the real walk still lands afterwards"
+            );
+        });
     }
 }

--- a/crates/app/src/worktree_history/flow.rs
+++ b/crates/app/src/worktree_history/flow.rs
@@ -249,6 +249,12 @@ impl AdeApp {
                         for id in orphaned {
                             this.close_agent(id, window, cx);
                         }
+                        // The discarded worktree's stashed switch-back content (GitHub issue
+                        // #454) describes a directory that no longer exists - evicted here, and
+                        // the stash helpers' own is-still-on-disk guard covers any later switch
+                        // that would otherwise re-record it.
+                        this.file_tree_by_worktree.remove(&discarded_path);
+                        this.changes_by_worktree.remove(&discarded_path);
                         this.remove_worktree_confirm_armed = None;
                         this.refresh_after_worktree_history_op(cx);
                     }


### PR DESCRIPTION
Closes #454

## What

Switching to an already-visited worktree now paints that worktree's own last-known file tree and Changes content in the very same frame as the click, with the normal async reload landing on top when it finishes. Before this, every switch blanked the sidebar to an empty tree and set all Changes scopes to `Loading`, then waited for the directory walk plus five git queries — on Windows, with agents actively writing to the checkout, that async gap is the observed ~1 second of "lag". (A code audit found no foreground stall to fix: everything heavyweight on the switch path was already backgrounded — details in the plan comment on #454.)

Mechanically: `reset_repo_scoped_state` stashes the outgoing worktree's landed content (`FileTreeListing` per root, plus a new `ChangesSnapshot` bundling everything `load_diff` blanks), and the switch-in path restores it via move semantics — `load_diff_for_switch` reuses `refresh_diff`'s existing no-blank reload shape (issue #399's own precedent) when a snapshot exists, falling back to today's honest blanking load on a first visit. The stash refuses in-flight `Loading` states and roots no longer on disk; a discarded worktree's entries are also evicted in the discard flow. First visits are pixel-identical to today, and content never bleeds across worktrees — each root restores only its own.

## Testing

- [x] `/check` — see note below on the known Windows-local suite gap.
- [x] New/changed behavior has a real test, in the right tier:
  - `root::state::instant_worktree_switch_tests::switching_back_to_a_visited_worktree_paints_its_last_known_content_immediately` (`ui` tier) — asserts, inside the same update the click runs in, that the tree and Changes scopes are populated, then that the real reload still lands on top (verified against a genuinely uncommitted file).
  - `root::state::instant_worktree_switch_tests::a_never_visited_worktree_still_starts_from_honest_loading_states` — pins that a first visit stays honestly empty/`Loading` and the previous worktree's content never bleeds across.
  - Written failing-first: the revisit test failed on unmodified code at the blank-tree assertion.
- Neighboring switch-path areas re-run green: session restore, per-worktree tab preservation, zoom-survives-switch, worktree list loading, file-tree watch re-arming, worktree discard regressions.
- `verify` capture: skipped deliberately — the change alters a transient loading window (what renders during the ~1s before async loads land), which a static screenshot can't meaningfully capture; steady-state layout, colors, and interaction states are untouched.
- Local full-suite note: fmt/clippy pass; the workspace test run on this Windows machine carries pre-existing failures that reproduce identically on clean `master` — the 7 known `terminal::pane` real-PTY ones (`ci.yml`'s own documented "full suite does not pass on Windows yet" gap, #440), plus 7 more (hooks-listener round-trip, provenance, two UI tests) that passed on this same machine earlier today and now fail on `master` too, i.e. mid-session environment degradation (loopback/socket state), not code. Every failure was re-run on clean `master` to confirm before shipping. Linux/macOS CI is the arbiter.

## Architecture notes

No crate-boundary changes and no new Command/Query — this is UI-state lifecycle inside `crates/app`, same shape as the existing per-worktree maps (`open_files_by_worktree`, fold state). New type: `code_surface::state::ChangesSnapshot`; new `AdeApp` fields `file_tree_by_worktree` / `changes_by_worktree`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
