### PR TITLE
feat(app): one change scope drives the Changes panel, tree marks, and open diffs

### DIFF
--- a/crates/app/src/code_surface/tabs.rs
+++ b/crates/app/src/code_surface/tabs.rs
@@ -548,13 +548,41 @@ impl AdeApp {
         }
     }
 
+    /// The one diff every changed-file surface derives from under the current
+    /// [`crate::sidebar::sections::ChangeScope`] (GitHub issue #487): tree markers, palette
+    /// marks, and the open file's diff hunks all read this, never
+    /// [`Self::current_diff`]/`uncommitted_diff` directly.
+    pub(crate) fn scoped_diff(&self) -> Option<&WorktreeDiff> {
+        match self.change_scope {
+            crate::sidebar::sections::ChangeScope::AllChanges => self.current_diff(),
+            crate::sidebar::sections::ChangeScope::Uncommitted => self.uncommitted_diff.loaded(),
+        }
+    }
+
+    /// Switches the change scope and recomputes everything derived from [`Self::scoped_diff`]
+    /// synchronously - the toggle must repaint every surface consistently in its own frame, not
+    /// leave some waiting on the next background reload.
+    pub(crate) fn set_change_scope(
+        &mut self,
+        scope: crate::sidebar::sections::ChangeScope,
+        cx: &mut Context<Self>,
+    ) {
+        if self.change_scope == scope {
+            return;
+        }
+        self.change_scope = scope;
+        self.refresh_open_diff_file_cache();
+        self.rebuild_palette_file_candidates();
+        cx.notify();
+    }
+
     /// Recomputes [`Self::open_diff_file_cache`] (and [`Self::file_view_changed_lines`] with it)
-    /// from [`Self::open_change`] and [`Self::current_diff`]. Called whenever either input
+    /// from [`Self::open_change`] and [`Self::scoped_diff`]. Called whenever either input
     /// changes; never from a render method, to avoid a per-render `DiffFile` clone - also the
     /// real hook [`Self::ensure_diff_highlight_cache`] recomputes real syntax highlighting from,
     /// for the same reason (see that method's own docs).
     pub(crate) fn refresh_open_diff_file_cache(&mut self) {
-        self.open_diff_file_cache = match (&self.open_change, self.current_diff()) {
+        self.open_diff_file_cache = match (&self.open_change, self.scoped_diff()) {
             (Some(open_path), Some(diff)) => diff
                 .files
                 .iter()

--- a/crates/app/src/palette/render.rs
+++ b/crates/app/src/palette/render.rs
@@ -354,14 +354,14 @@ impl AdeApp {
     }
 
     /// Rebuilds [`Self::palette_file_candidates`] from the current real [`Self::file_tree`]/
-    /// [`Self::current_diff`], on the calling (foreground) thread. This is the *diff* side's
-    /// entry point - [`Self::load_diff`]'s completion handler, and `open_file_tab`'s - where the
-    /// tree is unchanged and only the marks laid over it moved.
+    /// [`Self::scoped_diff`], on the calling (foreground) thread. This is the *diff* side's
+    /// entry point - [`Self::load_diff`]'s completion handler, `open_file_tab`'s, and a change-
+    /// scope switch's - where the tree is unchanged and only the marks laid over it moved.
     pub(crate) fn rebuild_palette_file_candidates(&mut self) {
         self.palette_file_candidates = build_file_candidates(
             &self.file_tree,
             &self.file_tree_root,
-            &file_diff_marks(self.current_diff()),
+            &file_diff_marks(self.scoped_diff()),
         );
     }
 

--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -731,6 +731,11 @@ pub struct AdeApp {
     /// unstaged, or untracked (`wt_core::stage::dirty_paths`, a real `git status --porcelain`
     /// read), or `None` while that answer isn't known yet.
     pub(crate) dirty_files: Option<HashSet<PathBuf>>,
+    /// Which git scope every changed-file surface shows (GitHub issue #487) - the Changes
+    /// panel's file list, the tree markers, the palette marks, and the opened diff's hunks all
+    /// derive from [`Self::scoped_diff`], never from `current_diff`/`uncommitted_diff` directly.
+    /// A viewing mode, not worktree state: it survives worktree switches on purpose.
+    pub(crate) change_scope: sections::ChangeScope,
     /// The most recent real git failure from one Changes row's own controls - `(path, message)`.
     /// Two writers today: [`Self::toggle_staged`]'s `git add`/`git reset`, and
     /// [`Self::discard_change_row`]'s `git checkout HEAD -- <path>` (GitHub issue #286's floating

--- a/crates/app/src/root/state.rs
+++ b/crates/app/src/root/state.rs
@@ -445,6 +445,7 @@ impl AdeApp {
             _tree_copy_task: None,
             staged_files: HashSet::new(),
             dirty_files: None,
+            change_scope: crate::sidebar::sections::ChangeScope::default(),
             changes_row_error: None,
             _stage_tasks: TaskPool::new(),
             change_row_hover: None,
@@ -1396,7 +1397,7 @@ impl AdeApp {
                         && this.file_tree_complete == listing.is_complete()
                         && this.file_tree == listing.tree;
                     (
-                        palette_render::file_diff_marks(this.current_diff()),
+                        palette_render::file_diff_marks(this.scoped_diff()),
                         unchanged,
                     )
                 })
@@ -1436,7 +1437,7 @@ impl AdeApp {
                 // before it. Re-deriving here is the O(loaded files) foreground pass this whole
                 // arrangement exists to avoid, so it is gated on the marks having genuinely moved
                 // - which needs one cheap comparison over the diff's files, not the tree's.
-                if palette_render::file_diff_marks(this.current_diff()) != marks {
+                if palette_render::file_diff_marks(this.scoped_diff()) != marks {
                     this.rebuild_palette_file_candidates();
                 }
                 this.prune_stale_fold_state(cx);

--- a/crates/app/src/sidebar/render.rs
+++ b/crates/app/src/sidebar/render.rs
@@ -711,7 +711,9 @@ impl AdeApp {
     pub(in crate::sidebar) fn tree_change_marks(
         &self,
     ) -> HashMap<PathBuf, (&'static str, gpui::Rgba)> {
-        let Some(diff) = self.current_diff() else {
+        // `scoped_diff`, never `current_diff` directly: the tree's marks must show the same
+        // scope the Changes panel lists (GitHub issue #487).
+        let Some(diff) = self.scoped_diff() else {
             return HashMap::new();
         };
         diff.files
@@ -1682,7 +1684,15 @@ impl AdeApp {
             },
         );
 
-        let totals = self.diff_totals;
+        // Scoped like every other changed-file surface (GitHub issue #487): the header's +n/−n
+        // must total the same list the panel below it shows, not always the against-base diff.
+        let totals = match self.change_scope {
+            sections::ChangeScope::AllChanges => self.diff_totals,
+            sections::ChangeScope::Uncommitted => self.uncommitted_diff.loaded().map(|_| {
+                let total = self.uncommitted_change_set.total();
+                (total.added, total.removed)
+            }),
+        };
 
         div()
             // See `crate::work_surface::render::AdeApp::render_tab_strip`'s own selector: the
@@ -1893,8 +1903,16 @@ impl AdeApp {
             // *bottom*, in its own capped well below the other three's shared scroller
             // (`Self::render_changes_runs_section`) - a separate, capped wrapper, not a fourth
             // entry in the shared one.
+            // The scope selector reads first (GitHub issue #487): it decides what every row
+            // below it means. The commit composer renders only under the Uncommitted scope -
+            // it is a git control acting on exactly that scope's list, and under All changes
+            // there is no staged set on screen for it to act on.
             RightSidebarView::Changes => container
-                .child(self.render_commit_composer(cx))
+                .child(self.render_change_scope_selector(cx))
+                .when(
+                    self.change_scope == sections::ChangeScope::Uncommitted,
+                    |el| el.child(self.render_commit_composer(cx)),
+                )
                 .children(self.render_changes_row_error(cx))
                 // Not `.overflow_y_scroll()` - `Self::render_changes_sections`' `gpui::list` owns
                 // its own scrolling, exactly like the Files arm's `uniform_list` above.
@@ -1917,6 +1935,37 @@ impl AdeApp {
                 )),
         }
         .into_any_element()
+    }
+
+    /// The change-scope selector (GitHub issue #487): two segments in
+    /// [`Self::render_choice_control`]'s standard shell, deciding which git scope the whole
+    /// panel - and every changed-file surface - shows. Left to right narrowing to widening,
+    /// the same order the old section ladder read in.
+    fn render_change_scope_selector(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        div()
+            .flex_none()
+            .flex()
+            .items_center()
+            .pl(px(10.0))
+            .py(px(4.0))
+            .child(self.render_choice_control(
+                "change-scope",
+                &[
+                    ChoiceOption::new(sections::ChangeScope::Uncommitted.label()),
+                    ChoiceOption::new(sections::ChangeScope::AllChanges.label()),
+                ],
+                self.change_scope.label().to_string(),
+                cx,
+                |this, index, _window, cx| {
+                    // Structural, index-based dispatch per the options literal right above -
+                    // `Self::render_choice_control`'s own convention.
+                    let scope = match index {
+                        0 => sections::ChangeScope::Uncommitted,
+                        _ => sections::ChangeScope::AllChanges,
+                    };
+                    this.set_change_scope(scope, cx);
+                },
+            ))
     }
 
     /// The real base branch the panel's Commits and Against-main sections are scoped to, or `None`
@@ -1980,14 +2029,14 @@ impl AdeApp {
         let mut rows: Vec<sections::SectionRow> = Vec::new();
 
         for section in sections::ChangesSection::ORDER {
+            // The scope decides which of the two file sections exists at all (GitHub issue
+            // #487); a hidden section renders no header either - it is not a collapsed section,
+            // it is not part of the panel under this scope.
+            if !self.change_scope.shows(section) {
+                continue;
+            }
             let body = self.changes_section_body(section, cx);
-            // Against main is the one exception: it renders no row per file (see
-            // `SectionRow::AgainstMainContext`'s own docs), so its count reads the real file
-            // total directly rather than counting rows that do not exist.
-            let count = match section {
-                sections::ChangesSection::AgainstMain => self.change_set.len(),
-                _ => body.iter().filter(|row| row.is_counted()).count(),
-            };
+            let count = body.iter().filter(|row| row.is_counted()).count();
             let open = self.changes_sections.is_open(section);
             rows.push(sections::SectionRow::Header(sections::SectionHeader {
                 section,
@@ -2116,20 +2165,18 @@ impl AdeApp {
                 if self.change_set.is_empty() {
                     return vec![quiet("this branch matches its base exactly")];
                 }
-                let mut body: Vec<SectionRow> = Vec::new();
+                // One row per branch file - see `SectionRow::AgainstMainFile`'s docs for why
+                // this reverses issue #285's earlier "no committed rows here" call now that the
+                // scope selector shows one file list at a time (GitHub issue #487).
+                let mut body: Vec<SectionRow> = (0..self.change_set.len())
+                    .map(SectionRow::AgainstMainFile)
+                    .collect();
                 // The read-only context card, deliberately **not** a counted row - see
-                // `SectionRow::is_counted`. This section carries no action buttons at all: a
-                // product decision recorded on GitHub issue #285. Merging a
-                // branch into its base is the git graph's job (issue #241) and removing a
-                // worktree already has its own entry point on the rail's worktree context menu,
-                // so putting either here would be a second home for an action that already has
+                // `SectionRow::is_counted`. This section still carries no action buttons:
+                // merging a branch into its base is the git graph's job (issue #241) and
+                // removing a worktree has its own entry point on the rail's worktree context
+                // menu, so either here would be a second home for an action that already has
                 // one - the exact defect §4e removed them from the agent header for.
-                //
-                // No per-file rows, though issue #285's own checklist says "diffstat, file list
-                // and commit context" - a deliberate deviation from that restated checklist: the
-                // design carries a plain file *count* here, never an array of files, so a
-                // committed file was never meant to be its own row. Requested directly:
-                // "commited files should not appear on the changes tab under against master."
                 let base = self.changes_base_branch().map(str::to_string);
                 if let Some(base) = base {
                     body.push(SectionRow::AgainstMainContext {
@@ -2321,6 +2368,12 @@ impl AdeApp {
                     None => div().into_any_element(),
                 }
             }
+            SectionRow::AgainstMainFile(index) => match self.change_set.entries().get(*index) {
+                Some(entry) => self
+                    .render_change_row(entry, ChangesSection::AgainstMain, cx)
+                    .into_any_element(),
+                None => div().into_any_element(),
+            },
             SectionRow::Commit(commit) => self.render_commit_row(commit).into_any_element(),
             SectionRow::AgainstMainContext { text, sub } => self
                 .render_against_main_context(text, sub)
@@ -3197,6 +3250,13 @@ impl AdeApp {
     /// The open file ([`Self::open_change`]) *as an Uncommitted-section row*, or `None` when
     /// nothing is open or what is open has no live uncommitted delta.
     pub(in crate::sidebar) fn open_uncommitted_change(&self) -> Option<&PathBuf> {
+        // Scope-gated (GitHub issue #487): staging and seen-marks are uncommitted-scope
+        // machinery, and every caller - the two footer keycap hints and both keyboard actions -
+        // funnels through here. Under All changes the keys no-op and the hints say so, rather
+        // than acting on a list that is not on screen.
+        if self.change_scope != sections::ChangeScope::Uncommitted {
+            return None;
+        }
         let path = self.open_change.as_ref()?;
         self.uncommitted_change_set
             .entry(path)
@@ -4350,6 +4410,9 @@ mod virtualization_tests {
         let (app, cx) = palette_focus_tests::open_test_app(cx, repo.clone());
         app.update_in(cx, |app, window, cx| {
             app.set_right_sidebar_view(RightSidebarView::Changes, window, cx);
+            // The `change-row-*` selectors below belong to the Uncommitted list (GitHub issue
+            // #487); which scope hosts the 40 rows is irrelevant to virtualization itself.
+            app.set_change_scope(crate::sidebar::sections::ChangeScope::Uncommitted, cx);
         });
         cx.run_until_parked();
 
@@ -4456,6 +4519,9 @@ mod change_row_selection_tests {
         let (app, cx) = palette_focus_tests::open_test_app(cx, repo.clone());
         app.update_in(cx, |app, window, cx| {
             app.set_right_sidebar_view(RightSidebarView::Changes, window, cx);
+            // The `change-row-*` selectors below belong to the Uncommitted list (GitHub issue
+            // #487); the selection edge itself is scope-independent.
+            app.set_change_scope(crate::sidebar::sections::ChangeScope::Uncommitted, cx);
         });
         cx.run_until_parked();
 
@@ -5469,6 +5535,12 @@ mod commit_composer_tests {
         let (app, cx) = palette_focus_tests::open_test_app(cx, repo.to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.set_right_sidebar_view(RightSidebarView::Changes, window, cx);
+        });
+        // The composer and staging are Uncommitted-scope machinery (GitHub issue #487) - the
+        // default All-changes scope renders neither, so this module tests under the scope its
+        // subject lives in.
+        app.update(cx, |app, cx| {
+            app.set_change_scope(crate::sidebar::sections::ChangeScope::Uncommitted, cx);
         });
         cx.run_until_parked();
         (app, cx)
@@ -6753,21 +6825,15 @@ mod commit_composer_tests {
              issue #220, removed by construction rather than by a per-row condition"
         );
 
-        // ...and it really is counted in the branch-scope section, which starts collapsed - but
-        // never as a row of its own, open or not (see `SectionRow::AgainstMainContext`'s own
-        // docs: Against main renders no row per file at all).
-        assert!(
-            cx.debug_bounds("against-main-row-committed.txt").is_none(),
-            "premise: Against main starts collapsed, so nothing of it is painted yet"
-        );
+        // ...and the committed file lives in the All-changes scope instead (GitHub issue #487):
+        // switching the scope is what reveals it, as a real row of its own.
         app.update(cx, |app, cx| {
-            app.toggle_changes_section(sections::ChangesSection::AgainstMain, cx);
+            app.set_change_scope(sections::ChangeScope::AllChanges, cx);
         });
         cx.run_until_parked();
         assert!(
-            cx.debug_bounds("against-main-row-committed.txt").is_none(),
-            "expanding Against main must still not paint a row for the committed file - only its \
-             one context card"
+            cx.debug_bounds("against-main-row-committed.txt").is_some(),
+            "reviewing what the branch would land is exactly what the All-changes scope is for"
         );
         let rows = app.update(cx, |app, cx| app.changes_section_rows(cx));
         let against_main_count = rows.iter().find_map(|row| match row {
@@ -6781,12 +6847,13 @@ mod commit_composer_tests {
         assert_eq!(
             against_main_count,
             Some(2),
-            "reviewing what the branch would land is exactly what this scope is for - the \
-             committed file is still counted (alongside dirty.txt), just not given its own row"
+            "the committed file is counted alongside dirty.txt"
         );
         assert!(
-            cx.debug_bounds("stage-checkbox-committed.txt").is_none(),
-            "and it offers no checkbox anywhere: checkboxes exist only in Uncommitted"
+            cx.debug_bounds("stage-checkbox-committed.txt").is_none()
+                && cx.debug_bounds("stage-checkbox-dirty.txt").is_none(),
+            "and no row offers a checkbox in this scope: staging exists only under Uncommitted \
+             (issue #220's misleading `stage me` checkbox stays removed by construction)"
         );
     }
 
@@ -6869,14 +6936,15 @@ mod commit_composer_tests {
             "the Uncommitted section is genuinely empty now, and its header says 0"
         );
 
+        // The committed work is still reviewable - it moved scopes, not vanished (GitHub issue
+        // #487): the All-changes list holds it as a real row.
         app.update(cx, |app, cx| {
-            app.toggle_changes_section(sections::ChangesSection::AgainstMain, cx);
+            app.set_change_scope(sections::ChangeScope::AllChanges, cx);
         });
         cx.run_until_parked();
         assert!(
-            cx.debug_bounds("against-main-row-dirty.txt").is_none(),
-            "it still differs from `main`, so it is still counted in the branch-scope section - \
-             but never as a row of its own, open or not"
+            cx.debug_bounds("against-main-row-dirty.txt").is_some(),
+            "it still differs from `main`, so the All-changes scope lists it as its own row"
         );
         let rows = app.update(cx, |app, cx| app.changes_section_rows(cx));
         let against_main_count = rows.iter().find_map(|row| match row {
@@ -6972,7 +7040,7 @@ mod changes_sections_tests {
     use super::*;
     use crate::provenance::{AgentKey, Author, DiffStat};
     use crate::root::focus::palette_focus_tests;
-    use crate::sidebar::sections::{ChangesSection, SectionRow};
+    use crate::sidebar::sections::{ChangeScope, ChangesSection, SectionRow};
     use gpui::TestAppContext;
     use tempfile::TempDir;
     use test_support::{git, seed_empty_repo_at};
@@ -7013,6 +7081,15 @@ mod changes_sections_tests {
         (app, cx)
     }
 
+    fn switch_scope(
+        app: &gpui::Entity<AdeApp>,
+        cx: &mut gpui::VisualTestContext,
+        scope: ChangeScope,
+    ) {
+        app.update(cx, |app, cx| app.set_change_scope(scope, cx));
+        cx.run_until_parked();
+    }
+
     fn open_every_section(app: &gpui::Entity<AdeApp>, cx: &mut gpui::VisualTestContext) {
         app.update(cx, |app, cx| {
             for section in ChangesSection::ORDER {
@@ -7025,16 +7102,22 @@ mod changes_sections_tests {
     }
 
     #[gpui::test]
-    fn the_panel_is_four_sections_with_runs_and_uncommitted_open_by_default(
+    fn each_scope_paints_its_own_file_list_open_with_commits_collapsed_and_runs_open(
         cx: &mut TestAppContext,
     ) {
         let (_repo_dir, repo) = four_scope_repo();
-        let (_app, cx) = open_changes_view(cx, &repo);
+        let (app, cx) = open_changes_view(cx, &repo);
 
+        // The default All-changes scope (GitHub issue #487): Against main is the file list, and
+        // the Uncommitted section does not exist at all - not even as a collapsed header.
         assert!(
-            cx.debug_bounds("changes-section-uncommitted-2-open")
+            cx.debug_bounds("changes-section-against-main-4-open")
                 .is_some(),
-            "the Uncommitted header must state its real count and start open"
+            "the default scope's file list must state its real count and start open"
+        );
+        assert!(
+            cx.debug_bounds("against-main-row-done-a.txt").is_some(),
+            "and paint its rows - a committed branch file is a real row under All changes"
         );
         assert!(
             cx.debug_bounds("changes-section-commits-2-collapsed")
@@ -7043,31 +7126,42 @@ mod changes_sections_tests {
              count on a closed section"
         );
         assert!(
-            cx.debug_bounds("changes-section-against-main-4-collapsed")
-                .is_some(),
-            "and so does Against main"
-        );
-        assert!(
             cx.debug_bounds("changes-section-runs-0-open").is_some(),
             "Runs is open by default too, even with no agent having run here yet"
         );
-
         assert!(
-            cx.debug_bounds("change-row-dirty-a.txt").is_some(),
-            "an open section paints its rows"
-        );
-        assert!(
-            cx.debug_bounds("against-main-row-done-a.txt").is_none(),
-            "a collapsed section paints none of them"
+            cx.debug_bounds("changes-section-uncommitted-2-open")
+                .is_none()
+                && cx
+                    .debug_bounds("changes-section-uncommitted-2-collapsed")
+                    .is_none(),
+            "the Uncommitted section must not render under All changes - hidden means gone, \
+             not collapsed"
         );
         assert!(
             cx.debug_bounds("changes-commit-").is_none(),
-            "nor does Commits"
+            "a collapsed Commits paints no rows"
+        );
+
+        switch_scope(&app, cx, ChangeScope::Uncommitted);
+        assert!(
+            cx.debug_bounds("changes-section-uncommitted-2-open")
+                .is_some(),
+            "the Uncommitted scope's own file list opens in its place"
+        );
+        assert!(
+            cx.debug_bounds("change-row-dirty-a.txt").is_some(),
+            "with its rows painted"
+        );
+        assert!(
+            cx.debug_bounds("changes-section-against-main-4-open")
+                .is_none(),
+            "and Against main is gone in the same way"
         );
     }
 
     #[gpui::test]
-    fn the_tab_is_called_changes_and_uncommitted_is_one_of_its_four_sections(
+    fn the_tab_is_called_changes_and_the_scope_decides_which_file_section_leads(
         cx: &mut TestAppContext,
     ) {
         let (_repo_dir, repo) = four_scope_repo();
@@ -7087,24 +7181,36 @@ mod changes_sections_tests {
             "and that segment selects the Changes view"
         );
 
-        let rows = app.update(cx, |app, cx| app.changes_section_rows(cx));
-        let labels: Vec<String> = rows
-            .iter()
-            .filter_map(|row| match row {
-                SectionRow::Header(header) => Some(header.label.clone()),
-                _ => None,
+        let header_labels = |app: &gpui::Entity<AdeApp>, cx: &mut gpui::VisualTestContext| {
+            app.update(cx, |app, cx| {
+                app.changes_section_rows(cx)
+                    .iter()
+                    .filter_map(|row| match row {
+                        SectionRow::Header(header) => Some(header.label.clone()),
+                        _ => None,
+                    })
+                    .collect::<Vec<String>>()
             })
-            .collect();
+        };
         assert_eq!(
-            labels,
+            header_labels(&app, cx),
+            vec![
+                "AGAINST MAIN".to_string(),
+                "COMMITS".to_string(),
+                "RUNS".to_string(),
+            ],
+            "one panel, three sections per scope, the scope's own file list leading - and \
+             `Uncommitted` is a section name under its scope, never the name of the whole panel"
+        );
+        switch_scope(&app, cx, ChangeScope::Uncommitted);
+        assert_eq!(
+            header_labels(&app, cx),
             vec![
                 "UNCOMMITTED".to_string(),
                 "COMMITS".to_string(),
-                "AGAINST MAIN".to_string(),
                 "RUNS".to_string(),
             ],
-            "one panel, four sections, and `Uncommitted` is one of them - never the name of the \
-             whole panel"
+            "the Uncommitted scope swaps exactly the leading file section and nothing else"
         );
     }
 
@@ -7112,59 +7218,64 @@ mod changes_sections_tests {
     fn every_section_header_count_equals_the_number_of_rows_it_renders(cx: &mut TestAppContext) {
         let (_repo_dir, repo) = four_scope_repo();
         let (app, cx) = open_changes_view(cx, &repo);
-        open_every_section(&app, cx);
 
-        // The generic form, over the exact row list the renderer consumes: for every header
-        // *except Against main*, the number of counted rows between it and the next header is
-        // that header's own `count`. Against main is the one exception - it renders no row per
-        // file at all (`SectionRow::AgainstMainContext`'s own docs), so its count is checked
-        // separately below, against the real file total instead of a rendered-row tally.
-        let rows = app.update(cx, |app, cx| app.changes_section_rows(cx));
-        let mut current: Option<(ChangesSection, usize)> = None;
-        let mut counted = 0usize;
-        let mut checked = 0usize;
-        let close = |section: ChangesSection, claimed: usize, actual: usize| {
-            if section == ChangesSection::AgainstMain {
-                return;
-            }
-            assert_eq!(
-                claimed,
-                actual,
-                "the {} header claims {claimed} rows but the list holds {actual}",
-                section.key()
-            );
-        };
-        for row in &rows {
-            if let SectionRow::Header(header) = row {
+        // The generic form, over the exact row list the renderer consumes, in both scopes: for
+        // every header, the number of counted rows between it and the next header is that
+        // header's own `count`. Since issue #487 Against main lists real per-file rows, so it
+        // is no longer an exception.
+        let check_scope =
+            |app: &gpui::Entity<AdeApp>, cx: &mut gpui::VisualTestContext, scope: ChangeScope| {
+                let rows = app.update(cx, |app, cx| app.changes_section_rows(cx));
+                let mut current: Option<(ChangesSection, usize)> = None;
+                let mut counted = 0usize;
+                let mut checked = 0usize;
+                let close = |section: ChangesSection, claimed: usize, actual: usize| {
+                    assert_eq!(
+                        claimed,
+                        actual,
+                        "under {scope:?}, the {} header claims {claimed} rows but the list holds \
+                     {actual}",
+                        section.key()
+                    );
+                };
+                for row in &rows {
+                    if let SectionRow::Header(header) = row {
+                        if let Some((section, claimed)) = current.take() {
+                            close(section, claimed, counted);
+                            checked += 1;
+                        }
+                        current = Some((header.section, header.count));
+                        counted = 0;
+                    } else if row.is_counted() {
+                        counted += 1;
+                    }
+                }
                 if let Some((section, claimed)) = current.take() {
                     close(section, claimed, counted);
                     checked += 1;
                 }
-                current = Some((header.section, header.count));
-                counted = 0;
-            } else if row.is_counted() {
-                counted += 1;
-            }
-        }
-        if let Some((section, claimed)) = current.take() {
-            close(section, claimed, counted);
-            checked += 1;
-        }
-        assert_eq!(checked, 4, "all four sections must have been checked");
+                assert_eq!(
+                    checked, 3,
+                    "under {scope:?}, exactly the scope's three sections must have been checked"
+                );
+            };
 
-        let against_main_count = rows.iter().find_map(|row| match row {
-            SectionRow::Header(header) if header.section == ChangesSection::AgainstMain => {
-                Some(header.count)
-            }
-            _ => None,
-        });
-        assert_eq!(
-            against_main_count,
-            Some(4),
-            "against main's count is the real file total (dirty-a, dirty-b, done-a, done-b), \
-             not a tally of rows it never renders"
-        );
+        open_every_section(&app, cx);
+        check_scope(&app, cx, ChangeScope::AllChanges);
+        for selector in [
+            "against-main-row-dirty-a.txt",
+            "against-main-row-done-a.txt",
+        ] {
+            assert!(
+                cx.debug_bounds(selector).is_some(),
+                "{selector} must really paint - the All-changes count is a tally of real rows \
+                 now, not a bare number"
+            );
+        }
 
+        switch_scope(&app, cx, ChangeScope::Uncommitted);
+        open_every_section(&app, cx);
+        check_scope(&app, cx, ChangeScope::Uncommitted);
         for selector in ["change-row-dirty-a.txt", "change-row-dirty-b.txt"] {
             assert!(
                 cx.debug_bounds(selector).is_some(),
@@ -7174,19 +7285,26 @@ mod changes_sections_tests {
     }
 
     #[gpui::test]
-    fn checkboxes_exist_only_in_the_uncommitted_section(cx: &mut TestAppContext) {
+    fn staging_checkboxes_exist_only_under_the_uncommitted_scope(cx: &mut TestAppContext) {
         let (_repo_dir, repo) = four_scope_repo();
         let (app, cx) = open_changes_view(cx, &repo);
         open_every_section(&app, cx);
 
+        // Default All-changes scope: the dirty file paints as a real row, but nothing stages -
+        // staging acts on the uncommitted scope's list only (GitHub issue #487).
         assert!(
-            cx.debug_bounds("stage-checkbox-dirty-a.txt").is_some(),
-            "the Uncommitted section stages"
+            cx.debug_bounds("against-main-row-dirty-a.txt").is_some(),
+            "premise: the dirty file really is a row under All changes"
         );
         assert!(
-            cx.debug_bounds("against-main-row-dirty-a.txt").is_none(),
-            "Against main renders no row per file at all (`SectionRow::AgainstMainContext`'s own \
-             docs), so there is no second row here for a stray checkbox to double up on"
+            cx.debug_bounds("stage-checkbox-dirty-a.txt").is_none(),
+            "and still carries no checkbox there"
+        );
+
+        switch_scope(&app, cx, ChangeScope::Uncommitted);
+        assert!(
+            cx.debug_bounds("stage-checkbox-dirty-a.txt").is_some(),
+            "the Uncommitted scope's own list stages"
         );
         // The structural guarantee is `ChangesSection::has_checkboxes`, asserted directly in
         // `crate::sidebar::sections`' own tests; this is its rendered half.
@@ -7195,6 +7313,7 @@ mod changes_sections_tests {
             .iter()
             .filter_map(|row| match row {
                 SectionRow::UncommittedFile(_) => Some(ChangesSection::Uncommitted),
+                SectionRow::AgainstMainFile(_) => Some(ChangesSection::AgainstMain),
                 SectionRow::Commit(_) => Some(ChangesSection::Commits),
                 SectionRow::Run(_) => Some(ChangesSection::Runs),
                 _ => None,
@@ -7218,6 +7337,9 @@ mod changes_sections_tests {
     fn collapsing_a_section_unpaints_its_rows_and_keeps_its_count(cx: &mut TestAppContext) {
         let (_repo_dir, repo) = four_scope_repo();
         let (app, cx) = open_changes_view(cx, &repo);
+        // Collapse mechanics are scope-independent; tested on the Uncommitted list because its
+        // selectors are the stable ones the rest of this module already reads.
+        switch_scope(&app, cx, ChangeScope::Uncommitted);
         assert!(cx.debug_bounds("change-row-dirty-a.txt").is_some());
 
         app.update(cx, |app, cx| {
@@ -7242,16 +7364,14 @@ mod changes_sections_tests {
     }
 
     #[gpui::test]
-    fn the_against_main_section_renders_no_action_buttons_and_no_file_rows(
+    fn the_against_main_section_lists_files_but_still_renders_no_action_buttons(
         cx: &mut TestAppContext,
     ) {
-        // The product decision recorded on GitHub issue #285: merging is the git
-        // graph's job and worktree removal already has its entry point on the rail, so this
-        // section is read-only.
-        //
-        // And, separately: no row per committed file either, reported directly ("commited files
-        // should not appear on the changes tab under against master"). Against main's only real
-        // body row is its context card.
+        // Issue #285's read-only half stands: merging is the git graph's job and worktree
+        // removal has its entry point on the rail, so this section carries no action rows. Its
+        // "no row per committed file" half is superseded by the scope selector (GitHub issue
+        // #487, `SectionRow::AgainstMainFile`'s own docs): with one file list at a time, the
+        // duplication that call prevented cannot occur.
         let (_repo_dir, repo) = four_scope_repo();
         let (app, cx) = open_changes_view(cx, &repo);
         open_every_section(&app, cx);
@@ -7271,23 +7391,25 @@ mod changes_sections_tests {
             assert!(
                 matches!(
                     row,
-                    SectionRow::AgainstMainContext { .. } | SectionRow::Note { .. }
+                    SectionRow::AgainstMainFile(_)
+                        | SectionRow::AgainstMainContext { .. }
+                        | SectionRow::Note { .. }
                 ),
-                "the Against-main section may only hold its context card and its own notes - no \
-                 action rows, and no row per file: {row:?}"
+                "the Against-main section holds file rows, its context card, and its own notes - \
+                 never an action row: {row:?}"
             );
         }
         assert!(
             against_main
                 .iter()
                 .any(|row| matches!(row, SectionRow::AgainstMainContext { .. })),
-            "it does still carry the read-only commit context"
+            "it still carries the read-only commit context, after the file rows"
         );
         assert!(
-            cx.debug_bounds("against-main-row-done-a.txt").is_none(),
-            "and neither committed file painted a row of its own"
+            cx.debug_bounds("against-main-row-done-a.txt").is_some(),
+            "a committed branch file paints a real row of its own now"
         );
-        assert!(cx.debug_bounds("against-main-row-done-b.txt").is_none());
+        assert!(cx.debug_bounds("against-main-row-done-b.txt").is_some());
     }
 
     #[gpui::test]
@@ -7305,6 +7427,9 @@ mod changes_sections_tests {
         git(&repo, &["commit", "-m", "initial"]);
 
         let (app, cx) = open_changes_view(cx, &repo);
+        // The Uncommitted header this test compares against only renders under its own scope
+        // (GitHub issue #487).
+        switch_scope(&app, cx, ChangeScope::Uncommitted);
         let agent_id = app
             .read_with(cx, |app, _| app.agents.active_id())
             .expect("the real startup agent");
@@ -7595,6 +7720,12 @@ mod change_row_tests {
         let (app, cx) = palette_focus_tests::open_test_app(cx, repo.to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.set_right_sidebar_view(RightSidebarView::Changes, window, cx);
+        });
+        // Seen marks, staging, and the `change-row-*` selectors these tests drive are all
+        // Uncommitted-scope machinery (GitHub issue #487), so this module tests under the scope
+        // its subject lives in.
+        app.update(cx, |app, cx| {
+            app.set_change_scope(crate::sidebar::sections::ChangeScope::Uncommitted, cx);
         });
         cx.run_until_parked();
         (app, cx)
@@ -8427,5 +8558,189 @@ mod file_tree_root_row_tests {
     fn a_root_with_no_final_component_falls_back_to_its_full_path() {
         let displayed = Path::new("/").display().to_string();
         assert_eq!(super::file_tree_root_label(Path::new("/")), displayed);
+    }
+}
+
+/// GitHub issue #487: one scope selector governs which file list the Changes panel shows, and
+/// every changed-file surface - tree marks, the open file's hunks, staging affordances - derives
+/// from that same scope instead of picking its own.
+#[cfg(test)]
+mod change_scope_panel_tests {
+    use super::RightSidebarView;
+    use crate::root::focus::palette_focus_tests;
+    use crate::sidebar::fixtures;
+    use crate::sidebar::sections::{ChangeScope, ChangesSection, SectionRow};
+    use gpui::TestAppContext;
+    use std::fs;
+    use std::path::PathBuf;
+    use test_support::{git, seed_empty_repo_at};
+
+    /// A branch where the two scopes genuinely differ: `committed.txt` carries a *committed*
+    /// branch change (against-base only), `dirty.txt` a tracked-but-uncommitted edit (both
+    /// scopes). Tracked rather than untracked, so the uncommitted side never depends on how
+    /// untracked files are diffed.
+    fn seed_scoped_repo() -> (tempfile::TempDir, PathBuf) {
+        let (dir, repo) = fixtures::temp_root();
+        seed_empty_repo_at(&repo);
+        fs::write(repo.join("committed.txt"), "base\n").expect("write");
+        fs::write(repo.join("dirty.txt"), "base\n").expect("write");
+        git(&repo, &["add", "."]);
+        git(&repo, &["commit", "-m", "initial"]);
+        git(&repo, &["checkout", "-b", "feature"]);
+        fs::write(repo.join("committed.txt"), "base\nbranch work\n").expect("write");
+        git(&repo, &["add", "."]);
+        git(&repo, &["commit", "-m", "branch work"]);
+        fs::write(repo.join("dirty.txt"), "base\nwip\n").expect("write");
+        (dir, repo)
+    }
+
+    fn open_on_changes(
+        cx: &mut TestAppContext,
+        repo: PathBuf,
+    ) -> (
+        gpui::Entity<crate::root::AdeApp>,
+        &mut gpui::VisualTestContext,
+    ) {
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo);
+        app.update_in(cx, |app, window, cx| {
+            app.set_right_sidebar_view(RightSidebarView::Changes, window, cx);
+        });
+        cx.run_until_parked();
+        (app, cx)
+    }
+
+    #[gpui::test]
+    fn the_default_all_changes_scope_lists_branch_files_and_hides_uncommitted_machinery(
+        cx: &mut TestAppContext,
+    ) {
+        let (_dir, repo) = seed_scoped_repo();
+        let (app, cx) = open_on_changes(cx, repo.clone());
+
+        app.read_with(cx, |app, _| {
+            assert_eq!(
+                app.current_diff().map(|diff| diff.files.len()),
+                Some(2),
+                "premise: the against-base diff must see both files"
+            );
+            assert_eq!(
+                app.uncommitted_diff.loaded().map(|diff| diff.files.len()),
+                Some(1),
+                "premise: the uncommitted diff must see only the dirty file"
+            );
+        });
+
+        let rows = app.update(cx, |app, cx| app.changes_section_rows(cx));
+        assert!(
+            rows.iter()
+                .any(|row| matches!(row, SectionRow::AgainstMainFile(_))),
+            "the default All-changes scope must list the branch's files as real rows"
+        );
+        assert!(
+            !rows
+                .iter()
+                .any(|row| row.section() == ChangesSection::Uncommitted),
+            "the Uncommitted section must not render at all under the All-changes scope - one \
+             file list at a time is the whole point of the selector"
+        );
+
+        assert!(
+            cx.debug_bounds("against-main-row-committed.txt").is_some(),
+            "a committed branch file must paint as a real row under All changes"
+        );
+        assert!(
+            cx.debug_bounds("stage-checkbox-committed.txt").is_none()
+                && cx.debug_bounds("stage-checkbox-dirty.txt").is_none(),
+            "no row stages under All changes - staging acts on the uncommitted scope only"
+        );
+        assert!(
+            cx.debug_bounds("commit-composer").is_none(),
+            "the commit composer is an uncommitted-scope control"
+        );
+
+        app.read_with(cx, |app, _| {
+            let marks = app.tree_change_marks();
+            assert!(
+                marks.contains_key(&repo.join("committed.txt"))
+                    && marks.contains_key(&repo.join("dirty.txt")),
+                "All-changes tree marks must cover the whole branch diff, matching the panel"
+            );
+        });
+    }
+
+    #[gpui::test]
+    fn switching_to_uncommitted_scope_swaps_the_list_the_marks_and_the_composer(
+        cx: &mut TestAppContext,
+    ) {
+        let (_dir, repo) = seed_scoped_repo();
+        let (app, cx) = open_on_changes(cx, repo.clone());
+
+        app.update(cx, |app, cx| {
+            app.set_change_scope(ChangeScope::Uncommitted, cx);
+        });
+        cx.run_until_parked();
+
+        let rows = app.update(cx, |app, cx| app.changes_section_rows(cx));
+        assert!(
+            rows.iter()
+                .any(|row| matches!(row, SectionRow::UncommittedFile(_))),
+            "the Uncommitted scope must list the dirty file as a real row"
+        );
+        assert!(
+            !rows
+                .iter()
+                .any(|row| row.section() == ChangesSection::AgainstMain),
+            "the Against-main section must not render at all under the Uncommitted scope"
+        );
+
+        assert!(
+            cx.debug_bounds("change-row-dirty.txt").is_some(),
+            "the dirty file must paint as a stageable row"
+        );
+        assert!(
+            cx.debug_bounds("stage-checkbox-dirty.txt").is_some(),
+            "the Uncommitted scope is where staging lives"
+        );
+        assert!(
+            cx.debug_bounds("commit-composer").is_some(),
+            "and where the commit composer lives"
+        );
+
+        app.read_with(cx, |app, _| {
+            let marks = app.tree_change_marks();
+            assert!(
+                marks.contains_key(&repo.join("dirty.txt")),
+                "the dirty file keeps its tree mark under the Uncommitted scope"
+            );
+            assert!(
+                !marks.contains_key(&repo.join("committed.txt")),
+                "a committed-only change is not uncommitted - the tree must agree with the \
+                 panel instead of marking files the list does not show (issue #487)"
+            );
+        });
+    }
+
+    #[gpui::test]
+    fn the_open_files_diff_hunks_follow_the_scope(cx: &mut TestAppContext) {
+        let (_dir, repo) = seed_scoped_repo();
+        let (app, cx) = open_on_changes(cx, repo.clone());
+
+        app.update_in(cx, |app, window, cx| {
+            app.open_file_view(repo.join("committed.txt"), window, cx);
+        });
+        cx.run_until_parked();
+        assert!(
+            app.read_with(cx, |app, _| !app.file_view_changed_lines.is_empty()),
+            "premise: under All changes the committed branch hunk must mark changed lines"
+        );
+
+        app.update(cx, |app, cx| {
+            app.set_change_scope(ChangeScope::Uncommitted, cx);
+        });
+        cx.run_until_parked();
+        assert!(
+            app.read_with(cx, |app, _| app.file_view_changed_lines.is_empty()),
+            "a committed-only file has no uncommitted hunks, so its gutter must clear the \
+             moment the scope narrows - the open file follows the same scope as everything else"
+        );
     }
 }

--- a/crates/app/src/sidebar/sections.rs
+++ b/crates/app/src/sidebar/sections.rs
@@ -47,15 +47,14 @@ pub enum ChangesSection {
 }
 
 impl ChangesSection {
-    /// Top to bottom, exactly as the design paints them and states in as many words:
-    /// "Four stacked sections, in this order: Uncommitted, Commits, Against main, Runs.
-    /// The first three are one ladder of git state, narrowing to widening. Runs is not on that
-    /// ladder — it indexes the same changes by author — so it sits after it rather than inside it,
-    /// which also keeps Uncommitted's top edge fixed however many agents have run."
+    /// Top to bottom *before* [`ChangeScope::shows`] filters it: the two file sections lead so
+    /// that whichever one the scope keeps is the panel's first section - the scope's own list is
+    /// the panel's main content - with Commits under it and Runs last, off the git ladder
+    /// (it re-indexes the same changes by author). Only one of the first two ever renders.
     pub const ORDER: [ChangesSection; 4] = [
         ChangesSection::Uncommitted,
-        ChangesSection::Commits,
         ChangesSection::AgainstMain,
+        ChangesSection::Commits,
         ChangesSection::Runs,
     ];
 
@@ -86,11 +85,15 @@ impl ChangesSection {
         }
     }
 
-    /// Runs and Uncommitted open by default; the two git-history sections start collapsed.
+    /// Every section that can carry the scope's file list opens by default - only one of the two
+    /// is ever visible at a time ([`ChangeScope::shows`]), and a default scope whose file list
+    /// started collapsed would render the panel empty. Commits alone starts collapsed.
     pub fn starts_open(self) -> bool {
         match self {
-            ChangesSection::Runs | ChangesSection::Uncommitted => true,
-            ChangesSection::Commits | ChangesSection::AgainstMain => false,
+            ChangesSection::Runs | ChangesSection::Uncommitted | ChangesSection::AgainstMain => {
+                true
+            }
+            ChangesSection::Commits => false,
         }
     }
 
@@ -107,6 +110,51 @@ impl ChangesSection {
     /// Whether rows in this section carry a staging checkbox.
     pub fn has_checkboxes(self) -> bool {
         matches!(self, ChangesSection::Uncommitted)
+    }
+}
+
+/// Which git scope the Changes panel's file list - and every surface that marks changed files:
+/// tree markers, palette marks, the opened diff's hunks - derives from (GitHub issue #487).
+/// One value drives all of them, which is the whole point: the surfaces used to pick scopes
+/// independently and visibly disagree.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum ChangeScope {
+    /// Everything this branch would land on its base - committed and uncommitted together. The
+    /// default: Jerry reviews agent branch work first, and agents commit on their own, so an
+    /// uncommitted-only default would blank the panel exactly when there is the most to review.
+    #[default]
+    AllChanges,
+    /// The working tree against `HEAD` - what a commit right now would pick up. The one scope
+    /// where staging and the commit composer make sense.
+    Uncommitted,
+}
+
+impl ChangeScope {
+    /// The section carrying this scope's file list; the other file section is hidden outright.
+    pub fn file_section(self) -> ChangesSection {
+        match self {
+            ChangeScope::AllChanges => ChangesSection::AgainstMain,
+            ChangeScope::Uncommitted => ChangesSection::Uncommitted,
+        }
+    }
+
+    /// Whether `section` renders at all under this scope: the two file sections swap with the
+    /// scope, Commits and Runs are scope-independent and always render.
+    pub fn shows(self, section: ChangesSection) -> bool {
+        match section {
+            ChangesSection::Uncommitted | ChangesSection::AgainstMain => {
+                self.file_section() == section
+            }
+            ChangesSection::Commits | ChangesSection::Runs => true,
+        }
+    }
+
+    /// The selector segment's label.
+    pub fn label(self) -> &'static str {
+        match self {
+            ChangeScope::AllChanges => "All changes",
+            ChangeScope::Uncommitted => "Uncommitted",
+        }
     }
 }
 
@@ -322,15 +370,15 @@ pub enum SectionRow {
     /// time so a diff replaced between this frame's row count and this row's build renders
     /// nothing rather than indexing a stale snapshot.
     UncommittedFile(usize),
+    /// [`SectionRow::UncommittedFile`]'s against-base twin: an index into the **against-base**
+    /// change set, re-resolved at build time for the same stale-snapshot reason. Per-file rows
+    /// here reverse issue #285's "no committed rows under Against main" call, which predated the
+    /// scope selector: with only one file list visible at a time ([`ChangeScope::shows`]), the
+    /// duplication that call removed cannot occur (GitHub issue #487).
+    AgainstMainFile(usize),
     Commit(wt_core::diff::BranchCommit),
-    /// The Against-main section's *only* body row (besides its own notes): what would land, and
-    /// how far ahead or behind the branch is. Unlike the other three sections, Against main never
-    /// lists a row per file - the design carries a plain file *count* here, never an array of
-    /// files, and the panel's
-    /// own header count reads that count directly (`Self::changes_section_rows`), not the number
-    /// of rows this section renders - a deliberate exception to `SectionHeader::count`'s usual
-    /// "derived from the body" rule, and a deliberate removal of this section's earlier per-file
-    /// listing (a committed file is no longer its own row here at all).
+    /// The Against-main section's summary row: what would land, and how far ahead or behind the
+    /// branch is. Renders after the file rows as the section's footer.
     AgainstMainContext {
         text: String,
         sub: String,
@@ -348,7 +396,10 @@ impl SectionRow {
     pub fn is_counted(&self) -> bool {
         matches!(
             self,
-            SectionRow::Run(_) | SectionRow::UncommittedFile(_) | SectionRow::Commit(_)
+            SectionRow::Run(_)
+                | SectionRow::UncommittedFile(_)
+                | SectionRow::AgainstMainFile(_)
+                | SectionRow::Commit(_)
         )
     }
 
@@ -361,6 +412,7 @@ impl SectionRow {
             SectionRow::Header(header) => header.section,
             SectionRow::Run(_) => ChangesSection::Runs,
             SectionRow::UncommittedFile(_) => ChangesSection::Uncommitted,
+            SectionRow::AgainstMainFile(_) => ChangesSection::AgainstMain,
             SectionRow::Commit(_) => ChangesSection::Commits,
             SectionRow::AgainstMainContext { .. } => ChangesSection::AgainstMain,
             SectionRow::Note { section, .. } => *section,
@@ -605,12 +657,14 @@ mod changes_section_tests {
     }
 
     #[test]
-    fn runs_and_uncommitted_start_open_and_the_two_git_history_sections_start_collapsed() {
+    fn every_possible_file_list_and_runs_start_open_and_only_commits_starts_collapsed() {
+        // Both file sections start open because whichever one the scope keeps is the panel's
+        // main content (GitHub issue #487) - see `ChangesSection::starts_open`'s own docs.
         let collapse = SectionCollapse::default();
         assert!(collapse.is_open(ChangesSection::Runs));
         assert!(collapse.is_open(ChangesSection::Uncommitted));
+        assert!(collapse.is_open(ChangesSection::AgainstMain));
         assert!(!collapse.is_open(ChangesSection::Commits));
-        assert!(!collapse.is_open(ChangesSection::AgainstMain));
     }
 
     #[test]
@@ -779,5 +833,48 @@ mod changes_section_tests {
             seen_label(1, change_set.len()),
             Some(format!("1/{} seen", change_set.len()))
         );
+    }
+}
+
+/// GitHub issue #487: one scope value decides which file section renders; Commits and Runs are
+/// scope-independent.
+#[cfg(test)]
+mod change_scope_tests {
+    use super::{ChangeScope, ChangesSection};
+
+    #[test]
+    fn the_default_scope_is_all_changes_the_review_scope() {
+        assert_eq!(
+            ChangeScope::default(),
+            ChangeScope::AllChanges,
+            "agents commit on their own, so an uncommitted-only default would blank the panel \
+             exactly when there is the most to review"
+        );
+    }
+
+    #[test]
+    fn each_scope_shows_exactly_its_own_file_section() {
+        assert!(ChangeScope::AllChanges.shows(ChangesSection::AgainstMain));
+        assert!(!ChangeScope::AllChanges.shows(ChangesSection::Uncommitted));
+        assert!(ChangeScope::Uncommitted.shows(ChangesSection::Uncommitted));
+        assert!(!ChangeScope::Uncommitted.shows(ChangesSection::AgainstMain));
+    }
+
+    #[test]
+    fn commits_and_runs_render_under_both_scopes() {
+        for scope in [ChangeScope::AllChanges, ChangeScope::Uncommitted] {
+            assert!(scope.shows(ChangesSection::Commits));
+            assert!(scope.shows(ChangesSection::Runs));
+        }
+    }
+
+    #[test]
+    fn every_scopes_own_file_section_starts_open() {
+        for scope in [ChangeScope::AllChanges, ChangeScope::Uncommitted] {
+            assert!(
+                scope.file_section().starts_open(),
+                "a default-collapsed file list would render {scope:?} as an empty panel"
+            );
+        }
     }
 }

--- a/docs/design/sidebar.md
+++ b/docs/design/sidebar.md
@@ -58,21 +58,36 @@ buffer, reusing the same three-state count.
 
 ### Changes
 
-Four stacked sections (`sidebar::sections::ChangesSection`), in a fixed render order that
-`ChangesSection::ORDER` is the single place recording:
+A **scope selector** heads the panel (`sidebar::sections::ChangeScope`, issue #487):
+`Uncommitted | All changes`, defaulting to All changes — Jerry reviews agent branch work first,
+and agents commit on their own, so an uncommitted-only default would blank the panel exactly when
+there is the most to review. The scope is one piece of app state every changed-file surface
+derives from: this panel's file list, the file tree's A/M markers, the palette's marks, and the
+hunks an open file shows all read `AdeApp::scoped_diff`, never a particular diff directly. Before
+the selector, each surface picked its own scope and they visibly disagreed.
 
-| Section | Answers |
-|---|---|
-| `UNCOMMITTED` | what is dirty in this worktree right now |
-| `COMMITS` | what has been committed on this branch |
-| `AGAINST <BASE>` | how this worktree differs from the merge-base with its base branch |
-| `RUNS` | the same changes, indexed by which agent produced them |
+The sections (`sidebar::sections::ChangesSection`, in `ChangesSection::ORDER` filtered by
+`ChangeScope::shows`):
 
-The first three are **one ladder of git state**, narrowing to widening. Runs is not on that ladder —
-it re-indexes the same changes by author — so it sits after the ladder rather than inside it, which
-also keeps `UNCOMMITTED`'s top edge fixed however many agents have run.
+| Section | Answers | Visible under |
+|---|---|---|
+| `UNCOMMITTED` | what is dirty in this worktree right now | Uncommitted scope |
+| `AGAINST <BASE>` | everything this branch would land on its base, one row per file | All-changes scope |
+| `COMMITS` | what has been committed on this branch | both |
+| `RUNS` | the same changes, indexed by which agent produced them | both |
 
-Rows carry a **seen** mark, a directory, a name, a tag pill, `+n −n`, and a stat bar.
+Only one of the two file sections exists at a time — that is the selector's whole point, and it is
+what superseded issue #285's earlier "no per-file rows under Against main" call (which prevented
+the same file listing twice when both sections stacked). The scope's own file section leads the
+filtered order, so the scope's list is always the panel's first section; Runs stays off the git
+ladder — it re-indexes the same changes by author — and sits last.
+
+The commit composer, staging checkboxes, and the `space stage` / `V seen` footer keys belong to
+the Uncommitted scope alone: they act on exactly that scope's list, and every one of them funnels
+through the scope-gated `open_uncommitted_change`.
+
+Rows carry a **seen** mark (Uncommitted scope), a directory, a name, a tag pill, `+n −n`, and a
+stat bar.
 
 `sections::SeenFiles` is deliberately **not** the staged set. A file counts as seen only if it was
 marked *and still has the diffstat it had when marked* — so a file you reviewed and an agent then
@@ -87,6 +102,9 @@ into another's.
 - **Files is the default tab.** Changes is where a review flow lands you, not where you start.
 - **`ChangesSection::ORDER` is the only place the section order is written down.** Re-deriving it at
   a render site is how the two get out of sync.
+- **One scope drives every surface.** Anything that marks or lists changed files reads
+  `AdeApp::scoped_diff`; reaching for `current_diff`/`uncommitted_diff` directly at a surface is
+  exactly how the panel, the tree, and the open diff disagreed before issue #487.
 - **Seen ≠ staged.** Two different questions; conflating them would make "reviewed" survive an
   agent's next edit.
 - **Panel-tab icons share one optical box.** Never one size per icon.


### PR DESCRIPTION
Closes #487

## What

Every changed-file surface now derives from **one** scope value instead of picking its own: a `Uncommitted | All changes` selector heads the Changes panel (`sections::ChangeScope`, default All changes), and the panel's file list, the file tree's A/M markers, the palette's file marks, the open file's diff hunks/gutter, and the panel header's `+n −n` totals all read the new `AdeApp::scoped_diff`. Before this, the tree marked against-base files while the panel's only file list was uncommitted-only, and the diff a click opened depended on which surface the click landed in — the disagreement reported in the issue.

Concretely:

- **One file list at a time.** The Against-main section gains real per-file rows (`SectionRow::AgainstMainFile`, reusing the existing row renderer with its ✓-committed annotation) and is the All-changes scope's list; the Uncommitted section (with staging and the commit composer) is the Uncommitted scope's. The hidden one doesn't render at all — not even a collapsed header. This deliberately supersedes issue #285's "no per-file rows under Against main" call, which existed to prevent duplication when both sections stacked; with one list at a time that duplication can't occur (recorded in `SectionRow::AgainstMainFile`'s docs and `docs/design/sidebar.md`).
- **Uncommitted-scope machinery is scope-gated at one choke point.** The commit composer, staging checkboxes, and the `space stage` / `V seen` footer keys all funnel through `open_uncommitted_change`, which now returns `None` outside the Uncommitted scope — the keys no-op and the hints say so.
- **`ChangesSection::ORDER` reorders** so the scope's file section always leads the filtered panel, and both file sections start open (a default-collapsed file list would render the default scope empty).
- VS Code's uncommitted-only model was considered and rejected in the issue discussion: agents commit on their own, so that default blanks the panel exactly when there is the most to review.

Seen-marks remain Uncommitted-scope machinery (their keying is tied to the uncommitted change set); whether review progress should exist under All changes is left as its own question. The scope is in-memory per window, not persisted — worth a follow-up if it should stick across launches.

## Testing

- [x] `/check` — fmt, clippy `-D warnings` pass; both convention ratchets verified manually at exactly baseline (globs 300/300, render-adapter calls 170/170; `jq` is missing locally so the script self-skips).
- [x] New/changed behavior has real tests, in the right tiers:
  - `sections::change_scope_tests` (unit): default scope, per-scope section visibility, both file sections start open.
  - `sidebar::render::change_scope_panel_tests` (ui, written failing-first — the panel tests failed on unmodified code): the default scope lists branch files with no uncommitted machinery; switching scope swaps the list, the tree marks, and the composer in the same frame; a committed-only file's gutter clears when the scope narrows.
  - `changes_sections_tests`/`commit_composer_tests`/`change_row_tests` reworked to the scope model, including scope-hopping rewrites of the two cross-section tests (a committed file lives in the All-changes list; committing a staged file moves it across scopes rather than out of sight).
- 253/253 sidebar+palette+scope tests pass locally.
- Known Windows-local failures, all verified pre-existing on clean `master` and unrelated to this branch: the fold_state families and the deeply-nested-path composer test (filed as #488 with the root cause — test expectations built from hardcoded `/` separators), the 7 `terminal::pane` real-PTY tests (#440). Linux/macOS CI is the arbiter.

## Architecture notes

No crate-boundary changes; UI state + pure section logic inside `crates/app`. New: `sections::ChangeScope`, `SectionRow::AgainstMainFile`, `AdeApp::{change_scope, scoped_diff, set_change_scope}`. `docs/design/sidebar.md`'s Changes section rewritten around the scope model, with a new "One scope drives every surface" rule.

## Screenshot

Not attached: `verify` was started (app built and launched against a seeded demo repo with a committed branch change plus a dirty file), but the machine was actively in use at capture time — the first capture grabbed the foreground application and the app window was closed under the live session, so the loop was aborted rather than hijacking input for staged screenshots. To try it locally: `cargo run --release -p app <repo-with-a-feature-branch>` → Changes tab → the `Uncommitted | All changes` selector at the top of the panel. Happy to attach captures in a follow-up pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
